### PR TITLE
Bump analytics client

### DIFF
--- a/templates/_track.html
+++ b/templates/_track.html
@@ -9,7 +9,7 @@
   ga('send', 'pageview');
 </script>
 
-<script type="text/javascript" src="https://unpkg.com/analytics-client@0.1.0/dist/bundle.js"></script>
+<script type="text/javascript" src="https://unpkg.com/analytics-client@0.1.1/dist/bundle.js"></script>
 
 <!-- start Mixpanel -->
 <script type="text/javascript">(function(f,b){if(!b.__SV){var a,e,i,g;window.mixpanel=b;b._i=[];b.init=function(a,e,d){function f(b,h){var a=h.split(".");2==a.length&&(b=b[a[0]],h=a[1]);b[h]=function(){b.push([h].concat(Array.prototype.slice.call(arguments,0)))}}var c=b;"undefined"!==typeof d?c=b[d]=[]:d="mixpanel";c.people=c.people||[];c.toString=function(b){var a="mixpanel";"mixpanel"!==d&&(a+="."+d);b||(a+=" (stub)");return a};c.people.toString=function(){return c.toString(1)+".people (stub)"};i="disable track track_pageview track_links track_forms register register_once alias unregister identify name_tag set_config people.set people.set_once people.increment people.append people.track_charge people.clear_charges people.delete_user".split(" ");


### PR DESCRIPTION
This fixes some skipped device IDs in generated dashboard URLs.
Update analytics-client from 0.1.0 to 0.1.1

See balena-io/analytics-client#2

Change-type: patch
Signed-off-by: Roman Mazur <roman@balena.io>