### PR TITLE
Update docsearch to use balena index

### DIFF
--- a/templates/_algolia.html
+++ b/templates/_algolia.html
@@ -1,7 +1,7 @@
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 <script type="text/javascript"> docsearch({
- apiKey: '0241ef4553148339721381e68044f60f',
- indexName: 'resin_io',
+ apiKey: 'dabd8d15d83b81d05cfb4a1f16689b7f',
+ indexName: 'balena',
  inputSelector: 'input[name=searchTerm]'
 });
 </script>


### PR DESCRIPTION
Algolia have now created a new docsearch index for our renamed docs site: https://github.com/algolia/docsearch-configs/commit/2e8626e8f7897854bdf1b78e81f8f1cb86e84fb1

This PR updates to use it, so that search shows the renamed balena content, and indexing continues to work for new content. Once it's been merged & released we can let Algolia know, and they'll delete the old `resin_io` index.