### PR TITLE
docs: Updating SSH troubleshooting

### DIFF
--- a/shared/general/host-ssh.md
+++ b/shared/general/host-ssh.md
@@ -1,44 +1,88 @@
 ## Troubleshooting with host OS access
 
+Host OS SSH access gives you a handful of tools that can help you gather more information about potential issues on your device.
+
 __Warning:__ Making changes to running services and network configurations carries the risk of losing access to your device. Before making changes to the host OS of a remote device, it is best to test locally. Changes made to the host OS will not be maintained when the OS is updated, and some changes could break the updating process. When in doubt, [reach out][forums] to us for guidance.
 
-Host OS SSH access gives you a handful of tools that can help you gather more information about potential issues on your device. Here are some tips for troubleshooting common issues:
+### {{ $names.os.upper }} services
 
-### Check logs
+{{ $names.os.upper }} uses **systemd** as its init system, and as such, almost all the fundamental components in {{ $names.os.lower }} run as systemd services. In general, some core services need to execute for a device to come online, connect to the {{ $names.cloud.lower }} VPN, download applications, and then run them:
+
+* `chronyd.service` - Responsible for NTP duties and syncing 'real' network time to the device.
+* `dnsmasq.service` - The local DNS service which is used for all host OS lookups.
+* `NetworkManager.service` - The underlying Network Manager service, ensuring that configured connections are used for networking.
+* `os-config.service` - Retrieves settings and configs from the API endpoint, including certificates, authorized keys, the VPN config, etc.
+* `openvpn.service` - The VPN service itself, which connects to the {{ $names.cloud.lower }} VPN, allowing a device to come online.
+* `balena.service` - The [{{ $names.engine.lower }}][balena-engine] service, the modified Docker daemon fork that allows the management and running of application service images, containers, volumes, and networking.
+* `resin-supervisor.service` - The {{ $names.company.short }} Supervisor service, responsible for the management of applications, including downloading updates for and self-healing (via monitoring) of those applications, variables (application/device/fleet), and exposure of these services to applications via an endpoint.
+* `dbus.service` - The DBus daemon socket which can be used by applications by applying the _io.balena.features.dbus_ [label][labels], which exposes it in-container. This allows applications to control several host OS features, including the Network Manager.
+
+Additionally, there are a couple of utility services that, while not required for a barebones operation, are also useful:
+
+* `ModemManager.service` - Deals with non-Ethernet or Wifi devices, such as LTE/GSM modems.
+* `avahi-daemon.service` - Used to broadcast the device’s local hostname.
+
+You may see all enabled services on the host OS with the following command:
+
+```shell
+$ systemctl list-unit-files | grep enabled
+```
+
+To check the status of a service, use the `systemctl status <serviceName>` command. The output includes whether the service is currently loaded and active, together with detail about the process, including the latest entries from the journal log. For example, to obtain the status of the OpenVPN service use the following command:
+
+```shell
+$ systemctl status openvpn.service
+```
+
+### Checking logs
 
 #### journalctl
 
-Information from a variety of services can be found using the **journalctl** utility. As the number of **journalctl** messages can be quite large, it is good to know how to narrow your search.
+Information from a variety of services can be found using the **journalctl** utility. The output from **journalctl** can be very large, and you can filter the output using the `--unit` (or the short version `-u`) option to only output logs from a single service.
 
-To find messages from a specific service, use the `-u` flag:
+A typical example of using **journalctl** might be following a service to see what’s occurring in real-time by using the `--follow` (`-f`) option. For example, to follow the latest supervisor logs on the device:
+
+```shell
+$ journalctl --follow --unit resin-supervisor
 ```
-journalctl -u systemd-timesyncd
+
+To limit the output to the last *x* messages, use the `-n` option. The following example lists the last 10 messages from the `chronyd` service:
+
+```shell
+$ journalctl -n 10 -u chronyd
 ```
-To return the last *x* messages, use `-fn x`:
-```
-journalctl -fn 100 -u {{ $names.company.short }}-supervisor
+
+The `--all` (`-a`) option may be used to show all entries, even if long or with unprintable characters. This is especially useful for displaying the service container logs from applications when applied to `{{ $names.company.short }}.service`.
+
+```shell
+$ journalctl --all -n 100 -u {{ $names.company.short }}
 ```
 
 #### dmesg
 
-For displaying messages from the kernel, you can use **dmesg**. Similar to **journalctl**, **dmesg** may have an unmanageable output without some additional commands:
-```
-dmesg | tail -n 100
+For displaying messages from the kernel, you can use **dmesg**. Similar to **journalctl**, the output from **dmesg** will be very large without additional options. The following example limits the output to the last 100 lines:
+
+```shell
+$ dmesg | tail -n 100
 ```
 
 ### Monitor {{ $names.engine.lower }}
 
