### PR TITLE
Update ref docs for the CLI, Node SDK, Python SDK and Supervisor

### DIFF
--- a/pages/reference/cli.md
+++ b/pages/reference/cli.md
@@ -1,85 +1,75 @@
 # Balena CLI Documentation
 
-This tool allows you to interact with the balena api from the comfort of your command line.
+The balena CLI (Command-Line Interface) allows you to interact with the balenaCloud and the
+[balena API](https://www.balena.io/docs/reference/api/overview/) through a terminal window
+on Linux, MacOS or Windows. You can also write shell scripts around it, or import its Node.js
+modules to use it programmatically.
+As an [open-source project on GitHub](https://github.com/balena-io/balena-cli/), your contribution
+is also welcome!
 
-Please make sure your system meets the requirements as specified in the [README](https://github.com/balena-io/balena-cli).
+## Installation
 
-## Install the CLI
+Check the [balena CLI installation instructions on GitHub](https://github.com/balena-io/balena-cli/blob/master/INSTALL.md).
 
-### Dependencies
+## Getting Started
 
-Before installing the Balena CLI from npm, make sure you have the following dependencies installed:
+### Choosing a shell (command prompt/terminal)
 
-* make
-* g++ compiler
-* Python 2.7
-* git
+On Linux and MacOS, `bash` is the standard and recommended shell for use with the balena CLI.
 
-For example, to install these packages on a Debian-based Linux operating systems:
+> **bash command auto completion**  
+`bash` command auto completion can be enabled by copying the
+[balena-completion.bash](https://github.com/balena-io/balena-cli/blob/master/balena-completion.bash)
+file to the default bash completions directory (usually `/etc/bash_completion.d/`), or by appending
+it to `~/.bash_completion`.
 
+On Windows, we support the standard Windows Command Prompt (`cmd.exe`) and the Windows
+[PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/getting-started/getting-started-with-windows-powershell?view=powershell-6).
+We are aware of users also having a good experience with alternative shells, including:
+
+* Microsoft's [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/about)
+  (a.k.a. Microsoft's "bash for Windows 10").
+* [Git for Windows](https://git-for-windows.github.io/).
+* [MinGW](http://www.mingw.org): install the `msys-rsync` and `msys-openssh` packages too.
+
+### Logging in
+
+Several CLI commands require access to your balenaCloud account, for example in order to push
+a new release to your app. Those commands require creating a CLI login session by running:
+
+```sh
+$ balena login
 ```
-$ sudo apt-get install g++ make python git --yes
-```
 
-**NOTE**: If you are installing the stand-alone binary CLI, you will not need to install these dependencies.
+### Proxy support
 
-### Npm install
+HTTP(S) proxies can be configured through any of the following methods, in order of preference:
 
-The best supported way to install the CLI is from npm:
-
-	$ npm install balena-cli -g --production --unsafe-perm
-
-`--unsafe-perm` is only required on systems where the global install directory is not user-writable.
-This allows npm install steps to download and save prebuilt native binaries. You may be able to omit it,
-especially if you're using a user-managed node install such as [nvm](https://github.com/creationix/nvm).
-
-### Standalone install
-
-Alternatively, if you don't have a node or pre-gyp environment, you can still install the CLI as a standalone
-binary. **This is in experimental and may not work perfectly yet in all environments**, but works well in
-initial cross-platform testing, so it may be useful, and we'd love your feedback if you hit any issues.
-
-To install the CLI as a standalone binary:
-
-* Download the latest zip for your OS from https://github.com/balena-io/balena-cli/releases.
-* Extract the contents, putting the `balena-cli` folder somewhere appropriate for your system (e.g. `C:/balena-cli`, `/usr/local/lib/balena-cli`, etc).
-* Add the `balena-cli` folder to your `PATH`. (
-[Windows instructions](https://www.computerhope.com/issues/ch000549.htm),
-[Linux instructions](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix),
-[OSX instructions](https://stackoverflow.com/questions/22465332/setting-path-environment-variable-in-osx-permanently))
-* Running `balena` in a fresh command line should print the balena CLI help.
-
-To update in future, simply download a new release and replace the extracted folder.
-
-Have any problems, or see any unexpected behaviour? Please file an issue!
-
-## Getting started
-
-Once you have the CLI installed, you'll need to log in, so it can access everything in your balena account.
-
-To authenticate yourself, run:
-
-	$ balena login
-
-You now have access to all the commands referenced below.
-
-## Proxy support
-
-The CLI does support HTTP(S) proxies.
-
-You can configure the proxy using several methods (in order of their precedence):
-
-* set the `BALENARC_PROXY` environment variable in the URL format (with protocol, host, port, and optionally the basic auth),
-* use the [balena config file](https://www.npmjs.com/package/balena-settings-client#documentation) (project-specific or user-level)
-and set the `proxy` setting. This can be:
-	* a string in the URL format,
-	* or an object following [this format](https://www.npmjs.com/package/global-tunnel-ng#options), which allows more control,
-* or set the conventional `https_proxy` / `HTTPS_PROXY` / `http_proxy` / `HTTP_PROXY`
+* Set the \`BALENARC_PROXY\` environment variable in URL format (with protocol, host, port, and
+  optionally basic auth).
+* Alternatively, use the [balena config file](https://www.npmjs.com/package/balena-settings-client#documentation)
+  (project-specific or user-level) and set the \`proxy\` setting. It can be:
+  * a string in URL format, or
+  * an object in the [global-tunnel-ng options format](https://www.npmjs.com/package/global-tunnel-ng#options) (which allows more control).
+* Alternatively, set the conventional \`https_proxy\` / \`HTTPS_PROXY\` / \`http_proxy\` / \`HTTP_PROXY\`
 environment variable (in the same standard URL format).
 
-# Table of contents
+To get a proxy to work with the `balena ssh` command, check the
+[installation instructions](https://github.com/balena-io/balena-cli/blob/master/INSTALL.md).
 
-- Api keys
+## Support, FAQ and troubleshooting
+
+If you come across any problems or would like to get in touch:
+
+* Check our [FAQ / troubleshooting document](https://github.com/balena-io/balena-cli/blob/master/TROUBLESHOOTING.md).
+* Ask us a question through the [balenaCloud forum](https://forums.balena.io/c/balena-cloud).
+* For bug reports or feature requests,
+  [have a look at the GitHub issues or create a new one](https://github.com/balena-io/balena-cli/issues/).
+
+
+# CLI Command Reference
+
+- API keys
 
 	- [api-key generate &#60;name&#62;](#api-key-generate-name)
 
@@ -146,7 +136,7 @@ environment variable (in the same standard URL format).
 
 - Logs
 
-	- [logs &#60;uuid&#62;](#logs-uuid)
+	- [logs &#60;uuidOrDevice&#62;](#logs-uuidordevice)
 
 - Sync
 
@@ -155,6 +145,7 @@ environment variable (in the same standard URL format).
 - SSH
 
 	- [ssh [uuid]](#ssh-uuid)
+	- [tunnel &#60;uuid&#62;](#tunnel-uuid)
 
 - Notes
 
@@ -188,10 +179,6 @@ environment variable (in the same standard URL format).
 
 	- [settings](#settings)
 
-- Wizard
-
-	- [quickstart [name]](#quickstart-name)
-
 - Local
 
 	- [local configure &#60;target&#62;](#local-configure-target)
@@ -216,7 +203,7 @@ environment variable (in the same standard URL format).
 
 	- [util available-drives](#util-available-drives)
 
-# Api keys
+# API keys
 
 ## api-key generate &#60;name&#62;
 
@@ -857,18 +844,31 @@ Examples:
 
 # Logs
 
-## logs &#60;uuid&#62;
+## logs &#60;uuidOrDevice&#62;
 
 Use this command to show logs for a specific device.
 
-By default, the command prints all log messages and exit.
+By default, the command prints all log messages and exits.
 
 To continuously stream output, and see new logs in real time, use the `--tail` option.
+
+If an IP or .local address is passed to this command, logs are displayed from
+a local mode device with that address. Note that --tail is implied
+when this command is provided a local mode device.
+
+Logs from a single service can be displayed with the --service flag. Just system logs
+can be shown with the --system flag. Note that these flags can be used together.
 
 Examples:
 
 	$ balena logs 23c73a1
-	$ balena logs 23c73a1
+	$ balena logs 23c73a1 --tail
+
+	$ balena logs 192.168.0.31
+	$ balena logs 192.168.0.31 --service my-service
+
+	$ balena logs 23c73a1.local --system
+	$ balena logs 23c73a1.local --system --service my-service
 
 ### Options
 
@@ -876,9 +876,23 @@ Examples:
 
 continuously stream output
 
+#### --service, -s &#60;service&#62;
+
+Only show logs for a single service. This can be used in combination with --system
+
+#### --system, -S
+
+Only show system logs. This can be used in combination with --service.
+
 # Sync
 
 ## sync [uuid]
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  
+Deprecation notice: please note that `balena sync` is deprecated and will
+be removed in a future release of the CLI. We are working on an exciting
+replacement that will be released soon!  
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 Warning: 'balena sync' requires an openssh-compatible client and 'rsync' to
 be correctly installed in your shell environment. For more information (including
@@ -975,6 +989,7 @@ Examples:
 	$ balena ssh 7cf02a6 --port 8080
 	$ balena ssh 7cf02a6 -v
 	$ balena ssh 7cf02a6 -s
+	$ balena ssh 7cf02a6 --noninteractive
 
 ### Options
 
@@ -988,11 +1003,47 @@ increase verbosity
 
 #### --host, -s
 
-access host OS (for devices with balenaOS >= 2.7.5)
+access host OS (for devices with balenaOS >= 2.0.0+rev1)
 
 #### --noproxy
 
 don't use the proxy configuration for this connection. Only makes sense if you've configured proxy globally.
+
+#### --noninteractive
+
+run command non-interactively, do not automatically suggest devices to connect to if UUID not found
+
+## tunnel &#60;uuid&#62;
+
+Use this command to open local ports which tunnel to listening ports on your balenaOS device.
+
+For example, you could open port 8080 on your local machine to connect to your managed balenaOS
+device running a web server listening on port 3000.
+
+You can tunnel multiple ports at any given time.
+
+Examples:
+
+	# map remote port 22222 to localhost:22222
+	$ balena tunnel abcde12345 -p 22222
+
+	# map remote port 22222 to localhost:222
+	$ balena tunnel abcde12345 -p 22222:222
+
+	# map remote port 22222 to any address on your host machine, port 22222
+	$ balena tunnel abcde12345 -p 22222:0.0.0.0
+
+	# map remote port 22222 to any address on your host machine, port 222
+	$ balena tunnel abcde12345 -p 22222:0.0.0.0:222
+
+	# multiple port tunnels can be specified at any one time
+	$ balena tunnel abcde12345 -p 8080:3000 -p 8081:9000
+
+### Options
+
+#### --port, -p &#60;port&#62;
+
+The mapping of remote to local ports.
 
 # Notes
 
@@ -1093,7 +1144,7 @@ Note that device api keys are only supported on balenaOS 2.0.3+.
 
 This command still supports the *deprecated* format where the UUID and optionally device key
 are passed directly on the command line, but the recommended way is to pass either an --app or
---device argument. The deprecated format will be remove in a future release.
+--device argument. The deprecated format will be removed in a future release.
 
 In case that you want to configure an image for an application with mixed device types,
 you can pass the --device-type argument along with --app to specify the target device type.
@@ -1383,18 +1434,26 @@ Docker host TLS key file
 
 ## push &#60;applicationOrDevice&#62;
 
-This command can be used to start an image build on the remote balenaCloud build
-servers, or on a local-mode balena device.
+This command can be used to start a build on the remote balena cloud builders,
+or a local mode balena device.
 
 When building on the balenaCloud servers, the given source directory will be
 sent to the remote server. This can be used as a drop-in replacement for the
 "git push" deployment method.
 
-When building on a local-mode device, the given source directory will be
+When building on a local mode device, the given source directory will be
 built on the device, and the resulting containers will be run on the device.
 Logs will be streamed back from the device as part of the same invocation.
 The web dashboard can be used to switch a device to local mode:
 https://www.balena.io/docs/learn/develop/local-mode/
+Note that local mode requires a supervisor version of at least v7.21.0.
+The logs from only a single service can be shown with the --service flag, and
+showing only the system logs can be achieved with --system. Note that these
+flags can be used together.
+
+It is also possible to run a push to a local mode device in live mode.
+This will watch for changes in the source directory and perform an
+in-place build in the running containers [BETA].
 
 The --registry-secrets option specifies a JSON or YAML file containing private
 Docker registry usernames and passwords to be used when pulling base images.
@@ -1418,7 +1477,10 @@ Examples:
 
 	$ balena push 10.0.0.1
 	$ balena push 10.0.0.1 --source <source directory>
-	$ balena push 10.0.0.1 -s <source directory>
+	$ balena push 10.0.0.1 --service my-service
+
+	$ balena push 23c73a1.local --system
+	$ balena push 23c73a1.local --system --service my-service
 
 ### Options
 
@@ -1430,6 +1492,10 @@ The source that should be sent to the balena builder to be built (defaults to th
 
 Force an emulated build to occur on the remote builder
 
+#### --dockerfile &#60;Dockerfile&#62;
+
+Alternative Dockerfile name/path, relative to the source folder
+
 #### --nocache, -c
 
 Don't use cache when building this project
@@ -1437,6 +1503,31 @@ Don't use cache when building this project
 #### --registry-secrets, -R &#60;secrets.yml|.json&#62;
 
 Path to a local YAML or JSON file containing Docker registry passwords used to pull base images
+
+#### --live, -l
+
+Note this feature is in beta.
+
+Start a live session with the containers pushed to a local mode device.
+The project source folder is watched for filesystem events, and changes
+to files and folders are automatically synchronized to the running
+containers. The synchronisation is only in one direction, from this machine to
+the device, and changes made on the device itself may be overwritten.
+This feature requires a device running supervisor version v9.7.0 or greater.
+
+#### --detached, -d
+
+Don't tail application logs when pushing to a local mode device
+
+#### --service &#60;service&#62;
+
+Only show logs from a single service. This can be used in combination with --system.
+Only valid when pushing to a local mode device.
+
+#### --system
+
+Only show system logs. This can be used in combination with --service.
+Only valid when pushing to a local mode device.
 
 # Settings
 
@@ -1447,24 +1538,6 @@ Use this command to display detected settings
 Examples:
 
 	$ balena settings
-
-# Wizard
-
-## quickstart [name]
-
-Use this command to run a friendly wizard to get started with balena.
-
-The wizard will guide you through:
-
-	- Create an application.
-	- Initialise an SDCard with the balena operating system.
-	- Associate an existing project directory with your balena application.
-	- Push your project to your devices.
-
-Examples:
-
-	$ balena quickstart
-	$ balena quickstart MyApp
 
 # Local
 
@@ -1578,11 +1651,18 @@ ssh port number (default: 22222)
 
 ## local push [deviceIp]
 
-Warning: 'balena local push' requires an openssh-compatible client and 'rsync' to
-be correctly installed in your shell environment. For more information (including
-Windows support) please check the README here: https://github.com/balena-io/balena-cli
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  
+Deprecation notice: `balena local push` is deprecated and will be removed in a
+future release of the CLI. Please use `balena push <ipAddress>` instead.  
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-Use this command to push your local changes to a container on a LAN-accessible balenaOS device on the fly.
+Use this command to push your local changes to a container on a LAN-accessible
+balenaOS device on the fly.
+
+This command requires an openssh-compatible 'ssh' client and 'rsync' to be
+available in the executable PATH of the shell environment. For more information
+(including Windows support) please check the README at:
+https://github.com/balena-io/balena-cli
 
 If `Dockerfile` or any file in the 'build-triggers' list is changed,
 a new container will be built and run on your device.
@@ -1700,20 +1780,20 @@ name of container to stop
 
 ## build [source]
 
-Use this command to build an image or a complete multicontainer project
-with the provided docker daemon in your development machine or balena
-device. (See also the `balena push` command for the option of building
-images in the balenaCloud build servers.)
+Use this command to build an image or a complete multicontainer project with
+the provided docker daemon in your development machine or balena device.
+(See also the `balena push` command for the option of building images in the
+balenaCloud build servers.)
 
-You must provide either an application or a device-type/architecture
-pair to use the balena Dockerfile pre-processor
-(e.g. Dockerfile.template -> Dockerfile).
+You must provide either an application or a device-type/architecture pair to use
+the balena Dockerfile pre-processor (e.g. Dockerfile.template -> Dockerfile).
 
 This command will look into the given source directory (or the current working
-directory if one isn't specified) for a compose file. If one is found, this
-command will build each service defined in the compose file. If a compose file
-isn't found, the command will look for a Dockerfile, and if yet that isn't found,
-it will try to generate one.
+directory if one isn't specified) for a docker-compose.yml file. If it is found,
+this command will build each service defined in the compose file. If a compose
+file isn't found, the command will look for a Dockerfile[.template] file (or
+alternative Dockerfile specified with the `-f` option), and if yet that isn't
+found, it will try to generate one.
 
 The --registry-secrets option specifies a JSON or YAML file containing private
 Docker registry usernames and passwords to be used when pulling base images.
@@ -1759,6 +1839,10 @@ Specify an alternate project name; default is the directory name
 #### --emulated, -e
 
 Run an emulated build using Qemu
+
+#### --dockerfile &#60;Dockerfile&#62;
+
+Alternative Dockerfile name/path, relative to the source folder
 
 #### --logs
 
@@ -1819,17 +1903,18 @@ balena device. (See also the `balena push` command for the option of building
 the image in the balenaCloud build servers.)
 
 Unless an image is specified, this command will look into the current directory
-(or the one specified by --source) for a compose file. If one is found, this
-command will deploy each service defined in the compose file, building it first
-if an image for it doesn't exist. If a compose file isn't found, the command
-will look for a Dockerfile, and if yet that isn't found, it will try to
-generate one.
+(or the one specified by --source) for a docker-compose.yml file.  If one is
+found, this command will deploy each service defined in the compose file,
+building it first if an image for it doesn't exist. If a compose file isn't
+found, the command will look for a Dockerfile[.template] file (or alternative
+Dockerfile specified with the `-f` option), and if yet that isn't found, it
+will try to generate one.
 
 To deploy to an app on which you're a collaborator, use
 `balena deploy <appOwnerUsername>/<appName>`.
 
-When --build is used, all options supported by `balena build` are also
-supported by this command.
+When --build is used, all options supported by `balena build` are also supported
+by this command.
 
 The --registry-secrets option specifies a JSON or YAML file containing private
 Docker registry usernames and passwords to be used when pulling base images.
@@ -1872,6 +1957,10 @@ Specify an alternate project name; default is the directory name
 #### --emulated, -e
 
 Run an emulated build using Qemu
+
+#### --dockerfile &#60;Dockerfile&#62;
+
+Alternative Dockerfile name/path, relative to the source folder
 
 #### --logs
 

--- a/pages/reference/sdk/node-sdk.md
+++ b/pages/reference/sdk/node-sdk.md
@@ -111,6 +111,8 @@ If you feel something is missing, not clear or could be improved, please don't h
             * [.shutdown(uuidOrId, [options])](#balena.models.device.shutdown) ⇒ <code>Promise</code>
             * [.purge(uuidOrId)](#balena.models.device.purge) ⇒ <code>Promise</code>
             * [.update(uuidOrId, [options])](#balena.models.device.update) ⇒ <code>Promise</code>
+            * [.getSupervisorTargetState(uuidOrId)](#balena.models.device.getSupervisorTargetState) ⇒ <code>Promise</code>
+            * [.getSupervisorState(uuidOrId)](#balena.models.device.getSupervisorState) ⇒ <code>Promise</code>
             * [.getDisplayName(deviceTypeSlug)](#balena.models.device.getDisplayName) ⇒ <code>Promise</code>
             * [.getDeviceSlug(deviceTypeName)](#balena.models.device.getDeviceSlug) ⇒ <code>Promise</code>
             * [.getSupportedDeviceTypes()](#balena.models.device.getSupportedDeviceTypes) ⇒ <code>Promise</code>
@@ -135,6 +137,8 @@ If you feel something is missing, not clear or could be improved, please don't h
             * [.getTargetReleaseHash(uuidOrId)](#balena.models.device.getTargetReleaseHash) ⇒ <code>Promise</code>
             * [.pinToRelease(uuidOrId, fullReleaseHashOrId)](#balena.models.device.pinToRelease) ⇒ <code>Promise</code>
             * [.trackApplicationRelease(uuidOrId)](#balena.models.device.trackApplicationRelease) ⇒ <code>Promise</code>
+            * [.startOsUpdate(uuid, targetOsVersion)](#balena.models.device.startOsUpdate) ⇒ <code>Promise</code>
+            * [.getOsUpdateStatus(uuid)](#balena.models.device.getOsUpdateStatus) ⇒ <code>Promise</code>
         * [.apiKey](#balena.models.apiKey) : <code>object</code>
             * [.create(name, [description])](#balena.models.apiKey.create) ⇒ <code>Promise</code>
             * [.getAll([options])](#balena.models.apiKey.getAll) ⇒ <code>Promise</code>
@@ -152,6 +156,8 @@ If you feel something is missing, not clear or could be improved, please don't h
             * [.getLastModified(deviceType, [version])](#balena.models.os.getLastModified) ⇒ <code>Promise</code>
             * [.download(deviceType, [version])](#balena.models.os.download) ⇒ <code>Promise</code>
             * [.getConfig(nameOrId, options)](#balena.models.os.getConfig) ⇒ <code>Promise</code>
+            * [.isSupportedOsUpdate(deviceType, currentVersion, targetVersion)](#balena.models.os.isSupportedOsUpdate) ⇒ <code>Promise</code>
+            * [.getSupportedOsUpdateVersions(deviceType, currentVersion)](#balena.models.os.getSupportedOsUpdateVersions) ⇒ <code>Promise</code>
         * [.config](#balena.models.config) : <code>object</code>
             * [.getAll()](#balena.models.config.getAll) ⇒ <code>Promise</code>
             * [.getDeviceTypes()](#balena.models.config.getDeviceTypes) ⇒ <code>Promise</code>
@@ -408,6 +414,8 @@ balena.models.device.get(123).catch(function (error) {
         * [.shutdown(uuidOrId, [options])](#balena.models.device.shutdown) ⇒ <code>Promise</code>
         * [.purge(uuidOrId)](#balena.models.device.purge) ⇒ <code>Promise</code>
         * [.update(uuidOrId, [options])](#balena.models.device.update) ⇒ <code>Promise</code>
+        * [.getSupervisorTargetState(uuidOrId)](#balena.models.device.getSupervisorTargetState) ⇒ <code>Promise</code>
+        * [.getSupervisorState(uuidOrId)](#balena.models.device.getSupervisorState) ⇒ <code>Promise</code>
         * [.getDisplayName(deviceTypeSlug)](#balena.models.device.getDisplayName) ⇒ <code>Promise</code>
         * [.getDeviceSlug(deviceTypeName)](#balena.models.device.getDeviceSlug) ⇒ <code>Promise</code>
         * [.getSupportedDeviceTypes()](#balena.models.device.getSupportedDeviceTypes) ⇒ <code>Promise</code>
@@ -432,6 +440,8 @@ balena.models.device.get(123).catch(function (error) {
         * [.getTargetReleaseHash(uuidOrId)](#balena.models.device.getTargetReleaseHash) ⇒ <code>Promise</code>
         * [.pinToRelease(uuidOrId, fullReleaseHashOrId)](#balena.models.device.pinToRelease) ⇒ <code>Promise</code>
         * [.trackApplicationRelease(uuidOrId)](#balena.models.device.trackApplicationRelease) ⇒ <code>Promise</code>
+        * [.startOsUpdate(uuid, targetOsVersion)](#balena.models.device.startOsUpdate) ⇒ <code>Promise</code>
+        * [.getOsUpdateStatus(uuid)](#balena.models.device.getOsUpdateStatus) ⇒ <code>Promise</code>
     * [.apiKey](#balena.models.apiKey) : <code>object</code>
         * [.create(name, [description])](#balena.models.apiKey.create) ⇒ <code>Promise</code>
         * [.getAll([options])](#balena.models.apiKey.getAll) ⇒ <code>Promise</code>
@@ -449,6 +459,8 @@ balena.models.device.get(123).catch(function (error) {
         * [.getLastModified(deviceType, [version])](#balena.models.os.getLastModified) ⇒ <code>Promise</code>
         * [.download(deviceType, [version])](#balena.models.os.download) ⇒ <code>Promise</code>
         * [.getConfig(nameOrId, options)](#balena.models.os.getConfig) ⇒ <code>Promise</code>
+        * [.isSupportedOsUpdate(deviceType, currentVersion, targetVersion)](#balena.models.os.isSupportedOsUpdate) ⇒ <code>Promise</code>
+        * [.getSupportedOsUpdateVersions(deviceType, currentVersion)](#balena.models.os.getSupportedOsUpdateVersions) ⇒ <code>Promise</code>
     * [.config](#balena.models.config) : <code>object</code>
         * [.getAll()](#balena.models.config.getAll) ⇒ <code>Promise</code>
         * [.getDeviceTypes()](#balena.models.config.getDeviceTypes) ⇒ <code>Promise</code>
@@ -1656,6 +1668,8 @@ balena.models.application.revokeSupportAccess('MyApp', function(error) {
     * [.shutdown(uuidOrId, [options])](#balena.models.device.shutdown) ⇒ <code>Promise</code>
     * [.purge(uuidOrId)](#balena.models.device.purge) ⇒ <code>Promise</code>
     * [.update(uuidOrId, [options])](#balena.models.device.update) ⇒ <code>Promise</code>
+    * [.getSupervisorTargetState(uuidOrId)](#balena.models.device.getSupervisorTargetState) ⇒ <code>Promise</code>
+    * [.getSupervisorState(uuidOrId)](#balena.models.device.getSupervisorState) ⇒ <code>Promise</code>
     * [.getDisplayName(deviceTypeSlug)](#balena.models.device.getDisplayName) ⇒ <code>Promise</code>
     * [.getDeviceSlug(deviceTypeName)](#balena.models.device.getDeviceSlug) ⇒ <code>Promise</code>
     * [.getSupportedDeviceTypes()](#balena.models.device.getSupportedDeviceTypes) ⇒ <code>Promise</code>
@@ -1680,6 +1694,8 @@ balena.models.application.revokeSupportAccess('MyApp', function(error) {
     * [.getTargetReleaseHash(uuidOrId)](#balena.models.device.getTargetReleaseHash) ⇒ <code>Promise</code>
     * [.pinToRelease(uuidOrId, fullReleaseHashOrId)](#balena.models.device.pinToRelease) ⇒ <code>Promise</code>
     * [.trackApplicationRelease(uuidOrId)](#balena.models.device.trackApplicationRelease) ⇒ <code>Promise</code>
+    * [.startOsUpdate(uuid, targetOsVersion)](#balena.models.device.startOsUpdate) ⇒ <code>Promise</code>
+    * [.getOsUpdateStatus(uuid)](#balena.models.device.getOsUpdateStatus) ⇒ <code>Promise</code>
 
 <a name="balena.models.device.tags"></a>
 
@@ -3236,6 +3252,66 @@ balena.models.device.update('7cf02a6', {
 	if (error) throw error;
 });
 ```
+<a name="balena.models.device.getSupervisorTargetState"></a>
+
+##### device.getSupervisorTargetState(uuidOrId) ⇒ <code>Promise</code>
+**Kind**: static method of [<code>device</code>](#balena.models.device)  
+**Summary**: Get the target supervisor state on a device  
+**Access**: public  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| uuidOrId | <code>String</code> \| <code>Number</code> | device uuid (string) or id (number) |
+
+**Example**  
+```js
+balena.models.device.getSupervisorTargetState('7cf02a6').then(function(state) {
+	console.log(state);
+});
+```
+**Example**  
+```js
+balena.models.device.getSupervisorTargetState(123).then(function(state) {
+	console.log(state);
+});
+```
+**Example**  
+```js
+balena.models.device.getSupervisorTargetState('7cf02a6', function(error, state) {
+	if (error) throw error;
+	console.log(state);
+});
+```
+<a name="balena.models.device.getSupervisorState"></a>
+
+##### device.getSupervisorState(uuidOrId) ⇒ <code>Promise</code>
+**Kind**: static method of [<code>device</code>](#balena.models.device)  
+**Summary**: Get the supervisor state on a device  
+**Access**: public  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| uuidOrId | <code>String</code> \| <code>Number</code> | device uuid (string) or id (number) |
+
+**Example**  
+```js
+balena.models.device.getSupervisorState('7cf02a6').then(function(state) {
+	console.log(state);
+});
+```
+**Example**  
+```js
+balena.models.device.getSupervisorState(123).then(function(state) {
+	console.log(state);
+});
+```
+**Example**  
+```js
+balena.models.device.getSupervisorState('7cf02a6', function(error, state) {
+	if (error) throw error;
+	console.log(state);
+});
+```
 <a name="balena.models.device.getDisplayName"></a>
 
 ##### device.getDisplayName(deviceTypeSlug) ⇒ <code>Promise</code>
@@ -3875,6 +3951,57 @@ balena.models.device.trackApplicationRelease('7cf02a6', function(error) {
 	...
 });
 ```
+<a name="balena.models.device.startOsUpdate"></a>
+
+##### device.startOsUpdate(uuid, targetOsVersion) ⇒ <code>Promise</code>
+**Kind**: static method of [<code>device</code>](#balena.models.device)  
+**Summary**: Start an OS update on a device  
+**Access**: public  
+**Fulfil**: <code>Object</code> - action response  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| uuid | <code>String</code> | full device uuid |
+| targetOsVersion | <code>String</code> | semver-compatible version for the target device Unsupported (unpublished) version will result in rejection. The version **must** be the exact version number, a "prod" variant and greater than the one running on the device. To resolve the semver-compatible range use `balena.model.os.getMaxSatisfyingVersion`. |
+
+**Example**  
+```js
+balena.models.device.startOsUpdate('7cf02a687b74206f92cb455969cf8e98', '2.29.2+rev1.prod').then(function(status) {
+	console.log(result.status);
+});
+```
+**Example**  
+```js
+balena.models.device.startOsUpdate('7cf02a687b74206f92cb455969cf8e98', '2.29.2+rev1.prod', function(error, status) {
+	if (error) throw error;
+	console.log(result.status);
+});
+```
+<a name="balena.models.device.getOsUpdateStatus"></a>
+
+##### device.getOsUpdateStatus(uuid) ⇒ <code>Promise</code>
+**Kind**: static method of [<code>device</code>](#balena.models.device)  
+**Summary**: Get the OS update status of a device  
+**Access**: public  
+**Fulfil**: <code>Object</code> - action response  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| uuid | <code>String</code> | full device uuid |
+
+**Example**  
+```js
+balena.models.device.getOsUpdateStatus('7cf02a687b74206f92cb455969cf8e98').then(function(status) {
+	console.log(result.status);
+});
+```
+**Example**  
+```js
+balena.models.device.getOsUpdateStatus('7cf02a687b74206f92cb455969cf8e98', function(error, status) {
+	if (error) throw error;
+	console.log(result.status);
+});
+```
 <a name="balena.models.apiKey"></a>
 
 #### models.apiKey : <code>object</code>
@@ -4117,6 +4244,8 @@ balena.models.key.create('Main', 'ssh-rsa AAAAB....', function(error, key) {
     * [.getLastModified(deviceType, [version])](#balena.models.os.getLastModified) ⇒ <code>Promise</code>
     * [.download(deviceType, [version])](#balena.models.os.download) ⇒ <code>Promise</code>
     * [.getConfig(nameOrId, options)](#balena.models.os.getConfig) ⇒ <code>Promise</code>
+    * [.isSupportedOsUpdate(deviceType, currentVersion, targetVersion)](#balena.models.os.isSupportedOsUpdate) ⇒ <code>Promise</code>
+    * [.getSupportedOsUpdateVersions(deviceType, currentVersion)](#balena.models.os.getSupportedOsUpdateVersions) ⇒ <code>Promise</code>
 
 <a name="balena.models.os.getDownloadSize"></a>
 
@@ -4289,6 +4418,60 @@ balena.models.os.getConfig(123, { version: ''2.12.7+rev1.prod'' }).then(function
 balena.models.os.getConfig('MyApp', { version: ''2.12.7+rev1.prod'' }, function(error, config) {
 	if (error) throw error;
 	fs.writeFile('foo/bar/config.json', JSON.stringify(config));
+});
+```
+<a name="balena.models.os.isSupportedOsUpdate"></a>
+
+##### os.isSupportedOsUpdate(deviceType, currentVersion, targetVersion) ⇒ <code>Promise</code>
+**Kind**: static method of [<code>os</code>](#balena.models.os)  
+**Summary**: Returns whether the provided device type supports OS updates between the provided balenaOS versions  
+**Access**: public  
+**Fulfil**: <code>Boolean</code> - whether upgrading the OS to the target version is supported  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| deviceType | <code>String</code> | device type slug |
+| currentVersion | <code>String</code> | semver-compatible version for the starting OS version |
+| targetVersion | <code>String</code> | semver-compatible version for the target OS version |
+
+**Example**  
+```js
+balena.models.os.isSupportedOsUpgrade('raspberry-pi', '2.9.6+rev2.prod', '2.29.2+rev1.prod').then(function(isSupported) {
+	console.log(isSupported);
+});
+
+balena.models.os.isSupportedOsUpgrade('raspberry-pi', '2.9.6+rev2.prod', '2.29.2+rev1.prod', function(error, config) {
+	if (error) throw error;
+	console.log(isSupported);
+});
+```
+<a name="balena.models.os.getSupportedOsUpdateVersions"></a>
+
+##### os.getSupportedOsUpdateVersions(deviceType, currentVersion) ⇒ <code>Promise</code>
+**Kind**: static method of [<code>os</code>](#balena.models.os)  
+**Summary**: Returns the supported OS update targets for the provided device type  
+**Access**: public  
+**Fulfil**: <code>Object</code> - the versions information, of the following structure:
+* versions - an array of strings,
+containing exact version numbers that OS update is supported
+* recommended - the recommended version, i.e. the most recent version
+that is _not_ pre-release, can be `null`
+* current - the provided current version after normalization  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| deviceType | <code>String</code> | device type slug |
+| currentVersion | <code>String</code> | semver-compatible version for the starting OS version |
+
+**Example**  
+```js
+balena.models.os.getSupportedOsUpdateVersions('raspberry-pi', '2.9.6+rev2.prod').then(function(isSupported) {
+	console.log(isSupported);
+});
+
+balena.models.os.getSupportedOsUpdateVersions('raspberry-pi', '2.9.6+rev2.prod', function(error, config) {
+	if (error) throw error;
+	console.log(isSupported);
 });
 ```
 <a name="balena.models.config"></a>
@@ -5430,10 +5613,6 @@ can be used to listen for logs as they appear, line by line.
 **Summary**: Subscribe to device logs  
 **Access**: public  
 **Fulfil**: [<code>LogSubscription</code>](#balena.logs.LogSubscription)  
-**Todo**
-
-- [ ] We should consider making this a readable stream.
-
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |

--- a/pages/reference/sdk/python-sdk.md
+++ b/pages/reference/sdk/python-sdk.md
@@ -66,11 +66,7 @@ This module implements all models for balena python SDK.
 
 This class implements application model for balena python SDK.
 
-Due to API changes, the returned Application object schema has changed. Here are the formats of the old and new returned objects.
-
-The old returned object's properties: `__metadata, actor, app_name, application, commit, device_type, git_repository, id, should_track_latest_release, support_expiry_date, user, version`.
-
-The new returned object's properties (since python SDK v2.0.0): `__metadata, actor, app_name, commit, depends_on__application, device_type, git_repository, id, is_accessible_by_support_until__date, should_track_latest_release, user, version`.
+The returned objects properties are `__metadata, actor, app_name, application_type, commit, depends_on__application, device_type, id, is_accessible_by_support_until__date, should_track_latest_release, slug, user`.
 ### Function: create(name, device_type, app_type)
 
 Create an application. This function only works if you log in using credentials or Auth Token.
@@ -89,8 +85,8 @@ Create an application. This function only works if you log in using credentials 
 
 #### Examples:
 ```python
->>> balena.models.application.create('Foobar', 'Raspberry Pi 3', 'microservices-starter')
-'{"id":1005767,"user":{"__deferred":{"uri":"/balena/user(32986)"},"__id":32986},"depends_on__application":null,"actor":2630233,"app_name":"Foobar","git_repository":"pythonsdk_test_balena/foobar","commit":null,"application_type":{"__deferred":{"uri":"/balena/application_type(5)"},"__id":5},"device_type":"raspberrypi3","should_track_latest_release":true,"is_accessible_by_support_until__date":null,"__metadata":{"uri":"/balena/application(1005767)","type":""}}'
+>>> balena.models.application.create('foo', 'Raspberry Pi 3', 'microservices-starter')
+'{u'depends_on__application': None, u'should_track_latest_release': True, u'app_name': u'foo', u'application_type': {u'__deferred': {u'uri': u'/resin/application_type(5)'}, u'__id': 5}, u'__metadata': {u'type': u'', u'uri': u'/resin/application(12345)'}, u'is_accessible_by_support_until__date': None, u'actor': 12345, u'id': 12345, u'user': {u'__deferred': {u'uri': u'/resin/user(12345)'}, u'__id': 12345}, u'device_type': u'raspberrypi3', u'commit': None, u'slug': u'my_user/foo'}'
 ```
 ### Function: disable_device_urls(app_id)
 
@@ -179,8 +175,8 @@ Get a single application.
 
 #### Examples:
 ```python
->>> balena.models.application.get('RPI1')
-{u'app_name': u'RPI1', u'__metadata': {u'type': u'', u'uri': u'/ewa/application(9020)'}, u'git_repository': u'g_trong_nghia_nguyen@git.balena.io:g_trong_nghia_nguyen/rpi1.git', u'user': {u'__deferred': {u'uri': u'/ewa/user(5397)'}, u'__id': 5397}, u'device_type': u'raspberry-pi', u'commit': None, u'id': 9020}
+>>> balena.models.application.get('foo')
+'{u'depends_on__application': None, u'should_track_latest_release': True, u'app_name': u'foo', u'application_type': {u'__deferred': {u'uri': u'/resin/application_type(5)'}, u'__id': 5}, u'__metadata': {u'type': u'', u'uri': u'/resin/application(12345)'}, u'is_accessible_by_support_until__date': None, u'actor': 12345, u'id': 12345, u'user': {u'__deferred': {u'uri': u'/resin/user(12345)'}, u'__id': 12345}, u'device_type': u'raspberrypi3', u'commit': None, u'slug': u'my_user/foo'}'
 ```
 ### Function: get_all()
 
@@ -192,7 +188,7 @@ Get all applications (including collaborator applications).
 #### Examples:
 ```python
 >>> balena.models.application.get_all()
-[{u'app_name': u'RPI1', u'__metadata': {u'type': u'', u'uri': u'/ewa/application(9020)'}, u'git_repository': u'g_trong_nghia_nguyen@git.balena.io:g_trong_nghia_nguyen/rpi1.git', u'user': {u'__deferred': {u'uri': u'/ewa/user(5397)'}, u'__id': 5397}, u'device_type': u'raspberry-pi', u'commit': None, u'id': 9020}, {u'app_name': u'RPI2', u'__metadata': {u'type': u'', u'uri': u'/ewa/application(9019)'}, u'git_repository': u'g_trong_nghia_nguyen@git.balena.io:g_trong_nghia_nguyen/rpi2.git', u'user': {u'__deferred': {u'uri': u'/ewa/user(5397)'}, u'__id': 5397}, u'device_type': u'raspberry-pi2', u'commit': None, u'id': 9019}]
+'[{u'depends_on__application': None, u'should_track_latest_release': True, u'app_name': u'foo', u'application_type': {u'__deferred': {u'uri': u'/resin/application_type(5)'}, u'__id': 5}, u'__metadata': {u'type': u'', u'uri': u'/resin/application(12345)'}, u'is_accessible_by_support_until__date': None, u'actor': 12345, u'id': 12345, u'user': {u'__deferred': {u'uri': u'/resin/user(12345)'}, u'__id': 12345}, u'device_type': u'raspberrypi3', u'commit': None, u'slug': u'my_user/foo'}, {u'depends_on__application': None, u'should_track_latest_release': True, u'app_name': u'bar', u'application_type': {u'__deferred': {u'uri': u'/resin/application_type(5)'}, u'__id': 5}, u'__metadata': {u'type': u'', u'uri': u'/resin/application(12346)'}, u'is_accessible_by_support_until__date': None, u'actor': 12345, u'id': 12346, u'user': {u'__deferred': {u'uri': u'/resin/user(12345)'}, u'__id': 12345}, u'device_type': u'raspberrypi3', u'commit': None, u'slug': u'my_user/bar'}]'
 ```
 ### Function: get_by_id(app_id)
 
@@ -209,8 +205,8 @@ Get a single application by application id.
 
 #### Examples:
 ```python
->>> balena.models.application.get_by_id(9020)
-{u'app_name': u'RPI1', u'__metadata': {u'type': u'', u'uri': u'/ewa/application(9020)'}, u'git_repository': u'g_trong_nghia_nguyen@git.balena.io:g_trong_nghia_nguyen/rpi1.git', u'user': {u'__deferred': {u'uri': u'/ewa/user(5397)'}, u'__id': 5397}, u'device_type': u'raspberry-pi', u'commit': None, u'id': 9020}
+>>> balena.models.application.get_by_id(12345)
+'{u'depends_on__application': None, u'should_track_latest_release': True, u'app_name': u'foo', u'application_type': {u'__deferred': {u'uri': u'/resin/application_type(5)'}, u'__id': 5}, u'__metadata': {u'type': u'', u'uri': u'/resin/application(12345)'}, u'is_accessible_by_support_until__date': None, u'actor': 12345, u'id': 12345, u'user': {u'__deferred': {u'uri': u'/resin/user(12345)'}, u'__id': 12345}, u'device_type': u'raspberrypi3', u'commit': None, u'slug': u'my_user/foo'}'
 ```
 ### Function: get_by_owner(name, owner)
 
@@ -229,8 +225,8 @@ Get a single application.
 
 #### Examples:
 ```python
->>> balena.models.application.get_by_owner('mothaiba', 'pythonsdk_test_resin')
-{u'depends_on__application': None, u'should_track_latest_release': True, u'app_name': u'mothaiba', u'application_type': {u'__deferred': {u'uri': u'/resin/application_type(5)'}, u'__id': 5}, u'__metadata': {u'type': u'', u'uri': u'/resin/application(1307755)'}, u'is_accessible_by_support_until__date': None, u'actor': 3438708, u'id': 1307755, u'user': {u'__deferred': {u'uri': u'/resin/user(32986)'}, u'__id': 32986}, u'device_type': u'raspberrypi3', u'commit': None, u'slug': u'pythonsdk_test_resin/mothaiba'}
+>>> balena.models.application.get_by_owner('foo', 'my_user')
+'{u'depends_on__application': None, u'should_track_latest_release': True, u'app_name': u'foo', u'application_type': {u'__deferred': {u'uri': u'/resin/application_type(5)'}, u'__id': 5}, u'__metadata': {u'type': u'', u'uri': u'/resin/application(12345)'}, u'is_accessible_by_support_until__date': None, u'actor': 12345, u'id': 12345, u'user': {u'__deferred': {u'uri': u'/resin/user(12345)'}, u'__id': 12345}, u'device_type': u'raspberrypi3', u'commit': None, u'slug': u'my_user/foo'}'
 ```
 ### Function: get_config(app_id, version)
 
@@ -293,7 +289,7 @@ Check if an application exists.
 
 #### Examples:
 ```python
->>> balena.models.application.has('RPI1')
+>>> balena.models.application.has('foo')
 True
 ```
 ### Function: has_any()
@@ -732,7 +728,7 @@ Get a single device by device uuid.
 #### Examples:
 ```python
 >>> balena.models.device.get('8deb12a58e3b6d3920db1c2b6303d1ff32f23d5ab99781ce1dde6876e8d143')
-{u'__metadata': {u'type': u'', u'uri': u'/ewa/device(122950)'}, u'last_seen_time': u'1970-01-01T00:00:00.000Z', u'is_web_accessible': False, u'device_type': u'raspberry-pi', u'id': 122950, u'logs_channel': None, u'uuid': u'8deb12a58e3b6d3920db1c2b6303d1ff32f23d5ab99781ce1dde6876e8d143', u'application': {u'__deferred': {u'uri': u'/ewa/application(9020)'}, u'__id': 9020}, u'note': None, u'os_version': None, u'location': u'', u'latitude': u'', u'status': None, u'public_address': u'', u'provisioning_state': None, u'user': {u'__deferred': {u'uri': u'/ewa/user(5397)'}, u'__id': 5397}, u'is_online': False, u'supervisor_version': None, u'ip_address': None, u'vpn_address': None, u'name': u'floral-mountain', u'download_progress': None, u'longitude': u'', u'commit': None, u'provisioning_progress': None, u'supervisor_release': None}
+{u'__metadata': {u'type': u'', u'uri': u'/ewa/device(122950)'}, u'last_connectivity_event': u'1970-01-01T00:00:00.000Z', u'is_web_accessible': False, u'device_type': u'raspberry-pi', u'id': 122950, u'logs_channel': None, u'uuid': u'8deb12a58e3b6d3920db1c2b6303d1ff32f23d5ab99781ce1dde6876e8d143', u'application': {u'__deferred': {u'uri': u'/ewa/application(9020)'}, u'__id': 9020}, u'note': None, u'os_version': None, u'location': u'', u'latitude': u'', u'status': None, u'public_address': u'', u'provisioning_state': None, u'user': {u'__deferred': {u'uri': u'/ewa/user(5397)'}, u'__id': 5397}, u'is_online': False, u'supervisor_version': None, u'ip_address': None, u'vpn_address': None, u'name': u'floral-mountain', u'download_progress': None, u'longitude': u'', u'commit': None, u'provisioning_progress': None, u'supervisor_release': None}
 ```
 ### Function: get_all()
 
@@ -744,7 +740,7 @@ Get all devices.
 #### Examples:
 ```python
 >>> balena.models.device.get_all()
-[{u'__metadata': {u'type': u'', u'uri': u'/ewa/device(122950)'}, u'last_seen_time': u'1970-01-01T00:00:00.000Z', u'is_web_accessible': False, u'device_type': u'raspberry-pi', u'id': 122950, u'logs_channel': None, u'uuid': u'8deb12a58e3b6d3920db1c2b6303d1ff32f23d5ab99781ce1dde6876e8d143', u'application': {u'__deferred': {u'uri': u'/ewa/application(9020)'}, u'__id': 9020}, u'note': None, u'os_version': None, u'location': u'', u'latitude': u'', u'status': None, u'public_address': u'', u'provisioning_state': None, u'user': {u'__deferred': {u'uri': u'/ewa/user(5397)'}, u'__id': 5397}, u'is_online': False, u'supervisor_version': None, u'ip_address': None, u'vpn_address': None, u'name': u'floral-mountain', u'download_progress': None, u'longitude': u'', u'commit': None, u'provisioning_progress': None, u'supervisor_release': None}]
+[{u'__metadata': {u'type': u'', u'uri': u'/ewa/device(122950)'}, u'last_connectivity_event': u'1970-01-01T00:00:00.000Z', u'is_web_accessible': False, u'device_type': u'raspberry-pi', u'id': 122950, u'logs_channel': None, u'uuid': u'8deb12a58e3b6d3920db1c2b6303d1ff32f23d5ab99781ce1dde6876e8d143', u'application': {u'__deferred': {u'uri': u'/ewa/application(9020)'}, u'__id': 9020}, u'note': None, u'os_version': None, u'location': u'', u'latitude': u'', u'status': None, u'public_address': u'', u'provisioning_state': None, u'user': {u'__deferred': {u'uri': u'/ewa/user(5397)'}, u'__id': 5397}, u'is_online': False, u'supervisor_version': None, u'ip_address': None, u'vpn_address': None, u'name': u'floral-mountain', u'download_progress': None, u'longitude': u'', u'commit': None, u'provisioning_progress': None, u'supervisor_release': None}]
 ```
 ### Function: get_all_by_application(name)
 
@@ -759,7 +755,7 @@ Get devices by application name.
 #### Examples:
 ```python
 >>> balena.models.device.get_all_by_application('RPI1')
-[{u'__metadata': {u'type': u'', u'uri': u'/ewa/device(122950)'}, u'last_seen_time': u'1970-01-01T00:00:00.000Z', u'is_web_accessible': False, u'device_type': u'raspberry-pi', u'id': 122950, u'logs_channel': None, u'uuid': u'8deb12a58e3b6d3920db1c2b6303d1ff32f23d5ab99781ce1dde6876e8d143', u'application': {u'__deferred': {u'uri': u'/ewa/application(9020)'}, u'__id': 9020}, u'note': None, u'os_version': None, u'location': u'', u'latitude': u'', u'status': None, u'public_address': u'', u'provisioning_state': None, u'user': {u'__deferred': {u'uri': u'/ewa/user(5397)'}, u'__id': 5397}, u'is_online': False, u'supervisor_version': None, u'ip_address': None, u'vpn_address': None, u'name': u'floral-mountain', u'download_progress': None, u'longitude': u'', u'commit': None, u'provisioning_progress': None, u'supervisor_release': None}]
+[{u'__metadata': {u'type': u'', u'uri': u'/ewa/device(122950)'}, u'last_connectivity_event': u'1970-01-01T00:00:00.000Z', u'is_web_accessible': False, u'device_type': u'raspberry-pi', u'id': 122950, u'logs_channel': None, u'uuid': u'8deb12a58e3b6d3920db1c2b6303d1ff32f23d5ab99781ce1dde6876e8d143', u'application': {u'__deferred': {u'uri': u'/ewa/application(9020)'}, u'__id': 9020}, u'note': None, u'os_version': None, u'location': u'', u'latitude': u'', u'status': None, u'public_address': u'', u'provisioning_state': None, u'user': {u'__deferred': {u'uri': u'/ewa/user(5397)'}, u'__id': 5397}, u'is_online': False, u'supervisor_version': None, u'ip_address': None, u'vpn_address': None, u'name': u'floral-mountain', u'download_progress': None, u'longitude': u'', u'commit': None, u'provisioning_progress': None, u'supervisor_release': None}]
 ```
 ### Function: get_all_by_application_id(appid)
 
@@ -774,7 +770,7 @@ Get devices by application name.
 #### Examples:
 ```python
 >>> balena.models.device.get_all_by_application_id(1234)
-[{u'__metadata': {u'type': u'', u'uri': u'/ewa/device(122950)'}, u'last_seen_time': u'1970-01-01T00:00:00.000Z', u'is_web_accessible': False, u'device_type': u'raspberry-pi', u'id': 122950, u'logs_channel': None, u'uuid': u'8deb12a58e3b6d3920db1c2b6303d1ff32f23d5ab99781ce1dde6876e8d143', u'application': {u'__deferred': {u'uri': u'/ewa/application(9020)'}, u'__id': 9020}, u'note': None, u'os_version': None, u'location': u'', u'latitude': u'', u'status': None, u'public_address': u'', u'provisioning_state': None, u'user': {u'__deferred': {u'uri': u'/ewa/user(5397)'}, u'__id': 5397}, u'is_online': False, u'supervisor_version': None, u'ip_address': None, u'vpn_address': None, u'name': u'floral-mountain', u'download_progress': None, u'longitude': u'', u'commit': None, u'provisioning_progress': None, u'supervisor_release': None}]
+[{u'__metadata': {u'type': u'', u'uri': u'/ewa/device(122950)'}, u'last_connectivity_event': u'1970-01-01T00:00:00.000Z', u'is_web_accessible': False, u'device_type': u'raspberry-pi', u'id': 122950, u'logs_channel': None, u'uuid': u'8deb12a58e3b6d3920db1c2b6303d1ff32f23d5ab99781ce1dde6876e8d143', u'application': {u'__deferred': {u'uri': u'/ewa/application(9020)'}, u'__id': 9020}, u'note': None, u'os_version': None, u'location': u'', u'latitude': u'', u'status': None, u'public_address': u'', u'provisioning_state': None, u'user': {u'__deferred': {u'uri': u'/ewa/user(5397)'}, u'__id': 5397}, u'is_online': False, u'supervisor_version': None, u'ip_address': None, u'vpn_address': None, u'name': u'floral-mountain', u'download_progress': None, u'longitude': u'', u'commit': None, u'provisioning_progress': None, u'supervisor_release': None}]
 ```
 ### Function: get_application_name(uuid)
 
@@ -801,7 +797,7 @@ Get devices by device name.
 #### Examples:
 ```python
 >>> balena.models.device.get_by_name('floral-mountain')
-[{u'__metadata': {u'type': u'', u'uri': u'/ewa/device(122950)'}, u'last_seen_time': u'1970-01-01T00:00:00.000Z', u'is_web_accessible': False, u'device_type': u'raspberry-pi', u'id': 122950, u'logs_channel': None, u'uuid': u'8deb12a58e3b6d3920db1c2b6303d1ff32f23d5ab99781ce1dde6876e8d143', u'application': {u'__deferred': {u'uri': u'/ewa/application(9020)'}, u'__id': 9020}, u'note': None, u'os_version': None, u'location': u'', u'latitude': u'', u'status': None, u'public_address': u'', u'provisioning_state': None, u'user': {u'__deferred': {u'uri': u'/ewa/user(5397)'}, u'__id': 5397}, u'is_online': False, u'supervisor_version': None, u'ip_address': None, u'vpn_address': None, u'name': u'floral-mountain', u'download_progress': None, u'longitude': u'', u'commit': None, u'provisioning_progress': None, u'supervisor_release': None}]
+[{u'__metadata': {u'type': u'', u'uri': u'/ewa/device(122950)'}, u'last_connectivity_event': u'1970-01-01T00:00:00.000Z', u'is_web_accessible': False, u'device_type': u'raspberry-pi', u'id': 122950, u'logs_channel': None, u'uuid': u'8deb12a58e3b6d3920db1c2b6303d1ff32f23d5ab99781ce1dde6876e8d143', u'application': {u'__deferred': {u'uri': u'/ewa/application(9020)'}, u'__id': 9020}, u'note': None, u'os_version': None, u'location': u'', u'latitude': u'', u'status': None, u'public_address': u'', u'provisioning_state': None, u'user': {u'__deferred': {u'uri': u'/ewa/user(5397)'}, u'__id': 5397}, u'is_online': False, u'supervisor_version': None, u'ip_address': None, u'vpn_address': None, u'name': u'floral-mountain', u'download_progress': None, u'longitude': u'', u'commit': None, u'provisioning_progress': None, u'supervisor_release': None}]
 ```
 ### Function: get_dashboard_url(uuid)
 
@@ -916,6 +912,23 @@ Get device name by device uuid.
 
 #### Raises:
     DeviceNotFound: if device couldn't be found.
+### Function: get_os_update_status(uuid)
+
+        Get the OS update status of a device.
+
+####         Args:
+            uuid (str): device uuid.
+
+####         Returns:
+            dict: action response.
+
+####         Examples:
+```python
+            >>> balena.models.device.get_os_update_status('b6070f4fea5edf808b576123157fe5ec')
+            {u'status': u'done', u'parameters': {u'target_version': u'2.29.2+rev1.prod'}, u'stdout': u'[1554490814][LOG]Normalized target version: 2.29.2+rev1
+', u'last_run': 1554491107242L, u'error': u'', u'action': u'resinhup'}
+        
+```
 ### Function: get_status(uuid)
 
 Get the status of a device.
@@ -933,6 +946,36 @@ Get the status of a device.
 ```python
 >>> balena.models.device.get_status('8deb12a58e3b6d3920db1c2b6303d1ff32f23d5ab99781ce1dde6876e8d143')
 'Offline'
+```
+### Function: get_supervisor_state(uuid)
+
+Get the supervisor state on a device
+
+#### Args:
+    uuid (str): device uuid.
+
+#### Returns:
+    dict: supervisor state.
+
+#### Examples:
+```python
+>>> balena.models.device.get_supervisor_state('b6070f4fea5edf808b576123157fe5ec')
+{u'status': u'Idle', u'update_failed': False, u'os_version': u'balenaOS 2.29.0+rev1', u'download_progress': None, u'update_pending': False, u'api_port': u'48484', u'commit': u'd26dd8a68a47c40daaa1d32e03c96d934f37c53b', u'update_downloaded': False, u'supervisor_version': u'9.0.1', u'ip_address': u'192.168.100.16'}
+```
+### Function: get_supervisor_target_state(uuid)
+
+Get the supervisor target state on a device
+
+#### Args:
+    uuid (str): device uuid.
+
+#### Returns:
+    dict: supervisor target state.
+
+#### Examples:
+```python
+>>> balena.models.device.get_supervisor_target_state('b6070f4fea5edf808b576123157fe5ec')
+{u'local': {u'name': u'holy-darkness', u'config': {u'RESIN_SUPERVISOR_NATIVE_LOGGER': u'true', u'RESIN_SUPERVISOR_POLL_INTERVAL': u'900000'}, u'apps': {u'1398898': {u'name': u'test-nuc', u'commit': u'f9d139b80a7df94f90d7b9098b1353b14ca31b85', u'releaseId': 850293, u'services': {u'229592': {u'imageId': 1016025, u'serviceName': u'main', u'image': u'registry2.balena-cloud.com/v2/27aa30131b770a4f993da9a54eca6ed8@sha256:f489c30335a0036ecf1606df3150907b32ea39d73ec6de825a549385022e3e22', u'running': True, u'environment': {}, u'labels': {u'io.resin.features.dbus': u'1', u'io.resin.features.firmware': u'1', u'io.resin.features.kernel-modules': u'1', u'io.resin.features.resin-api': u'1', u'io.resin.features.supervisor-api': u'1'}, u'privileged': True, u'tty': True, u'restart': u'always', u'network_mode': u'host', u'volumes': ['resin-data:/data']}}, u'volumes': {u'resin-data': {}}, u'networks': {}}}}, u'dependent': {u'apps': {}, u'devices': {}}}
 ```
 ### Function: get_supported_device_types()
 
@@ -1093,7 +1136,7 @@ Register a new device with a balena application. This function only works if you
 ```python
 >>> device_uuid = balena.models.device.generate_uuid()
 >>> balena.models.device.register('RPI1',device_uuid)
-{'id':122950,'application':{'__deferred':{'uri':'/ewa/application(9020)'},'__id':9020},'user':{'__deferred':{'uri':'/ewa/user(5397)'},'__id':5397},'name':'floral-mountain','device_type':'raspberry-pi','uuid':'8deb12a58e3b6d3920db1c2b6303d1ff32f23d5ab99781ce1dde6876e8d143','commit':null,'note':null,'status':null,'is_online':false,'last_seen_time':'1970-01-01T00:00:00.000Z','ip_address':null,'vpn_address':null,'public_address':'','os_version':null,'supervisor_version':null,'supervisor_release':null,'provisioning_progress':null,'provisioning_state':null,'download_progress':null,'is_web_accessible':false,'longitude':'','latitude':'','location':'','logs_channel':null,'__metadata':{'uri':'/ewa/device(122950)','type':''}}
+{'id':122950,'application':{'__deferred':{'uri':'/ewa/application(9020)'},'__id':9020},'user':{'__deferred':{'uri':'/ewa/user(5397)'},'__id':5397},'name':'floral-mountain','device_type':'raspberry-pi','uuid':'8deb12a58e3b6d3920db1c2b6303d1ff32f23d5ab99781ce1dde6876e8d143','commit':null,'note':null,'status':null,'is_online':false,'last_connectivity_event':'1970-01-01T00:00:00.000Z','ip_address':null,'vpn_address':null,'public_address':'','os_version':null,'supervisor_version':null,'supervisor_release':null,'provisioning_progress':null,'provisioning_state':null,'download_progress':null,'is_web_accessible':false,'longitude':'','latitude':'','location':'','logs_channel':null,'__metadata':{'uri':'/ewa/device(122950)','type':''}}
 ```
 ### Function: remove(uuid)
 
@@ -1181,8 +1224,51 @@ Set an empty commit_id will restore rolling releases to the device.
     OK.
 
 #### Examples:
-    >> > balena.models.device.set_to_release('49b2a76b7f188c1d6f781e67c8f34adb4a7bfd2eec3f91d40b1efb75fe413d', '45c90004de73557ded7274d4896a6db90ea61e36')
-    'OK'
+```python
+>>> balena.models.device.set_to_release('49b2a76b7f188c1d6f781e67c8f34adb4a7bfd2eec3f91d40b1efb75fe413d', '45c90004de73557ded7274d4896a6db90ea61e36')
+'OK'
+```
+### Function: set_to_release_by_id(uuid, release_id)
+
+Set device to a specific release by release id (please notice that release id is not the commit hash on balena dashboard).
+Remove release_id will restore rolling releases to the device.
+
+#### Args:
+    uuid (str): device uuid.
+    release_id (Optional[int]): release id.
+
+#### Returns:
+    OK.
+
+#### Examples:
+```python
+>>> balena.models.device.set_to_release_by_id('49b2a76b7f188c1d6f781e67c8f34adb4a7bfd2eec3f91d40b1efb75fe413d', 165432)
+'OK'
+>>> balena.models.device.set_to_release_by_id('49b2a76b7f188c1d6f781e67c8f34adb4a7bfd2eec3f91d40b1efb75fe413d')
+'OK'
+```
+### Function: start_os_update(uuid, target_os_version)
+
+Start an OS update on a device.
+
+#### Args:
+    uuid (str): device uuid.
+    target_os_version (str): semver-compatible version for the target device.
+        Unsupported (unpublished) version will result in rejection.
+        The version **must** be the exact version number, a "prod" variant and greater than the one running on the device.
+
+#### Returns:
+    dict: action response.
+
+#### Raises:
+    DeviceNotFound: if device couldn't be found.
+    InvalidParameter|OsUpdateError: if target_os_version is invalid.
+
+#### Examples:
+```python
+>>> balena.models.device.start_os_update('b6070f4fea5edf808b576123157fe5ec', '2.29.2+rev1.prod')
+{u'status': u'in_progress', u'action': u'resinhup', u'parameters': {u'target_version': u'2.29.2+rev1.prod'}, u'last_run': 1554490809219L}
+```
 ### Function: track_application_release(uuid)
 
 Configure a specific device to track the current application release.
@@ -1255,6 +1341,32 @@ Get an application config.json.
 
 #### Returns:
     dict: application config.json
+### Function: get_device_os_semver_with_variant(os_version, os_variant)
+
+Get current device os semver with variant.
+
+#### Args:
+    os_version (str): current os version.
+    os_variant (str): os variant.
+
+#### Examples:
+```python
+>>> balena.models.device_os.get_device_os_semver_with_variant('balenaOS 2.29.2+rev1', 'prod')
+'2.29.2+rev1.prod'
+```
+### Function: get_supported_versions(device_type)
+
+Get OS supported versions.
+
+#### Args:
+    device_type (str): device type slug
+
+#### Returns:
+    dict: the versions information, of the following structure:
+        * versions - an array of strings, containing exact version numbers supported by the current environment.
+        * recommended - the recommended version, i.e. the most recent version that is _not_ pre-release, can be `None`.
+        * latest - the most recent version, including pre-releases.
+        * default - recommended (if available) or latest otherwise.
 ### Function: parse_params()
 
 Validate parameters for downloading device OS image.

--- a/pages/reference/supervisor/supervisor-api.md
+++ b/pages/reference/supervisor/supervisor-api.md
@@ -14,8 +14,6 @@ The supervisor exposes an HTTP API on port 48484 (`BALENA_SUPERVISOR_PORT`).
 
 To enable these Supervisor environment variables, the `io.balena.features.supervisor-api` label must be applied for each service that requires them. See [here](https://www.balena.io/docs/learn/develop/multicontainer/#labels) for further details.
 
-__Note:__  If you have devices with a supervisor version lower than 7.22.0, you should use `io.resin.features` labelling as that will ensure backward compatibility. 
-
 **All endpoints require an apikey parameter, which is exposed to the application as `BALENA_SUPERVISOR_API_KEY`.**
 
 The full address for the API, i.e. `"http://127.0.0.1:48484"`, is available as `BALENA_SUPERVISOR_ADDRESS`. **Always use these variables when communicating via the API, since address and port could change**.
@@ -37,7 +35,7 @@ Here's the full list of endpoints implemented so far. In all examples, replace e
 Responds with a simple "OK", signaling that the supervisor is alive and well.
 
 #### Examples:
-From the app on the device:
+From an application container:
 ```bash
 $ curl -X GET --header "Content-Type:application/json" \
 	"$BALENA_SUPERVISOR_ADDRESS/ping?apikey=$BALENA_SUPERVISOR_API_KEY"
@@ -65,7 +63,7 @@ Starts a blink pattern on a LED for 15 seconds, if your device has one.
 Responds with an empty 200 response. It implements the "identify device" feature from the dashboard.
 
 #### Examples:
-From the app on the device:
+From an application container:
 ```bash
 $ curl -X POST --header "Content-Type:application/json" \
 	"$BALENA_SUPERVISOR_ADDRESS/v1/blink?apikey=$BALENA_SUPERVISOR_API_KEY"
@@ -100,7 +98,7 @@ Can be a JSON object with a `force` property. If this property is true, the upda
 ```
 
 #### Examples:
-From the app on the device:
+From an application container:
 ```bash
 $ curl -X POST --header "Content-Type:application/json" \
 	--data '{"force": true}' \
@@ -138,7 +136,7 @@ When successful, responds with 202 accepted and a JSON object:
 Can contain a `force` property, which if set to `true` will cause the update lock to be overridden.
 
 #### Examples:
-From the app on the device:
+From an application container:
 ```bash
 $ curl -X POST --header "Content-Type:application/json" \
 	"$BALENA_SUPERVISOR_ADDRESS/v1/reboot?apikey=$BALENA_SUPERVISOR_API_KEY"
@@ -178,7 +176,7 @@ When successful, responds with 202 accepted and a JSON object:
 Can contain a `force` property, which if set to `true` will cause the update lock to be overridden.
 
 #### Examples:
-From the app on the device:
+From an application container:
 ```bash
 $ curl -X POST --header "Content-Type:application/json" \
 	"$BALENA_SUPERVISOR_ADDRESS/v1/shutdown?apikey=$BALENA_SUPERVISOR_API_KEY"
@@ -225,7 +223,7 @@ Example:
 ```
 
 #### Examples:
-From the app on the device:
+From an application container:
 ```bash
 $ curl -X POST --header "Content-Type:application/json" \
 	--data '{"appId": <appId>}' \
@@ -267,7 +265,7 @@ Example:
 ```
 
 #### Examples:
-From the app on the device:
+From an application container:
 
 ```bash
 $ curl -X POST --header "Content-Type:application/json" \
@@ -297,7 +295,7 @@ $ curl -X POST --header "Content-Type:application/json" \
 Invalidates the current `BALENA_SUPERVISOR_API_KEY` and generates a new one. Responds with the new API key, but **the application will be restarted on the next update cycle** to update the API key environment variable.
 
 #### Examples:
-From the app on the device:
+From an application container:
 ```bash
 $ curl -X POST --header "Content-Type:application/json" \
 	"$BALENA_SUPERVISOR_ADDRESS/v1/regenerate-api-key?apikey=$BALENA_SUPERVISOR_API_KEY"
@@ -340,7 +338,7 @@ The state is a JSON object that contains some or all of the following:
 Other attributes may be added in the future, and some may be missing or null if they haven't been set yet.
 
 #### Examples:
-From the app on the device:
+From an application container:
 ```bash
 $ curl -X GET --header "Content-Type:application/json" \
 	"$BALENA_SUPERVISOR_ADDRESS/v1/device?apikey=$BALENA_SUPERVISOR_API_KEY"
@@ -378,7 +376,7 @@ The appId must be specified in the URL.
 Can contain a `force` property, which if set to `true` will cause the update lock to be overridden.
 
 #### Examples:
-From the app on the device:
+From an application container:
 
 ```bash
 $ curl -X POST --header "Content-Type:application/json" \
@@ -416,7 +414,7 @@ When successful, responds with 200 and the Id of the started container.
 The appId must be specified in the URL.
 
 #### Examples:
-From the app on the device:
+From an application container:
 
 ```bash
 $ curl -X POST --header "Content-Type:application/json" \
@@ -458,7 +456,7 @@ The appId must be specified in the URL.
 This is only supported on single-container devices, and will return 400 on devices running multiple containers.
 
 #### Examples:
-From the app on the device:
+From an application container:
 ```bash
 $ curl -X GET --header "Content-Type:application/json" \
 	"$BALENA_SUPERVISOR_ADDRESS/v1/apps/<appId>?apikey=$BALENA_SUPERVISOR_API_KEY"
@@ -491,7 +489,7 @@ Responds with an empty 200 response if the supervisor is healthy, or a 500 statu
 correctly.
 
 #### Examples:
-From the app on the device:
+From an application container:
 ```bash
 $ curl "$BALENA_SUPERVISOR_ADDRESS/v1/healthy"
 ```
@@ -552,7 +550,7 @@ proxy. Keep in mind that local/reserved subnets are already [excluded by balenaO
 If either "proxy" or "hostname" are null or empty values (i.e. `{}` for proxy or an empty string for hostname), they will be cleared to their default values (i.e. not using a proxy, and a hostname equal to the first 7 characters of the device's uuid, respectively).
 
 #### Examples:
-From the app on the device:
+From an application container:
 ```bash
 $ curl -X PATCH --header "Content-Type:application/json" \
 	--data '{"network": {"hostname": "newhostname"}}' \
@@ -586,7 +584,7 @@ proxy and hostname configuration.
 Please refer to the PATCH endpoint above for details on the behavior and meaning of the fields in the response.
 
 #### Examples:
-From the app on the device:
+From an application container:
 ```bash
 $ curl "$BALENA_SUPERVISOR_ADDRESS/v1/device/host-config?apikey=$BALENA_SUPERVISOR_API_KEY"
 ```
@@ -613,7 +611,7 @@ Added in supervisor v7.12.0
 Get a list of applications, services and their statuses. This will reflect the
 current state of the supervisor, and not the target state.
 
-From the user container:
+From an application container:
 ```bash
 $ curl "$BALENA_SUPERVISOR_ADDRESS/v2/applications/state?apikey=$BALENA_SUPERVISOR_API_KEY"
 ```
@@ -673,7 +671,7 @@ Added in supervisor version v7.12.0.
 
 Use this endpoint to get the state of a single application, given the appId.
 
-From the user container:
+From an application container:
 ```bash
 curl "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$APPID/state?apikey=$BALENA_SUPERVISOR_API_KEY"
 ```
@@ -697,6 +695,48 @@ Response:
 }
 ```
 
+### GET /v2/state/status
+Added in supervisor version v9.7.0
+
+This will return a list of images, containers, the overall download progress and the status of the state engine.
+
+From an application container:
+```bash
+curl "$BALENA_SUPERVISOR_ADDRESS/v2/state/status?apikey=$RESIN_SUPERVISOR_API_KEY"
+```
+
+Response:
+```json
+{
+  "status": "success",
+  "appState": "applied",
+  "overallDownloadProgress": null,
+  "containers": [
+    {
+      "status": "Running",
+      "serviceName": "main",
+      "appId": 1032480,
+      "imageId": 959262,
+      "serviceId": 29396,
+      "containerId": "be4a860e34ffca609866f8af3596e9ee7b869e1e0bb9f51406d0b120b0a81cdd",
+      "createdAt": "2019-03-11T16:05:34.506Z"
+    }
+  ],
+  "images": [
+    {
+      "name": "registry2.balena-cloud.com/v2/fbf67cf6574fb0f8da3c8998226fde9e@sha256:9e328a53813e3c2337393c63cfd6c2f5294872cf0d03dc9f74d02e66b9ca1221",
+      "appId": 1032480,
+      "serviceName": "main",
+      "imageId": 959262,
+      "dockerImageId": "sha256:2662fc0ca0c7dd0f549e87e224f454165f260ff54aac59308d2641d99ca95e58",
+      "status": "Downloaded",
+      "downloadProgress": null
+    }
+  ],
+  "release": "804281fb17e8291c542f9640814ef546"
+}
+```
+
 ### Service Actions
 
 #### The application ID
@@ -707,7 +747,7 @@ For the following endpoints the application id is required in the url. The
 easiest way to get the application id from the device is to use the following
 process (note that you will need jq and curl inside your container):
 
-From the user container:
+From an application container:
 ```bash
 APPNAME="supervisortest"
 APPID=$(curl --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/state?apikey=$BALENA_SUPERVISOR_API_KEY" | jq ".$APPNAME.appId")
@@ -726,7 +766,7 @@ Added in supervisor version v7.0.0. Support for passing `serviceName` instead of
 Use this endpoint to restart a service in the application with application id
 passed in with the url.
 
-From the user container:
+From an application container:
 ```bash
 curl --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$APPID/restart-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "my-service"}'
 curl --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$APPID/restart-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"imageId": 1234}'
@@ -749,7 +789,7 @@ Added in supervisor version v7.0.0. Support for passing `serviceName` instead of
 Use this endpoint to stop a service in the application with application id
 passed in with the url.
 
-From the user container:
+From an application container:
 ```bash
 curl --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$APPID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "my-service"}'
 curl --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$APPID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"imageId": 1234}'
@@ -772,7 +812,7 @@ Added in supervisor version v7.0.0. Support for passing `serviceName` instead of
 Use this endpoint to start a service in the application with application id
 passed in with the url.
 
-From the user container:
+From an application container:
 ```bash
 curl --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$APPID/start-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "my-service"}'
 curl --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$APPID/start-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"imageId": 1234}'
@@ -793,7 +833,7 @@ Added in supervisor version v7.0.0.
 
 Use this endpoint to restart every service in an application.
 
-From the user container:
+From an application container:
 ```bash
 curl -X POST --header "Content-Type: application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$APPID/restart?apikey=$BALENA_SUPERVISOR_API_KEY"
 ```
@@ -813,7 +853,7 @@ Added in supervisor version v7.0.0.
 
 Use this endpoint to purge all user data for a given application id.
 
-From the user container:
+From an application container:
 ```bash
 curl -X POST --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$APPID/purge?apikey=$BALENA_SUPERVISOR_API_KEY"
 ```
@@ -832,7 +872,7 @@ Added in supervisor v7.21.0
 
 This endpoint returns the supervisor version currently running the device api.
 
-From the user container:
+From an application container:
 ```
 $ curl "$BALENA_SUPERVISOR_ADDRESS/v2/version?apikey=$BALENA_SUPERVISOR_API_KEY"
 ```
@@ -851,7 +891,7 @@ Added in supervisor v8.6.0
 
 Use this endpoint to match a service name to a container ID.
 
-From the user container:
+From an application container:
 ```
 $ curl "$BALENA_SUPERVISOR_ADDRESS/v2/containerId?apikey=$BALENA_SUPERVISOR_API_KEY"
 ```
@@ -1060,5 +1100,55 @@ Response:
 	"message": "another log line",
 	"timestamp": 1541508467072,
 	"serviceName": "main"
+}
+```
+
+### V2 Device Information
+
+#### Device name
+
+Added in supervisor version v9.11.0
+
+Get the last returned device name from the balena API. Note that this differs from the
+`BALENA_DEVICE_NAME_AT_INIT` environment variable provided to containers, as this will
+not change throughout the runtime of the container, but the endpoint will always return
+the latest known device name.
+
+From an application container:
+```
+$ curl "$BALENA_SUPERVISOR_ADDRESS/v2/device/name?apikey=$BALENA_SUPERVISOR_API_KEY"
+```
+
+Response:
+```json
+{
+	"status": "success",
+	"deviceName": "holy-wildflower"
+}
+```
+
+#### Device tags
+
+Added in supervisor version v9.11.0
+
+Retrieve any device tags from the balena API. Note that this endpoint will not work when
+the device does not have an available connection to the balena API.
+
+From an application container:
+```
+$ curl "$BALENA_SUPERVISOR_ADDRESS/v2/device/tags?apikey=$BALENA_SUPERVISOR_API_KEY"
+```
+
+Response:
+```json
+{
+	"status": "success",
+	"tags": [
+		{
+			"id": 188303,
+			"name": "DeviceLocation",
+			"value": "warehouse #3"
+		}
+	]
 }
 ```


### PR DESCRIPTION
* Make the standalone installer the recommended option.
* Move installation instructions to a new INSTALL.md in the CLI repo.
* Also patch updates for the Node SDK, Python SDK and the Supervisor.

Btw, FYI, there is an open CLI PR implementing review changes requested by @hedss: 
https://github.com/balena-io/balena-cli/pull/1200

Change-type: minor
Signed-off-by: Paulo Castro <paulo@balena.io>