### PR TITLE
Fix page views reporting

### DIFF
--- a/templates/_track.html
+++ b/templates/_track.html
@@ -15,9 +15,11 @@
 <script type="text/javascript">(function(f,b){if(!b.__SV){var a,e,i,g;window.mixpanel=b;b._i=[];b.init=function(a,e,d){function f(b,h){var a=h.split(".");2==a.length&&(b=b[a[0]],h=a[1]);b[h]=function(){b.push([h].concat(Array.prototype.slice.call(arguments,0)))}}var c=b;"undefined"!==typeof d?c=b[d]=[]:d="mixpanel";c.people=c.people||[];c.toString=function(b){var a="mixpanel";"mixpanel"!==d&&(a+="."+d);b||(a+=" (stub)");return a};c.people.toString=function(){return c.toString(1)+".people (stub)"};i="disable track track_pageview track_links track_forms register register_once alias unregister identify name_tag set_config people.set people.set_once people.increment people.append people.track_charge people.clear_charges people.delete_user".split(" ");
 for(g=0;g<i.length;g++)f(c,i[g]);b._i.push([a,e,d])};b.__SV=1.2;a=f.createElement("script");a.type="text/javascript";a.async=!0;a.src="//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";e=f.getElementsByTagName("script")[0];e.parentNode.insertBefore(a,e)}})(document,window.mixpanel||[]);
 
-window.jQuery.get('https://api.resin.io/config', (config) => {
+var baseUrl = 'https://api.balena-cloud.com';
+window.jQuery.get(baseUrl + '/config', (config) => {
   mixpanel.init(config.mixpanelToken, {
-      api_host: 'https://api.balena-cloud.com/mixpanel',
+      api_host: baseUrl + '/mixpanel',
+      api_method: 'GET',
       track_pageview: false,
       autotrack: false
   });


### PR DESCRIPTION
In December, mixpanel client update broke our reporting because it switched from
GET to POST. GET is not handled by our backend.

This change forces the supported method to be used.

Change-type: patch
Signed-off-by: Roman Mazur <roman@balena.io>