### PR TITLE
docs: Removing outdated initsystem references

### DIFF
--- a/pages/learn/develop/multicontainer.md
+++ b/pages/learn/develop/multicontainer.md
@@ -60,15 +60,6 @@ gpio:
 
 There are a few settings and considerations specific to {{ $names.company.lower }} that need to be taken into account when building multicontainer applications.
 
-### Init system
-
-Using the `INITSYSTEM=on` [setting][init-system] in the `Dockerfile` of a service is only supported if the container is run as privileged, as **systemd** does not run correctly in unprivileged containers. In addition, if you want to ensure your container is always kept running, set `restart` to `always`:
-
-```
-privileged: true
-restart: always
-```
-
 ### Network mode
 
 Setting `network_mode` to `host` allows the container to share the same network namespace as the host OS. When this is set, any ports exposed on the container will be exposed locally on the device. This is necessary for features such as bluetooth.


### PR DESCRIPTION
This setting was removed as I understand. There is this section https://www.balena.io/docs/reference/base-images/base-images/#installing-your-own-initsystem in the docs as well as this masterclass section https://github.com/balena-io-projects/services-masterclass#5-running-systemd-in-a-service for running systemd in a container.

Change-type: patch
Signed-off-by: Gareth Davies gareth@balena.io