### PR TITLE
meta: Fix Supervisor API redirect

### DIFF
--- a/config/redirects.txt
+++ b/config/redirects.txt
@@ -49,6 +49,7 @@
 ^\/runtime\/terminal\/?(\?.+)?(#.+)?$ -> /learn/manage/ssh-access/$1$2
 ^\/using\/cli\/?(\?.+)?(#.+)?$ -> /reference/cli/$1$2
 ^\/learn\/deploy\/release-strategy\/update-locking\/API\/?(\?.+)?(#.+)?$ -> /reference/supervisor/supervisor-api/$1$2
+^\/docs\/learn\/deploy\/release-strategy\/update-locking\/API\/?(\?.+)?(#.+)?$ -> /reference/supervisor/supervisor-api/$1$2
 
 # Restructure
 ^\/introduction\/?(\?.+)?(#.+)?$ -> /learn/welcome/introduction/$1$2


### PR DESCRIPTION
This actually fixes the redirect. It's a hacky fix as there is a double redirect going on as it first strips the file extension. Given this is coming from an upstream repo I don't think there is too much else that can be done unless anyone has any good ideas?

Closes: #1154

Change-type: patch
Signed-off-by: Gareth Davies <gareth@balena.io>