### PR TITLE
deps: Bump all dependabot dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3914,9 +3914,9 @@
       "integrity": "sha1-o0MhkvObkQtfAsyYlIeDbscKqF4="
     },
     "jquery": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.0.tgz",
-      "integrity": "sha512-ggRCXln9zEqv6OqAGXFEcshF5dSBvCkzj6Gm2gzuR5fWawaX8t7cxKVkkygKODrDAzKdoYw3l/e3pm3vlT4IbQ=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
     },
     "jquery-colorbox": {
       "version": "1.6.4",
@@ -4075,9 +4075,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
-      "integrity": "sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -4203,9 +4203,9 @@
       }
     },
     "merge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
       "dev": true
     },
     "merge-descriptors": {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "express-http-to-https": "1.1.4",
     "headroom.js": "0.9.3",
     "highlight.js": "9.11.0",
-    "jquery": "3.4.0",
+    "jquery": "3.4.1",
     "jquery-colorbox": "1.6.4",
-    "lodash": "^4.17.13",
+    "lodash": "^4.17.15",
     "metalsmith-prefixoid": "^1.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Bump merge from 1.2.0 to 1.2.1
Bump jquery from 3.4.0 to 3.4.1
Bump lodash from 4.17.13 to 4.17.15

Tested on staging site https://www.balena-staging.io/docs/learn/welcome/introduction/