### PR TITLE
Update build-optimization.md

### DIFF
--- a/pages/learn/deploy/build-optimization.md
+++ b/pages/learn/deploy/build-optimization.md
@@ -65,7 +65,7 @@ This will start downloading both files and wait for them to complete. The next l
 
 These are just a few tips from our engineers on how to reduce your build size
 
-* npm install commands like `npm install --unsafe-perm -g @some/node-module` can have `&& npm cache clean && rm -rf /tmp/*` added in order to clean up the npm cache and the /tmp/npm-... folders it uses.
+* npm install commands like `npm install --unsafe-perm -g @some/node-module` can have `&& npm cache clean --force && rm -rf /tmp/*` added in order to clean up the npm cache and the /tmp/npm-... folders it uses.
 
 * apt-get update commands should have a matching `rm -rf /var/lib/apt/lists` in order to clean up the package lists (or `rm -rf /var/lib/apt/*` which is equivalent).
 


### PR DESCRIPTION
component: add --force flag.  Must be used with NodeJS versions higher than ver 5. "Cache corruption will either trigger an error, or signal to pacote that the data must be refetched, which it will do automatically. For this reason, it should never be necessary to clear the cache for any reason other than reclaiming disk space, thus why clean now requires --force to run."

Change-type: patch
Signed-off-by: William Walker <wwalker@udel.edu>