### PR TITLE
Update network requirements

### DIFF
--- a/pages/faq/troubleshooting/faq.md
+++ b/pages/faq/troubleshooting/faq.md
@@ -79,9 +79,6 @@ Additionally, you should whitelist the following domains for the relevant ports 
 * `*.docker.com`
 * `*.docker.io`
 
-
-Additionally, an outgoing connection to `mixpanel.com` is made. This is not a functional requirement for {{ $names.company.lower }}, but allows tracking of some useful metrics.
-
 ##### Can I access /dev and things like GPIO from the container?
 If you're application uses a single container, it will be run in privileged mode by default and will have access to hardware in the same way as a vanilla Linux system.
 

--- a/shared/network/2.x.md
+++ b/shared/network/2.x.md
@@ -338,8 +338,6 @@ Additionally, you should whitelist the following domains for the relevant ports 
 * `*.docker.io`
 
 
-Additionally, an outgoing connection to `mixpanel.com` is made. This is not a functional requirement for {{ $names.company.lower }}, but allows tracking of some useful metrics.
-
 ## Connecting Behind a Proxy
 
 We use **[redsocks][redsocks]** to connect your device to {{ $names.company.lower }} from behind a proxy. To enable, a `redsocks.conf` file should be added at `/mnt/boot/system-proxy/`, specifying the needed proxy configuration:


### PR DESCRIPTION
Whitelisting Mixpanel should be no longer necessary.
Change-type: patch
Signed-off-by: Michael Angelos Simos <michalis@balena.io>