### PR TITLE
Add owns__device to the application resource, and fix local dev URLs

### DIFF
--- a/config/dictionaries/resource.json
+++ b/config/dictionaries/resource.json
@@ -5,6 +5,7 @@
     "fields": [
       "id",
       "user",
+      "owns__device",
       "depends_on__application",
       "actor",
       "app_name",
@@ -36,6 +37,13 @@
         "method": "GET",
         "endpoint": "/v4/application",
         "filters": "?\\$filter=app_name%20eq%20'<NAME>'"
+      },
+      {
+        "id": "app-with-devices",
+        "summary": "Get application by id along with its devices",
+        "method": "GET",
+        "endpoint": "/v4/application(<ID>)",
+        "filters": "?\\$expand=owns__device"
       },
       {
         "id": "create-app",

--- a/config/links.coffee
+++ b/config/links.coffee
@@ -15,7 +15,7 @@ module.exports =
   githubProjects: 'https://github.com/balena-io-projects'
   githubPlayground: 'https://github.com/balena-io-playground'
   githubOS: 'https://github.com/balena-os'
-  apiBase: process.env.API_BASE || 'https://api.balena-cloud.com/'
+  apiBase: process.env.API_BASE || 'https://api.balena-cloud.com'
   mainSiteUrl: 'http://balena.io'
   blogSiteUrl: 'https://balena.io/blog'
   dashboardUrl: process.env.DASHBOARD_SITE || 'https://dashboard.balena-cloud.com'


### PR DESCRIPTION
This adds an example expanding from application to devices, after a user (https://app.frontapp.com/open/cnv_11nbptv) pointed out that that wasn't documented.

This PR also changes the default `API_BASE`. Everywhere expects this to not have a trailing slash, and it doesn't appear to in production, but in dev every generated URL ends up with a double slash here before this change.

Fixes #917 