### PR TITLE
Fix the 404 page from not displaying correctly

### DIFF
--- a/pages/404.md
+++ b/pages/404.md
@@ -1,0 +1,4 @@
+---
+title: Not found
+layout: not-found.html
+---

--- a/server/index.coffee
+++ b/server/index.coffee
@@ -42,9 +42,7 @@ console.error('serving everything under pathPrefix:', "#{config.pathPrefix}")
 app.use("#{config.pathPrefix}/", express.static(contentsDir))
 
 app.get '*', (req, res) ->
-  res.render 'not-found', getLocals
-    title: "We don't seem to have such page"
-    breadcrumbs: [ 'Page not found' ]
+  res.redirect("#{config.pathPrefix}/404")
 
 port = process.env.PORT ? 3000
 

--- a/templates/_algolia.html
+++ b/templates/_algolia.html
@@ -8,6 +8,11 @@ docsearch({
 docsearch({
  apiKey: 'dabd8d15d83b81d05cfb4a1f16689b7f',
  indexName: 'balena',
+ inputSelector: 'input[name=searchTerm404]'
+});
+docsearch({
+ apiKey: 'dabd8d15d83b81d05cfb4a1f16689b7f',
+ indexName: 'balena',
  inputSelector: 'input[name=searchTermMobile]'
 });
 </script>

--- a/templates/not-found.html
+++ b/templates/not-found.html
@@ -3,11 +3,14 @@
 {% block "contents" %}
   <h1>Page not found</h1>
 
-  <p>We think we don't have a page you're looking for.</p>
+  <p>We think we don't have the page you're looking for.</p>
   <p>
     Try starting from the
     <a href="/">Introduction</a> or use the search:
   </p>
-  {% include "_search-form.html" %}
+
+  <div class='algolia-wrapper'>
+    <input name="searchTerm404" type="text" class="form-control" placeholder="Search Docs..." value="{{ searchTerm }}">
+  </div>
 
 {% endblock %}


### PR DESCRIPTION
In order to fix the issue I made the 404 page also be served
by Doxx, fixing the issue with the wrong routing of the css and 
js files. This one was very annoying, I am so glad it got fixed.

Connects-to: #940
Change-type: patch
Signed-off-by: Stevche Radevski <stevche@balena.io>