### PR TITLE
docs: Fixing broken link to base images

### DIFF
--- a/shared/network/2.x.md
+++ b/shared/network/2.x.md
@@ -434,6 +434,6 @@ custom endpoints, the URL, expected response, and check interval can be set in `
 [network-manager-examples]:https://wiki.gnome.org/Projects/NetworkManager/Developers#Show_me_more_examples.21 "NetworkManager: Show me more examples!"
 [redsocks]:https://github.com/darkk/redsocks
 [redsocks-conf-example]:https://github.com/darkk/redsocks/blob/master/redsocks.conf.example
-[python-base-images]:/base-images/base-images/#python
+[python-base-images]:/reference/base-images/base-images/
 [nm-connectivity]:https://manpages.debian.org/jessie/network-manager/NetworkManager.conf.5.en.html#CONNECTIVITY_SECTION
 [meta-balena-connectivity]:{{ $links.githubOS }}/meta-balena#connectivity


### PR DESCRIPTION
Closes #1275 

Change-type: patch
Connects-to: 1275
Signed-off-by: Gareth Davies gareth@balena.io