### PR TITLE
docs: Update base image machine types

### DIFF
--- a/config/links.coffee
+++ b/config/links.coffee
@@ -15,6 +15,7 @@ module.exports =
   githubProjects: 'https://github.com/balena-io-projects'
   githubPlayground: 'https://github.com/balena-io-playground'
   githubOS: 'https://github.com/balena-os'
+  githubBaseImages: 'https://github.com/balena-io-library/base-images/tree/master/balena-base-images/device-base'
   apiBase: process.env.API_BASE || 'https://api.balena-cloud.com'
   mainSiteUrl: 'https://balena.io'
   blogSiteUrl: 'https://balena.io/blog'

--- a/shared/general/deviceTypeNames.md
+++ b/shared/general/deviceTypeNames.md
@@ -1,28 +1,75 @@
 Device Name | {{ $names.company.allCaps }}_MACHINE_NAME | {{ $names.company.allCaps }}_ARCH | GitHub
 ------------ | ------------- | ------------- | -------------
-Raspberry Pi (v1 and Zero) | raspberry-pi | rpi | {{ $links.githubOS }}/balena-raspberrypi
-Raspberry Pi 2 | raspberry-pi2 | armv7hf | {{ $links.githubOS }}/balena-raspberrypi
-Raspberry Pi 3 | raspberrypi3 | armv7hf | {{ $links.githubOS }}/balena-raspberrypi
-Raspberry Pi 3 (using 64-bit OS) | raspberrypi3-64 | aarch64 | {{ $links.githubOS }}/balena-raspberrypi
-Raspberry Pi 4 (using 64-bit OS) | raspberrypi4-64 | aarch64 | {{ $links.githubOS }}/balena-raspberrypi
-BeagleBone Black | beaglebone-black | armv7hf | {{ $links.githubOS }}/balena-beaglebone
-BeagleBone Green Wireless | beaglebone-green-wifi | armv7hf | {{ $links.githubOS }}/balena-beaglebone
-BeagleBone Green | beaglebone-green | armv7hf | {{ $links.githubOS }}/balena-beaglebone
-Intel Edison | intel-edison | i386 | {{ $links.githubOS }}/balena-edison
-Intel NUC | intel-nuc | amd64 | {{ $links.githubOS }}/balena-intel
-Jetson TX2 | jetson-tx2 | aarch64 | {{ $links.githubOS }}/balena-jetson-tx2
-Hummingboard | hummingboard | armv7hf | {{ $links.githubOS }}/balena-fsl-arm
-Nitrogen 6X | nitrogen6x | armv7hf | {{ $links.githubOS }}/balena-fsl-arm
-Parallella | parallella | armv7hf | {{ $links.githubOS }}/balena-parallella
-Samsung Artik 1020 | artik10 | armv7hf | {{ $links.githubOS }}/balena-artik
-Samsung Artik 530 | artik530 | armv7hf | {{ $links.githubOS }}/balena-artik
-Samsung Artik 530s 1G | artik533s | armv7hf | {{ $links.githubOS }}/balena-artik
-Samsung Artik 710 | artik710 | aarch64 | {{ $links.githubOS }}/balena-artik710
-RushUp Kitra 710 | kitra710 | aarch64 | {{ $links.githubOS }}/balena-artik710
-UpBoard | up-board | amd64 | {{ $links.githubOS }}/balena-up-board
-Technologic TS-4900 | ts4900 | armv7hf | {{ $links.githubOS }}/balena-ts
-Odroid C1/C1+ | odroid-c1 | armv7hf | {{ $links.githubOS }}/balena-odroid
-Odroid XU4 | odroid-xu4 | armv7hf | {{ $links.githubOS }}/balena-odroid
-Variscite DART-6UL | imx6ul-var-dart | armv7hf | {{ $links.githubOS }}/balena-variscite-mx8
-Generic ARMv7-a HF | generic-armv7ahf | armv7hf | {{ $links.githubOS }}/balena-generic
-Generic AARCH64 (ARMv8) | generic-aarch64 | aarch64 | {{ $links.githubOS }}/balena-generic
+AM571X-EVM | am571x-evm | armv7hf | [Link]({{ $links.githubBaseImages }}/am571x-evm)
+Aetina N510 TX2 | n510-tx2 | aarch64 | [Link]({{ $links.githubBaseImages }}/n510-tx2)
+Asus Tinker Board | asus-tinker-board | armv7hf | [Link]({{ $links.githubBaseImages }}/asus-tinker-board)
+Asus Tinker Board S | asus-tinker-board-s | armv7hf | [Link]({{ $links.githubBaseImages }}/asus-tinker-board-s)
+Auvidea JN30B Nano | jn30b-nano | aarch64 | [Link]({{ $links.githubBaseImages }}/jn30b-nano)
+BALENA FIN | fincm3 | armv7hf | [Link]({{ $links.githubBaseImages }}/fincm3)
+BananaPi-M1+ | bananapi-m1-plus | armv7hf | [Link]({{ $links.githubBaseImages }}/bananapi-m1-plus)
+BeagleBoard-XM | beagleboard-xm | armv7hf | [Link]({{ $links.githubBaseImages }}/beagleboard-xm)
+BeagleBone Black | beaglebone-black | armv7hf | [Link]({{ $links.githubBaseImages }}/beaglebone-black)
+BeagleBone Green | beaglebone-green | armv7hf | [Link]({{ $links.githubBaseImages }}/beaglebone-green)
+BeagleBone Green Wifi | beaglebone-green-wifi | armv7hf | [Link]({{ $links.githubBaseImages }}/beaglebone-green-wifi)
+CTI Orbitty TX2 | orbitty-tx2 | aarch64 | [Link]({{ $links.githubBaseImages }}/orbitty-tx2)
+CTI Spacely TX2 | spacely-tx2 | aarch64 | [Link]({{ $links.githubBaseImages }}/spacely-tx2)
+Compulab iMX8 | cl-som-imx8 | aarch64 | [Link]({{ $links.githubBaseImages }}/cl-som-imx8)
+Cybertan ze250 | cybertan-ze250 | i386-nlp | [Link]({{ $links.githubBaseImages }}/cybertan-ze250)
+Dart | imx6ul-var-dart | armv7hf | [Link]({{ $links.githubBaseImages }}/imx6ul-var-dart)
+Generic AARCH64 | generic-aarch64 | aarch64 | [Link]({{ $links.githubBaseImages }}/generic-aarch64)
+Generic ARMv7-a HF | generic-armv7ahf | armv7hf | [Link]({{ $links.githubBaseImages }}/generic-armv7ahf)
+Google Coral Dev Board | coral-dev | aarch64 | [Link]({{ $links.githubBaseImages }}/coral-dev)
+Hummingboard | hummingboard | armv7hf | [Link]({{ $links.githubBaseImages }}/hummingboard)
+Intel Edison | intel-edison | i386 | [Link]({{ $links.githubBaseImages }}/intel-edison)
+Intel NUC | intel-nuc | amd64 | [Link]({{ $links.githubBaseImages }}/intel-nuc)
+Microsoft Surface Go | surface-go | amd64 | [Link]({{ $links.githubBaseImages }}/surface-go)
+Microsoft Surface Pro 6 | surface-pro-6 | amd64 | [Link]({{ $links.githubBaseImages }}/surface-pro-6)
+NPE X500 M3 | npe-x500-m3 | armv7hf | [Link]({{ $links.githubBaseImages }}/npe-x500-m3)
+NanoPC-T4 | nanopc-t4 | aarch64 | [Link]({{ $links.githubBaseImages }}/nanopc-t4)
+Nanopi Neo Air | nanopi-neo-air | armv7hf | [Link]({{ $links.githubBaseImages }}/nanopi-neo-air)
+Nitrogen 6X Quad 2GB | nitrogen6xq2g | armv7hf | [Link]({{ $links.githubBaseImages }}/nitrogen6xq2g)
+Nitrogen 6x | nitrogen6x | armv7hf | [Link]({{ $links.githubBaseImages }}/nitrogen6x)
+Nitrogen8M Mini SBC | nitrogen8mm | aarch64 | [Link]({{ $links.githubBaseImages }}/nitrogen8mm)
+Nvidia D3 TX2 | srd3-tx2 | aarch64 | [Link]({{ $links.githubBaseImages }}/srd3-tx2)
+Nvidia Jetson Nano | jetson-nano | aarch64 | [Link]({{ $links.githubBaseImages }}/jetson-nano)
+Nvidia Jetson TX1 | jetson-tx1 | aarch64 | [Link]({{ $links.githubBaseImages }}/jetson-tx1)
+Nvidia Jetson TX2 | jetson-tx2 | aarch64 | [Link]({{ $links.githubBaseImages }}/jetson-tx2)
+Nvidia Jetson Xavier | jetson-xavier | aarch64 | [Link]({{ $links.githubBaseImages }}/jetson-xavier)
+Nvidia blackboard TX2 | blackboard-tx2 | aarch64 | [Link]({{ $links.githubBaseImages }}/blackboard-tx2)
+ODroid C1 | odroid-c1 | armv7hf | [Link]({{ $links.githubBaseImages }}/odroid-c1)
+ODroid XU4 | odroid-xu4 | armv7hf | [Link]({{ $links.githubBaseImages }}/odroid-xu4)
+Orange Pi Lite | orange-pi-lite | armv7hf | [Link]({{ $links.githubBaseImages }}/orange-pi-lite)
+Orange Pi One | orange-pi-one | armv7hf | [Link]({{ $links.githubBaseImages }}/orange-pi-one)
+Orange Pi Plus2 | orangepi-plus2 | armv7hf | [Link]({{ $links.githubBaseImages }}/orangepi-plus2)
+Orange Pi Zero | orange-pi-zero | armv7hf | [Link]({{ $links.githubBaseImages }}/orange-pi-zero)
+Parallella | parallella | armv7hf | [Link]({{ $links.githubBaseImages }}/parallella)
+PocketBeagle | beaglebone-pocket | armv7hf | [Link]({{ $links.githubBaseImages }}/beaglebone-pocket)
+QEMU x86 | qemux86 | i386 | [Link]({{ $links.githubBaseImages }}/qemux86)
+QEMU x86-64 | qemux86-64 | amd64 | [Link]({{ $links.githubBaseImages }}/qemux86-64)
+Raspberry Pi (1, Zero, Zero W) | raspberry-pi | rpi | [Link]({{ $links.githubBaseImages }}/raspberry-pi)
+Raspberry Pi 2 | raspberry-pi2 | armv7hf | [Link]({{ $links.githubBaseImages }}/raspberry-pi2)
+Raspberry Pi 3 | raspberrypi3 | armv7hf | [Link]({{ $links.githubBaseImages }}/raspberrypi3)
+Raspberry Pi 3 64bits | raspberrypi3-64 | aarch64 | [Link]({{ $links.githubBaseImages }}/raspberrypi3-64)
+Raspberry Pi 4 (using 64bit OS) | raspberrypi4-64 | aarch64 | [Link]({{ $links.githubBaseImages }}/raspberrypi4-64)
+Revolution Pi Core 3 | revpi-core-3 | armv7hf | [Link]({{ $links.githubBaseImages }}/revpi-core-3)
+RushUp Kitra 520 | kitra520 | armv7hf | [Link]({{ $links.githubBaseImages }}/kitra520)
+RushUp Kitra 710 | kitra710 | aarch64 | [Link]({{ $links.githubBaseImages }}/kitra710)
+Samsung Artik 10 | artik10 | armv7hf | [Link]({{ $links.githubBaseImages }}/artik10)
+Samsung Artik 5 | artik5 | armv7hf | [Link]({{ $links.githubBaseImages }}/artik5)
+Samsung Artik 530 | artik530 | armv7hf | [Link]({{ $links.githubBaseImages }}/artik530)
+Samsung Artik 530s 1G | artik533s | armv7hf | [Link]({{ $links.githubBaseImages }}/artik533s)
+Samsung Artik 710 | artik710 | aarch64 | [Link]({{ $links.githubBaseImages }}/artik710)
+Siemens IOT2000 | iot2000 | i386-nlp | [Link]({{ $links.githubBaseImages }}/iot2000)
+Technologic TS-4900 | ts4900 | armv7hf | [Link]({{ $links.githubBaseImages }}/ts4900)
+Technologic TS-7700 | ts7700 | armv5e | [Link]({{ $links.githubBaseImages }}/ts7700)
+Toradex Apalis | apalis-imx6q | armv7hf | [Link]({{ $links.githubBaseImages }}/apalis-imx6q)
+Toradex Colibri | colibri-imx6dl | armv7hf | [Link]({{ $links.githubBaseImages }}/colibri-imx6dl)
+UP Board | up-board | amd64 | [Link]({{ $links.githubBaseImages }}/up-board)
+UP Core | up-core | amd64 | [Link]({{ $links.githubBaseImages }}/up-core)
+UP Core Plus | up-core-plus | amd64 | [Link]({{ $links.githubBaseImages }}/up-core-plus)
+UP Squared | up-squared | amd64 | [Link]({{ $links.githubBaseImages }}/up-squared)
+VIA vab820 | via-vab820-quad | armv7hf | [Link]({{ $links.githubBaseImages }}/via-vab820-quad)
+Variscite DART-MX8M | imx8m-var-dart | aarch64 | [Link]({{ $links.githubBaseImages }}/imx8m-var-dart)
+Variscite VAR-SOM-MX6 | var-som-mx6 | armv7hf | [Link]({{ $links.githubBaseImages }}/var-som-mx6)
+Variscite VAR-SOM-MX7 | imx7-var-som | armv7hf | [Link]({{ $links.githubBaseImages }}/imx7-var-som)
+Zynq zc702 | zc702-zynq7 | armv7hf | [Link]({{ $links.githubBaseImages }}/zc702-zynq7)


### PR DESCRIPTION
This PR updates this page https://www.balena.io/docs/reference/base-images/devicetypes/ for all supported device types. This is generated from the contracts repo using this simple Python snippet https://gist.github.com/garethtdavies/00f9c361d0b9f274f8c9bf452c6f9603

More discussion here: https://www.flowdock.com/app/rulemotion/i-baseimages/threads/J9S58kUKH8Z35I2EvhCm1VpaO-K

Change-type: minor
Signed-off-by: Gareth Davies gareth@balena.io