### PR TITLE
Remove information about dockerignore files

### DIFF
--- a/pages/learn/deploy/build-optimization.md
+++ b/pages/learn/deploy/build-optimization.md
@@ -38,10 +38,6 @@ __NOTE:__ The above command should never be split over two or more `RUN` command
 
 It is also wise to remove any .tar.gz or temporary files in a similar fashion to the above, as this will reduce build size.
 
-## Use .dockerignore
-
-Make use of `.dockerignore` to ignore anything that is in the git repo, but is not strictly needed on the device(s). This can allow you to safely ignore images or assets used to document your project on github or bitbucket.
-
 ## Don't do apt-get update or upgrade
 
 This isn't so much of an optimization tip, but more a guideline to ensure maintainable Docker images. Note the below tips were kindly borrowed from [Docker Best Practices][docker-best-practices].


### PR DESCRIPTION
As far as I'm aware this has never been possible while I've been at resin. Either way I've removed it here, but I will make an issue on the builder to tackle this (and we'll certainly need to once the support has been released on the CLI)

Builder issue: https://github.com/resin-io/resin-builder/issues/542

Change-type: patch
Signed-off-by: Cameron Diver <cameron@resin.io>