### PR TITLE
Remove a wrong note about mixpanel

### DIFF
--- a/shared/network/1.x.md
+++ b/shared/network/1.x.md
@@ -32,8 +32,6 @@ Additionally, you should whitelist the following domains for the relevant ports 
 * `*.docker.io`
 
 
-Additionally, an outgoing connection to `mixpanel.com` is made. This is not a functional requirement for {{ $names.company.lower }}, but allows tracking of some useful metrics.
-
 ## Ethernet Connections
 
 As mentioned earlier, {{ $names.company.lower }} the host OS defaults to using ethernet for internet connectivity, so if you connect an active ethernet cable to your device and all the [network requirements](#network-requirements) are satisfied, your device should simply just connect to the dashboard and you should be able to push code to it.


### PR DESCRIPTION
All the data is submitted using our own backend if a recent enough supervisor is used.
So, no extra connection to a third-party domain.

Change-type: patch
Signed-off-by: Roman Mazur <roman@balena.io>