### PR TITLE
balena sync: standardize references to `.balena-sync.yml` config

### DIFF
--- a/pages/learn/manage/serv-vars.md
+++ b/pages/learn/manage/serv-vars.md
@@ -2,17 +2,17 @@
 title: Environment and service variables
 ---
 
-# Environment and service variables 
+# Environment and service variables
 
 Environment and service variables allow you to provide runtime configuration to one or more running services without having to modify your source code. You can use them to keep secrets and other sensitive values out of your codebase.
 
 __Note:__ Adding or modifying an environment variable will restart all services on a device. Service variables only restart the affected service.
 
-Environment variables are accessible to all services running on a device, whereas service variables are assigned to a specific service. Both environment and service variables can be applied at the fleet or the individual device level. 
+Environment variables are accessible to all services running on a device, whereas service variables are assigned to a specific service. Both environment and service variables can be applied at the fleet or the individual device level.
 
 Values defined for individual devices always override those defined for the fleet. Values defined for services override environment variables defined at the same level. So for any given variable, the **device service variable** will always have top priority, followed by the **device environment variable**, then the **fleet service variable**, and finally the **fleet environment variable**.
 
-__Note:__ Environment and service variables defined in the dashboard will not apply to devices in [local mode][local-mode]. You will need to define them in your `.resin-sync.yml`.
+__Note:__ Environment and service variables defined in the dashboard will not apply to devices in [local mode][local-mode]. You will need to define them in your `.{{ $names.company.short }}-sync.yml`.
 
 ## Fleet environment and service variables
 
@@ -24,7 +24,7 @@ To define a new variable, click the *Add variable* button in the upper-left corn
 
 <img src="/img/env-vars/add_application_variable.png" width="40%">
 
-For service variables, you will be asked to select a service from the drop down menu. 
+For service variables, you will be asked to select a service from the drop down menu.
 
 Define a name and value for your variable. Click *Add* to apply to all devices in your fleet that do not have their own values defined:
 
@@ -46,7 +46,7 @@ Device environment and service variables are applied to only one device. Device 
 
 Adding a device variable is very similar to adding a fleet variable. From the device summary page, select *Device Variables* for environment variables or *Device Service Variables* for service variables. Click *Add variable*, select the appropriate service if necessary, add a name and and a value, and click *Add*.
 
-The variable list will include both values defined for that specific device, as well as any fleet variables of the same type: 
+The variable list will include both values defined for that specific device, as well as any fleet variables of the same type:
 
 <img src="/img/env-vars/device_variables.png" width="100%">
 

--- a/pages/reference/OS/advanced.md
+++ b/pages/reference/OS/advanced.md
@@ -38,7 +38,7 @@ These variables can be set using the API or any of its clients, including the [S
 
 **After modifying a config.txt variable, the device supervisor will apply the changes and reboot the device.**
 
-__Note:__ Configuration variables defined through the API will not apply to devices in [local mode][local-mode]. You will need to define them in your `resin-sync.yml`.
+__Note:__ Configuration variables defined through the API will not apply to devices in [local mode][local-mode]. You will need to define them in your `{{ $names.company.short }}-sync.yml`.
 
 ### GPU Memory
 


### PR DESCRIPTION
remove spurious trailing spaces

Change-type: patch
Signed-off-by: Matthew McGinn <matthew@balena.io>