### PR TITLE
Fix the example Dockerfile for crossbuilding

### DIFF
--- a/pages/reference/base-images/base-images.md
+++ b/pages/reference/base-images/base-images.md
@@ -229,12 +229,12 @@ ENTRYPOINT ["/usr/bin/entry.sh"]
 This is a unique feature of balenalib ARM base images that allows you to run them anywhere (running ARM image on x86/x86_64 machines). A tool called `resin-xbuild` and QEMU are installed inside any balenalib ARM base images and can be triggered by `RUN [ "cross-build-start" ]` and `RUN [ "cross-build-end" ]`. QEMU will emulate any instructions between `cross-build-start` and `cross-build-end`. So this Dockerfile:
 
 ```Dockerfile
-FROM resin/armv7hf-debian
+FROM balenalib/armv7hf-debian
 
 RUN [ "cross-build-start" ]
 
 RUN apt-get update  
-RUN apt-get install python  
+RUN apt-get install python-pip
 RUN pip install virtualenv
 
 RUN [ "cross-build-end" ]


### PR DESCRIPTION
The example for building an ARM image on an x86 machine was using the outdated resin base image and installed python instead of python-pip