### PR TITLE
meta: Fix excerpt tag expanding variables correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/balena-io/docs",
   "dependencies": {
-    "@resin.io/doxx": "0.11.3",
+    "@resin.io/doxx": "0.11.4",
     "bootstrap": "3.4.1",
     "bootstrap-select": "1.12.2",
     "coffee-script": "~1.10.0",


### PR DESCRIPTION
This closes #1247 💥 Fixed via this commit in Doxx repo https://github.com/balena-io/doxx/pull/29

Change-type: patch
Connects-to: #1247
Signed-off-by: Gareth Davies gareth@balena.io