### PR TITLE
resources: Fix app & device envvars to use the translated name field

### DIFF
--- a/config/dictionaries/resource.json
+++ b/config/dictionaries/resource.json
@@ -286,7 +286,7 @@
       "id",
       "created_at",
       "device",
-      "env_var_name",
+      "name",
       "value"
     ],
     "examples": [
@@ -303,7 +303,7 @@
         "method": "POST",
         "endpoint": "/v4/device_environment_variable",
         "filters": "",
-        "data": "{\n    \"device\": \"<DEVICE ID>\",\n    \"env_var_name\": \"<NAME>\",\n    \"value\": \"<VALUE>\"\n}"
+        "data": "{\n    \"device\": \"<DEVICE ID>\",\n    \"name\": \"<NAME>\",\n    \"value\": \"<VALUE>\"\n}"
       },
       {
         "id": "update-device-env-var",
@@ -441,7 +441,7 @@
       "id",
       "created_at",
       "application",
-      "env_var_name",
+      "name",
       "value"
     ],
     "examples": [
@@ -458,7 +458,7 @@
         "method": "POST",
         "endpoint": "/v4/application_environment_variable",
         "filters": "",
-        "data": "{\n    \"application\": \"<APP ID>\",\n    \"env_var_name\": \"<NAME>\",\n    \"value\": \"<VALUE>\"\n}"
+        "data": "{\n    \"application\": \"<APP ID>\",\n    \"name\": \"<NAME>\",\n    \"value\": \"<VALUE>\"\n}"
       },
       {
         "id": "update-fleet-env-var",


### PR DESCRIPTION
We originally used `env_var_name` as a field on those resources,
but we ended up adding a translation before announcing this API
version, so that all env var resources have the same base fields.

Resolves: #978
Change-type: patch
See: https://github.com/balena-io/resin-api/pull/832
See: https://github.com/balena-io/resin-api/blob/a8f53ce3ffce55cfc64e16e5d016eab5520a9cc2/test/06_device_environment_variable.coffee#L45
See: https://github.com/balena-io/resin-api/blob/a8f53ce3ffce55cfc64e16e5d016eab5520a9cc2/test/06_device_environment_variable.coffee#L87-L89
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>