### PR TITLE
Escape characters in markdown formatting

### DIFF
--- a/pages/reference/base-images/base-images.md
+++ b/pages/reference/base-images/base-images.md
@@ -3,7 +3,7 @@ title: {{ $names.company.upper }} base images
 excerpt: Docker images maintained by {{ $names.company.lower }}
 ---
 
-# {{ $names.company.upper }} base images 
+# {{ $names.company.upper }} base images
 
 This page contains all the information about the images maintained on the {{ $names.company.lower }} Docker Hub registry.
 
@@ -1331,9 +1331,9 @@ This is a set of images with node.js binary installed. The node images come in m
 
 #### Variants:
 
-* **node:<version>**: This is the defacto image. If you are unsure about what your needs are, you probably want to use this one. It is designed to be used both as a throw away container (mount your source code and start the container to start your app), as well as the base to build other images off of. **This tag is based off of buildpack-deps image**. buildpack-deps is designed for the average user of Docker who has many images on their system. It, by design, has a large number of extremely common Debian packages. This reduces the number of packages that images that derive from it need to install, thus reducing the overall size of all images on your system.
-* **node:<version>-onbuild**: This image makes building derivative images easier. For most use cases, creating a Dockerfile in the base of your project directory with the line FROM node:onbuild will be enough to create a stand-alone image for your project.
-* **node:<version>-slim**: This image does not contain the common packages contained in the default tag and only contains the minimal packages needed to run node. Unless you are working in an environment where only the node image will be deployed and you have space constraints, we highly recommend using the default image of this repository.
+* **node:\<version\>**: This is the defacto image. If you are unsure about what your needs are, you probably want to use this one. It is designed to be used both as a throw away container (mount your source code and start the container to start your app), as well as the base to build other images off of. **This tag is based off of buildpack-deps image**. buildpack-deps is designed for the average user of Docker who has many images on their system. It, by design, has a large number of extremely common Debian packages. This reduces the number of packages that images that derive from it need to install, thus reducing the overall size of all images on your system.
+* **node:\<version\>-onbuild**: This image makes building derivative images easier. For most use cases, creating a Dockerfile in the base of your project directory with the line FROM node:onbuild will be enough to create a stand-alone image for your project.
+* **node:\<version\>-slim**: This image does not contain the common packages contained in the default tag and only contains the minimal packages needed to run node. Unless you are working in an environment where only the node image will be deployed and you have space constraints, we highly recommend using the default image of this repository.
 
 ### <a name="python"></a>Python
 


### PR DESCRIPTION
Originally from PR #930

Change-type: patch
Signed-off-by: Chris Crocker-White <chriscw@balena.io>