### PR TITLE
management: Operator is not allowed to add new device

### DIFF
--- a/pages/learn/manage/account.md
+++ b/pages/learn/manage/account.md
@@ -62,7 +62,7 @@ Observers are given read-only access to the application and its devices. They ar
 
 #### Operator
 
-Operators have all the access given to observers, plus the ability to manage an application's devices. This means operators can add new devices, remove devices, perform device actions, and modify device tags, metadata, and environment variables. Operators also have full [SSH access][ssh] to the application's devices. This role can only be assigned by application owners on paid plans.
+Operators have all the access given to observers, plus the ability to manage an application's devices. This means operators can remove devices, perform device actions, and modify device tags, metadata, and environment variables. Operators also have full [SSH access][ssh] to the application's devices. This role can only be assigned by application owners on paid plans.
 
 #### Developer
 


### PR DESCRIPTION
Fixes #1141 

Documentation says that the operator can add a new device. But it's not allowed, because the operator can't select the OS version.

User was confused by this, see https://jel.ly.fish/4dee4de8-d26a-4733-8f93-1a125fd85442

Change-type: patch
Signed-off-by: Robert Vojta <robert@balena.io>