-{{ $names.os.upper }}, beginning with version 2.9.0, includes the lightweight container engine **[{{ $names.engine.lower }}][engine-link]** to manage **Docker** containers. If you think the supervisor or application container may be having problems, you’ll want to use **balena** for debugging.
+beginning with version 2.9.0, {{ $names.os.lower }} includes the lightweight container engine **[{{ $names.engine.lower }}][engine-link]** to manage **Docker** containers. If you think the supervisor or application container may be having problems, you’ll want to use `balena` for debugging.
 
-This command will show the status of all containers:
+From the host OS this command will show the status of all containers:
+
+```shell
+$ {{ $names.company.short }} ps -a
 ```
-balena ps -a
+
+You can also check the **journalctl** logs for messages related to the {{ $names.engine.lower }} service:
+
+```shell
+$ journalctl --follow -n 100 -u {{ $names.company.short }}
 ```
-You can also check the **journalctl** logs for messages related to **balena**:
-```
-journalctl -fn 100 -u {{ $names.engine.lower }}
-```
-For devices with {{ $names.os.lower }} versions earlier than 2.9.0, you can replace `balena` in these commands with `docker`.
+
+__Note:__ For devices with {{ $names.os.lower }} versions earlier than 2.9.0, you can replace `{{ $names.company.short }}` in these commands with `docker`.
 
 ### Inspect network settings
 
@@ -47,8 +91,9 @@ For devices with {{ $names.os.lower }} versions earlier than 2.9.0, you can repl
 **NetworkManager** includes a [CLI][nmcli] that can be useful for debugging your ethernet and WiFi connections. The `nmcli` command, on its own, will show all interfaces and the connections they have. `nmcli c` provides a connection summary, showing all known connection files with the connected ones highlighted. `nmcli d` displays all network interfaces (devices).
 
 Another useful place to look for **NetworkManager** information is in the **journalctl** logs:
-```
-journalctl -fn 100 -u NetworkManager
+
+```shell
+$ journalctl -f -n 100 -u NetworkManager
 ```
 
 #### ModemManager
@@ -57,21 +102,19 @@ Similar to **NetworkManager**, **ModemManager** includes a [CLI][mmcli], `mmcli`
 
 ### Look up version information
 
-Knowing what version of a specific service is being run on your device can help you troubleshoot compatibility issues, known bugs, and supported features.
+Knowing what version of a specific service is being run on your device can help you troubleshoot compatibility issues, known bugs, and supported features. Many services provide a direct option for displaying their version:
 
-Many services provide a direct option for displaying their version:
-```
-udevadm --version
-systemd --version
-openssl version
+```shell
+$ udevadm --version
+$ systemctl --version
+$ openssl version
 ```
 
 ### Understand the file system
 
-In some cases, you may need to examine the contents of certain directories or files directly. One location that is useful for troubleshooting purposes is the `/data` directory, which contains your device's Docker images, [persistent application data][persistent-storage], and host OS update logs. The `/boot` directory includes configuration files, such as [config.txt][config-txt] and [**NetworkManager** connections][network].
+In some cases, you may need to examine the contents of certain directories or files directly. One location that is useful for troubleshooting purposes is the `/data` directory, which contains your device's Docker images, [persistent application data][persistent-storage], and host OS update logs. The `boot` directory includes configuration files, such as [config.json][config-json], [config.txt][config-txt] and [**NetworkManager** connections][network].
 
-Note that the [filesystem layout][filesystem] may look slightly different from what you’d expect—for example the two locations mentioned above are found at `/mnt/data` and `/mnt/boot`, respectively.
-
+Note that the [filesystem layout][filesystem] may look slightly different from what you’d expect—for example, the two locations mentioned above are found at `/mnt/data` and `/mnt/boot` respectively.
 
 [forums]:{{$names.forums_domain}}/c/balena-cloud
 [engine-link]:{{ $links.engineSiteUrl }}
@@ -81,3 +124,6 @@ Note that the [filesystem layout][filesystem] may look slightly different from w
 [config-txt]:/reference/OS/advanced/#config-txt
 [network]:/reference/OS/network/2.x
 [filesystem]:/reference/OS/overview/2.x/#stateless-and-read-only-rootfs
+[labels]:/learn/develop/multicontainer/#labels
+[config-json]:{{ $links.osSiteUrl }}/meta-balena#configjson
+[balena-engine]:{{ $links.engineSiteUrl }}


### PR DESCRIPTION
Some updates to the second half of the SSH page which deals with troubleshooting.  This might eventually make sense on its own page but for now, I’ve updated what it there.

This is largely taken from WIP debugging masterclass and the host OS masterclass but I think this info really needs to be in the docs.

Change-type: patch
Signed-off-by: Gareth Davies gareth@balena.io