### PR TITLE
Restrict tests to node 10 and 12

### DIFF
--- a/.resinci.yml
+++ b/.resinci.yml
@@ -5,3 +5,11 @@ docker:
       dockerfile: Dockerfile
       docker_repo: resin/docs
 
+npm:
+  platforms:
+    - name: linux
+      os: alpine
+      architecture: x86_64
+      node_versions:
+        - "10"
+        - "12"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "npm run build",
     "postinstall": "./tools/prepare.sh",
     "build": "./tools/build.sh && webpack -p",
     "watch-pages": "watch ./tools/build.sh pages shared templates config",


### PR DESCRIPTION
Since there are no tests, we run npm build in place of the tests

Change-type: patch
Signed-off-by: Giovanni Garufi <giovanni@balena.io>