### PR TITLE
config/redirects: Fix unescaped and device type alias redirects

### DIFF
--- a/config/redirects.txt
+++ b/config/redirects.txt
@@ -20,12 +20,12 @@
 ^\/installing\/otherboards\/?(\?.+)?(#.+)?$ -> /learn/getting-started/raspberrypi3/nodejs/$1$2
 
 # Device name changes
-(.*)\/raspberrypi/(.*) -> $1/raspberry-pi/$2
-(.*)\/raspberrypi2/(.*) -> $1/raspberry-pi2/$2
-(.*)\/edison/(.*) -> $1/intel-edison/$2
-(.*)\/nuc/(.*) -> $1/intel-nuc/$2
-(.*)\/beaglebone/(.*) -> $1/beaglebone-black/$2
-(.*)\/dart6ul/(.*) -> $1/imx6ul-var-dart/$2
+^\/(.*)\/raspberrypi\/(.*) -> /$1/raspberry-pi/$2
+^\/(.*)\/raspberrypi2\/(.*) -> /$1/raspberry-pi2/$2
+^\/(.*)\/edison\/(.*) -> /$1/intel-edison/$2
+^\/(.*)\/nuc\/(.*) -> /$1/intel-nuc/$2
+^\/(.*)\/beaglebone\/(.*) -> /$1/beaglebone-black/$2
+^\/(.*)\/dart6ul\/(.*) -> /$1/imx6ul-var-dart/$2
 
 # Default redirects
 ^\/learn\/getting-started\/?(\?.+)?(#.+)?$ -> /learn/getting-started/raspberrypi3/nodejs/$1$2
@@ -37,8 +37,8 @@
 ^\/reference\/?(\?.+)?(#.+)?$ -> /reference/hardware/devices/$1$2
 ^\/deployment\/network\/2\.0.*\/?(\?.+)?(#.+)?$ -> /reference/OS/network/2.x/$1$2
 ^\/deployment\/network\/1.x.x\/?(\?.+)?(#.+)?$-> /reference/OS/network/1.x/$1$2
-^\/understanding/understanding-devices\/2\.0.*\/?(\?.+)?(#.+)?$ -> /reference/OS/overview/2.x/$1$2
-^\/understanding/understanding-devices\/1.x.x\/?(\?.+)?(#.+)?$ -> /reference/OS/overview/1.x/$1$2
+^\/understanding\/understanding-devices\/2\.0.*\/?(\?.+)?(#.+)?$ -> /reference/OS/overview/2.x/$1$2
+^\/understanding\/understanding-devices\/1.x.x\/?(\?.+)?(#.+)?$ -> /reference/OS/overview/1.x/$1$2
 ^\/reference\/api\/?(\?.+)?(#.+)?$ -> /reference/api/application/$1$2
 
 # Renamed pages
@@ -93,7 +93,7 @@
 ^\/tools\/python-sdk\/?(\?.+)?(#.+)?$ -> /reference/sdk/python-sdk/$1$2
 ^\/runtime\/resin-base-images\/?(\?.+)?(#.+)?$ -> /reference/base-images/base-images/$1$2
 ^\/configuration\/custom-docker-base-images\/?(\?.+)?(#.+)?$ -> /reference/base-images/customer-docker-base-images/$1$2
-^\/deployment/docker-templates\/?(\?.+)?(#.+)?$ -> /learn/develop/dockerfile/$1$2
+^\/deployment\/docker-templates\/?(\?.+)?(#.+)?$ -> /learn/develop/dockerfile/$1$2
 ^\/support\/?(\?.+)?(#.+)?$ -> /learn/welcome/support/$1$2
 ^\/devicetypes\/?(\?.+)?(#.+)?$ -> /reference/base-images/devicetypes/$1$2
 ^\/deployment\/build-optimisation\/?(\?.+)?(#.+)?$ -> /learn/deploy/build-optimization/$1$2


### PR DESCRIPTION
Fixes the following redirects:
* https://docs.resin.io/nuc/nodejs/getting-started/
* https://docs.resin.io/dart6ul/nodejs/getting-started/
* https://docs.resin.io/beaglebone/nodejs/getting-started/
* https://docs.resin.io/raspberrypi/nodejs/getting-started/
* https://docs.resin.io/raspberrypi2/nodejs/getting-started/

Couldn't figure out how to fix:
https://docs.resin.io/#/pages/installing/gettingStarted-ODROID-C1.md#windows
https://docs.resin.io/#/pages/installing/gettingStarted-ODROID-XU4.md#windows

Trying to match the `#` wasn't working as expected.

Connects-to: #958
Change-type: patch