### PR TITLE
docs: Updating content for custom board support

### DIFF
--- a/pages/reference/OS/meta-balena.md
+++ b/pages/reference/OS/meta-balena.md
@@ -6,57 +6,181 @@ excerpt: Instructions for adding boards not currently supported by {{ $names.com
 
 # Custom board support
 
-### Its important to note that the instructions for [meta-balena][meta-balena] are still a draft, we still may have some detail to cover, if you have any feedback please let us know - hello@{{ $names.email_domain }}.
+Pre-requisites: a [Yocto](https://www.yoctoproject.org) Board Support Package (BSP) layer for your particular board. It should be compatible to the Yocto releases balenaOS supports.
 
-__NOTE:__ Pre-requisites: yocto BSP layer for your particular board. Should be compatible to yocto sumo release at the time of writing this howto.
+Repositories used to build balenaOS host Operating System (OS) are typically named `balena-<board-family>`. For example, consider [balena-raspberrypi](https://github.com/balena-os/balena-raspberrypi) which is used for building the OS for [Raspberryi Pi](https://raspberrypi.org), or [balena-intel](https://github.com/balena-os/balena-intel) repository which can be used to build a balena image for the Intel NUC boards.
 
-The following are the steps to follow in order to add a new board to {{ $names.company.lower }}.
-I - Add the dependencies for your layer in the resin-yocto manifests. For examples, check out **resin-yocto/manifests/resin-master-board.xml**.
+Contributing support for a new board consist of creating a a Yocto package that includes:
 
-II - Create a layer in meta-balena that will hold the relevant files pertaining to the new board. The layer should follow the naming convention `meta-resin-${board_name}` **(i.e. meta-resin-nuc)**
-Following files should be present in this layer:
-Depending on the type of board you are adding suport for, you should have your device support either just resin-image or resin-image-flasher and resin-image. Generally, resin-image is for boards that boot directly from external storage (these boards do not have internal storage to install resin on). resin-image-flasher is used when the targeted board has internal storage so this flasher image is burned onto an SD card or USB stick that is used for the initial boot. When booted, this flasher image should automatically install resin on internal storage.
+* general hardware support for the specific board,
+* the balenaOS-specific software features,
+* deployment-specific features (i.e. settings to create SD card images or self-flashing images)
 
-1. The resin-image and/or resin-image-flasher appends reside in **meta-balena/meta-resin-${board_name}/recipes-core/images/** directory.
-One should define the following variables in the resin-image bbappend:
+The following documentation walks you through the steps of creating such a Yocto package. Because of the substantial difference between the hardware of many boards, this document provides general directions, and often it might be helpful to see the examples of already supported boards. The list of the relevant repositories is found the end of this document.
 
-	- `IMAGE_FSTYPES_${board_name}` - using this variable one can declare the type of the produced image. It can be ext3, ext4, resin-sdcard etc. Usual type for a board that can boot from SD card, USB, is "resin-sdcard".
+## Board Support Repository Breakout
 
-	- `RESIN_BOOT_PARTITION_FILES_${board_name}` - this allows adding needed files from the deploy directory into the boot partition (one can add here bootloader config files, first stage bootloader, initramfs etc).
-	This is a list of files relative to `DEPLOY_DIR_IMAGE` that will be included in the vfat partition. It has the following format: "FilenameRelativeToDeployDir:FilenameOnTheTarget". if `FilenameOnTheTarget` is omitted the same filename will be used
-	For example to have the `bzImage-nuc.bin` copied from deploy directory in the boot partition, renamed to vmlinuz: `RESIN_BOOT_PARTITION_FILES_nuc = "bzImage-nuc.bin:vmlinuz"`
+The `balena-<board-family>` repositories use [git submodules](https://git-scm.com/docs/git-submodule) for including required Yocto layers from the relevant sub-projects.
 
-	If using **resin-image-flasher**, the following variables should be defined/appended:
+The root directory shall contain 2 directory entries:
 
-	- `IMAGE_DEPENDS` - this allows to add dependencies for the image. Use this for example if you need the initrams to be a dependency of your flasher image: `IMAGE_DEPENDS_resin-sdcard_append_nuc = " core-image-minimal-initramfs:do_rootfs"`
+* a `layers` directory
+* [balena-yocto-scripts](https://github.com/balena-os/balena-yocto-scripts) git submodule.
 
-	- `BOOT_SPACE_${board_name}` - can be used to customize the space of the boot partition
+_Note: you add submodules by `git submodule add <url> <directory>`, see the git documentation for more details._
 
-	- `RESIN_BOOT_PARTITION_FILES_append_${board_name}` - one can use this append here to add extra files to the boot partition needed for the **resin-image-flasher** that are not already contained in resin-image.
+The root directory generally also includes the following files:
 
-2. Create a `.bbappend` for having the kernel recipe in your BSP layer inherit kernel-resin. This adds the necessary kernel configs for using with resin.
+* `CHANGELOG.md`
+* `LICENSE`
+* `README.md`
+* `VERSION`
 
-	This should reside in **meta-balena/meta-resin-${board_name}/recipes-kernel/linux/**
+and one or more files named `<yocto-machine-name>.coffee`, one for each of the boards that the repository will add support for (eg. [`raspberry-pi3.coffee`](https://github.com/balena-os/balena-raspberrypi/blob/master/raspberrypi3.coffee) for Raspberry Pi 3 in `balena-raspberrypi`). This file contains information on the Yocto build for the specific board, in [CoffeeScript](http://coffeescript.org/) format. A minimal version of this file, using Raspberry Pi 3 as the example, would be:
 
-3. Create a `.bbappend` for specifying the build of the resin supervisor to be used with your board. This append resides in **meta-balena/meta-resin-${board-name}/recipes-support/resin-supervisor-disk/**
+``` coffeescript
+module.exports =
+  yocto:
+    machine: 'raspberrypi3'
+    image: 'balena-image'
+    fstype: 'balenaos-img'
+    version: 'yocto-jethro'
+    deployArtifact: 'balena-image-raspberrypi3.balenaos-img'
+    compressed: true
+```
 
-	Following variables should be defined:
+The `layers` directory contains the git submodules of the yocto layers used in the build process. This normally means the following components are present:
 
-	- `TARGET_REPOSITORY_${board-name}` - this defines the build of the supervisor. Can be one of the values(must match the arch of your board): *resin/rpi-supervisor*, *resin/armv7hf-supervisor*, *resin/i386-supervisor*, (TBC when we also have the *amd64 rce*)
+- [poky](https://www.yoctoproject.org/tools-resources/projects/poky)  at the version/revision required by the board BSP
+- [meta-openembedded](https://github.com/openembedded/meta-openembedded) at the revision poky uses
+- [meta-balena](https://github.com/balena-os/meta-balena) using the master branch
+- [oe-meta-go](https://github.com/balena-os/oe-meta-go) using the master branch (there were no branches corresponding to the yocto releases at the time this howto was written)
+- Yocto BSP layer for the board (for example, the BSP layer for Raspberry Pi is [meta-raspberrypi](https://github.com/agherzan/meta-raspberrypi))
+- any additional Yocto layers required by the board BSP (check the Yocto BSP layer of the respective board for instructions on how to build the BSP and what are the Yocto dependencies of that particular BSP layer)
 
-	Optional variables:
+In addition to the above git submodules, the "layers" directory also contains a `meta-balena-<board-family>` directory (please note this directory is _not_ a git submodule, but an actual directory in the ). This directory contains the required customization for making a board balena enabled. For example, the [balena-raspberrypi](https://github.com/balena-os/balena-raspberrypi) repository contains the directory `layers/meta-balena-raspberrypi` to supplement the BSP from `layers/meta-raspberrypi` git submodule, with any changes that might be required by balenaOS.
 
-	- `PARTITION_SIZE_${board_name}` - size of partition
+The layout so far looks as follows:
 
-	- `LED_FILE_${board_name}` - points to a sysfs property that allows an LED to be flashed on your board.
+```
+├── CHANGELOG.md
+├── LICENSE
+├── README.md
+├── VERSION
+├── layers
+│   ├── meta-openembedded
+│   ├── meta-<board-family>
+│   ├── meta-balena
+│   ├── meta-balena-<board-family>
+│   ├── oe-meta-go
+│   └── poky
+├── <board>.coffee
+└── balena-yocto-scripts
+```
 
-4. If using *resin-image-flasher*, you must define some variables to pass to the flashing script. Create a `resin-init-flasher.bbappend` in **meta-balena/meta-resin-${board_name}/recipes-support/resin-init/** and define in it:
+## meta-balena-`<board-family>` breakout
 
-	- `BOARD_BOOTLOADER_${board_name}` - for the moment, "grub-efi" and "u-boot" are the supported options
+This directory contains:
 
-	- `INTERNAL_DEVICE_UBOOT_${board_name}` - variable used for u-boot based boards, to keep track of how uboot enumerates the internal emmc device on that particular board so we know where to load the kernel from after we flash it.
+* `COPYING.Apache-2.0` file with the [Apache Version 2.0 license](http://www.apache.org/licenses/LICENSE-2.0),
+* `README.md` file specifying the supported boards
 
-5. And of course your typical yocto `conf/layer.conf` file, COPYING and README.md file specifying what is the machine this layer adds support for and what are the yocto layers it depends on.
+and a number of directories out of which the mandatory ones are:
+
+- `conf` directory - contains the following files:
+    - `layer.conf`, see the [layer.conf](https://github.com/balena-os/balena-raspberrypi/blob/master/layers/meta-balena-raspberrypi/conf/layer.conf) from `meta-balena-raspberrypi` for an example, and see [Yocto documentation](http://www.yoctoproject.org/docs/2.0/mega-manual/mega-manual.html#bsp-filelayout-layer)
+    - `samples/bblayers.conf.sample` file in which all the required Yocto layers are listed, see this [bblayers.conf.sample](https://github.com/balena-os/balena-raspberrypi/blob/master/layers/meta-balena-raspberrypi/conf/samples/bblayers.conf.sample) from `meta-balena-raspberrypi` for an example, and see the [Yocto documentation](http://www.yoctoproject.org/docs/2.0/mega-manual/mega-manual.html#var-BBLAYERS)
+    - `samples/local.conf.sample` file which defines part of the build configuration (see the meta-balena [README.md](https://github.com/balena-os/meta-balena/blob/master/README.md) for an overview of some of the variables use in the `local.conf.sample` file). An existing file can be used (e.g. [local.conf.sample](https://github.com/balena-os/balena-raspberrypi/blob/master/layers/meta-balena-raspberrypi/conf/samples/local.conf.sample)) but making sure the "Supported machines" area lists the appropriate machines this repository is used for. See also the [Yocto documentation](http://www.yoctoproject.org/docs/2.0/mega-manual/mega-manual.html#structure-build-conf-local.conf).
+
+- `recipes-containers/docker-disk` directory, which contains `docker-balena-supervisor-disk.bbappend` that shall define the following variable(s):
+
+    - `SUPERVISOR_REPOSITORY_<yocto-machine-name>`: this variable is used to specify the build of the supervisor. It can be one of (must match the architecture of the board):
+        *  **balena/armv7hf-supervisor** (for armv7 boards),
+        * **balena/i386-supervisor**
+        (for x86 boards),
+        * **balena/amd64-supervisor** (for x86-64 boards),
+        * **balena/rpi-supervisor** (for raspberry pi 1),
+        * **balena/armel-supervisor** (for armv5 boards).
+
+    - `LED_FILE_<yocto-machine-name>`: this variable should point to the [Linux sysfs path of an unused LED](https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-class-led) if available for that particular board. This allows the unused LED to be flashed for quick visual device identification purposes. If no such unused LED exists, this variable shall not be used.
+
+- `recipes-core/images` directory, which contains at least a `balena-image.bbappend` file. Depending on the type of board you are adding support for, you should have your device support either just `balena-image` or both `balena-image-flasher` and `balena-image`. Generally, `balena-image` is for boards that boot directly
+from external storage (these boards do not have internal storage to install balena on). `balena-image-flasher` is used when the targeted board has internal storage so this flasher image is burned onto an SD card or USB stick that is used for the initial boot. When booted, this flasher image will automatically install balena on internal storage.
+
+  The `balena-image.bbappend` file shall define the following variables:
+
+    - `IMAGE_FSTYPES_<yocto-machine-name>`: this variable is used to declare the type of the produced image (it can be ext3, ext4, balenaos-img etc. The usual type for a board that can boot from SD card, USB, is "balenaos-img").
+
+    - `BALENA_BOOT_PARTITION_FILES_<yocto-machine-name>`: this allows adding files from the build's deploy directory into the vfat formatted resin-boot partition (can be used to add bootloader config files, first stage bootloader, initramfs or anything else needed for the booting process to take place for your particular board). If the board uses different bootloader configuration files when booting from either external media (USB thumb drive, SD card etc.) or from internal media (mSATA, eMMC etc) then you would want make use of this variable to make sure the different bootloader configuration files get copied over and further manipulated as needed (see `INTERNAL_DEVICE_BOOTLOADER_CONFIG_<yocto-machine-name>` and `INTERNAL_DEVICE_BOOTLOADER_CONFIG_PATH_<yocto-machine-name>` below). Please note that you only reference these files here, it is the responsibility of a `.bb` or `.bbappend` to provide and deploy them (for bootloader config files this is done with an append typically in `recipes-bsp/<your board's bootloader>/<your board's bootloader>.bbappend`, see [balena-intel grub bbappend](https://github.com/balena-os/balena-intel/blob/master/layers/meta-balena-genericx86/recipes-bsp/grub/grub_%25.bbappend) for an example)
+
+    It is a space separated list of items with the following format: *FilenameRelativeToDeployDir:FilenameOnTheTarget*. If *FilenameOnTheTarget* is omitted then the *FilenameRelativeToDeployDir* will be used.
+
+    For example to have the Intel NUC `bzImage-intel-corei7-64.bin` copied from deploy directory over to the boot partition, renamed to `vmlinuz`:
+
+    ```sh
+    BALENA_BOOT_PARTITION_FILES_nuc = "bzImage-intel-corei7-64.bin:vmlinuz"
+    ```
+
+  The `balena-image-flasher.bbappend` file shall define the following variables:
+
+    - `IMAGE_FSTYPES_<yocto-machine-name>` (see above)
+    - `BALENA_BOOT_PARTITION_FILES_<yocto-machine-name>` (see above). For example, if the board uses different bootloader configuration files for booting from SD/USB and internal storage (see below the use of `INTERNAL_DEVICE_BOOTLOADER_CONFIG` variable), then make sure these files end up in the boot partition (i.e. they should be listed in this `BALENA_BOOT_PARTITION_FILES_<yocto-machine-name>` variable)
+
+- `recipes-kernel/linux directory`: shall contain a `.bbappend` to the kernel recipe used by the respective board. This kernel `.bbappend` must "inherit kernel-balena" in order to add the necessary kernel configs for using with balena.
+
+- `recipes-support/balena-init` directory - shall contain a `balena-init-flasher.bbappend` file if you intend to install balena to internal storage and hence use the flasher image. This shall define the following variables:
+
+  - `INTERNAL_DEVICE_KERNEL_<yocto-machine-name>`: this variable is used to identify the internal storage where balena will be written to.
+  - `INTERNAL_DEVICE_BOOTLOADER_CONFIG_<yocto-machine-name>`: this variable is used to specify the filename of the bootloader configuration file used by your board when booting from internal media (must be the same with the *FilenameOnTheTarget* parameter of the bootloader internal config file used in the `BALENA_BOOT_PARTITION_FILES_<yocto-machine-name>` variable from `recipes-core/images/balena-image-flasher.bbappend`)
+
+  - `INTERNAL_DEVICE_BOOTLOADER_CONFIG_PATH_<yocto-machine-name>`: this variable is used to specify the relative path (including filename) to the resin-boot partition where `INTERNAL_DEVICE_BOOTLOADER_CONFIG_<yocto-machine-name>` will be copied to.
+
+    For example, setting
+
+    ```sh
+    INTERNAL_DEVICE_BOOTLOADER_CONFIG_intel-corei7-64 = "grub.cfg_internal"
+    ```
+    and
+    ```sh
+    INTERNAL_DEVICE_BOOTLOADER_CONFIG_PATH_intel-corei7-64 = "/EFI/BOOT/grub.cfg"
+    ```
+    will result that after flashing the file `grub.cfg`_internal is copied with the name `grub.cfg` to the /EFI/BOOT/ directory on the resin-boot partition.
 
 
-[meta-balena]:{{ $links.githubOS }}/meta-balena
+The directory structure then looks similar to this:
+```
+├── COPYING.Apache-2.0
+├── README.md
+├── conf
+│   ├── layer.conf
+│   └── samples
+│       ├── bblayers.conf.sample
+│       └── local.conf.sample
+├── recipes-bsp
+│   └── bootfiles
+├── recipes-containers
+│   └── docker-disk
+│       └── docker-balena-supervisor-disk.bbappend
+├── recipes-core
+│   ├── images
+│   │   └── balena-image.bbappend
+├── recipes-kernel
+│   └── linux
+│       ├── linux-<board-family>-<version>
+│       │   └── <patch files>
+│       ├── linux-<board-family>_%.bbappend
+│       └── linux-<board>_<version>.bbappend
+└── recipes-support
+    └── balena-init
+        ├── files
+        │   └── balena-init-board
+        └── balena-init-board.bbappend
+```
+
+## Building
+
+See the [meta-balena Readme](https://github.com/balena-os/meta-balena/blob/master/README.md) on how to build the new balenaOS image after setting up the new board package as defined above.
+
+## Troubleshooting
+
+For specific examples on how board support is provided for existing devices, see the repositories in the [Supported Boards](https://www.balena.io/os/docs/supported-boards/) section.


### PR DESCRIPTION
Closes #1225 

This is the content from https://www.balena.io/os/docs/custom-build/#Supporting-your-Own-Board. Content on https://github.com/balena-io/resin-site is private so not currently suitable for `fetch-external.sh`. This at least removes the outdated content.

Change-type: patch
Signed-off-by: Gareth Davies gareth@balena.io