### PR TITLE
Prevent algolia input from from being submitted

### DIFF
--- a/server/index.coffee
+++ b/server/index.coffee
@@ -38,17 +38,6 @@ getLocals = (extra) ->
 
 doxx.loadLunrIndex()
 
-app.get "#{config.pathPrefix}/search-results", (req, res) ->
-  { searchTerm } = req.query
-  res.render 'search', getLocals
-    title: "Search results for \"#{searchTerm}\""
-    breadcrumbs: [
-      'Search Results'
-      searchTerm
-    ]
-    searchTerm: searchTerm
-    searchResults: doxx.lunrSearch(searchTerm)
-
 console.error('serving everything under pathPrefix:', "#{config.pathPrefix}")
 app.use("#{config.pathPrefix}/", express.static(contentsDir))
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -182,12 +182,16 @@ article .headroom {
  color: #6b6d73;
 }
 
-.sidebar .search-wrapper form {
+.sidebar .search-wrapper .algolia-wrapper {
   border-bottom: 1px solid #e6e8eb;
   border-right: 1px solid #e6e8eb;
   padding: 10px;
   padding-bottom: 9px;
   background: #F7F7F7;
+}
+
+.sidebar .search-wrapper .algolia-wrapper .algolia-autocomplete {
+  width: 100%;
 }
 
 .sidebar .search-wrapper {

--- a/templates/_search-form-mobile.html
+++ b/templates/_search-form-mobile.html
@@ -1,3 +1,3 @@
-<form action="/search-results">
+<div class='algolia-wrapper'>
   <input name="searchTermMobile" type="text" class="form-control" placeholder="Search Docs..." value="{{ searchTerm }}">
-</form>
+</div>

--- a/templates/_search-form.html
+++ b/templates/_search-form.html
@@ -1,3 +1,3 @@
-<form action="/search-results">
+<div class='algolia-wrapper'>
   <input name="searchTerm" type="text" class="form-control" placeholder="Search Docs..." value="{{ searchTerm }}">
-</form>
+</div>


### PR DESCRIPTION
The algolia input was under a form. Before algolia would load, this form
could be submitted, resulting in an undesired redirect.

Connects-to: #1024
Change-type: patch
Signed-off-by: Dimitrios Lytras <dimitrios@balena.io>