### PR TITLE
os: Updating host OS variants

### DIFF
--- a/shared/overview/2.x.md
+++ b/shared/overview/2.x.md
@@ -4,9 +4,9 @@
 
 {{ $names.os.upper }} is an operating system optimized for running [Docker][Docker] containers on embedded devices, with an emphasis on reliability over long periods of operation, as well as a productive developer workflow inspired by the lessons learned while building {{ $names.company.lower }}.
 
-The core insight behind {{ $names.os.lower }} is that Linux Containers offer, for the first time, a practical path to using virtualisation on embedded devices. VMs and hypervisors have lead to huge leaps in productivity and automation for cloud deployments, but their abstraction of hardware as well as their resource overhead and lack of hardware support means that they are out of the question for embedded scenarios. With OS-level virtualisation as implemented for Linux Containers, both those objections are lifted for Linux devices, of which there are many in the Internet of Things.
+The core insight behind {{ $names.os.lower }} is that Linux containers offer, for the first time, a practical path to using virtualization on embedded devices. VMs and hypervisors have lead to huge leaps in productivity and automation for cloud deployments, but their abstraction of hardware, as well as their resource overhead and lack of hardware support, means that they are not suitable for embedded scenarios. With OS-level virtualization, as implemented for Linux containers, both those objections are lifted for Linux devices, of which there are many in the Internet of Things.
 
-{{ $names.os.upper }} is an operating system built for easy portability to multiple device types (via the [Yocto framework](https://www.yoctoproject.org/)) and optimized for Linux Containers, and Docker in particular. There are many decisions, large and small, we have made to enable that vision, which are present throughout our architecture.
+{{ $names.os.upper }} is an operating system built for easy portability to multiple device types (via the [Yocto framework][yocto] and optimized for Linux containers, and Docker in particular. There are many decisions, large and small, we have made to enable that vision, which are present throughout our architecture.
 
 The first version of {{ $names.os.lower }} was developed as part of the {{ $names.company.lower }} platform, and has run on thousands of embedded devices on {{ $names.company.lower }}, deployed in many different contexts for several years. {{ $names.os.lower }} v2 represents the combination of the learnings we extracted over those years, as well as our determination to make {{ $names.os.lower }} a first-class open source project, able to run as an independent operating system, for any context where embedded devices and containers intersect.
 
@@ -14,42 +14,45 @@ We look forward to working with the community to grow and mature {{ $names.os.lo
 
 ## Variants of {{ $names.os.lower }}
 
-{{ $names.os.upper }} currently comes in 3 different variants all built from the same source but with slightly differing features enabled or disabled. Each version of {{ $names.os.lower }} produces the following variants:
+Each version of {{ $names.os.lower }} is available in development and production variants, both built from the same source, but with slightly differing feature sets.
 
-| Version Name | Variant Type | Description |
-|:------------:|:------------:|:------------:|
-| 2.0.0+rev2   | production   | This is the production version of the {{ $names.company.lower }} managed OS. This is the OS you should use for any production fleet deployments |
-| 2.0.0+rev2-dev | development | This version the development version of the above and should be used when you are developing a new application and want to use the fast [local mode][local-mode-link] workflow. This variant should never be used in production. |
-| 2.0.0+rev2.dev | standalone | This version is an unmanaged version of {{ $names.os.lower }}, it doesn't have the {{ $names.company.lower }} supervisor and does not connect to the management console. Use this variant if you want a stable linux OS to run Docker on. |
+|   Version Name   | Variant Type |                                                                                                            Description                                                                                                             |
+|:----------------:|:------------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
+| 2.46.1+rev3-prod |  production  |                                                          This is the production version of {{ $names.os.lower }} and should be used for any production fleet deployments.                                                          |
+| 2.46.1+rev3-dev  | development  | This is the development version of {{ $names.os.lower }} and should be used when you are developing a new application and want to use the fast [local mode][local-mode] workflow. This variant should never be used in production. |
 
-### Dev vs. Prod images
+### Development vs. Production images
 
-The Development images are recommended while getting started with {{ $names.os.lower }} and building a system.
-The dev images enable a number of useful features while developing, namely:
+__Warning:__ Development images have an exposed Docker socket and enable passwordless root SSH access and should never be used in production.
 
-* Passwordless SSH into {{ $names.os.lower }} on port `22222` as the root user. So one can do `ssh root@<DEVICE_IP> -p22222` and poke around to see how the system runs.
-* Docker socket exposed on port `2375`, which allows `{{ $names.company.lower }} push` / `build` / `deploy`
-  to do remote Docker builds on the target device (see [Deploy to your Fleet][deploy-to-fleet]).
+The development images are recommended while getting started with {{ $names.os.lower }} and building an application. The development images enable a number of useful features while developing, namely:
+
+* Passwordless [SSH access][ssh-host] into {{ $names.os.lower }} on port `22222` as the root user.
+* Docker socket exposed on port `2375`, which allows `{{ $names.company.lower }} push` / `build` / `deploy`, that enables remote Docker builds on the target device (see [Deploy to your Fleet][deploy-to-fleet]).
 * Getty console attached to tty1 and serial.
-* Capable of entering [local mode][local-mode-link] for rapid development of application containers locally.
+* Capable of entering [local mode][local-mode] for rapid development of application containers locally.
 
 __Note:__ Raspberry Pi devices don’t have Getty attached to serial.
 
-The production images have all of the above functionality disabled by default. In both forms of the OS we write logs to an 8 MB journald RAM
-buffer in order to avoid wear on the flash storage used by most of the supported boards. However, persistent logging can be enabled by setting
-the `"persistentLogging": true` key in the `config.json` file in the boot partition of the device. The logs can be accessed [via the host OS][ssh-host] at `/var/log/journal`.
+Production images disable passwordless root access, and an SSH key must be [added][config-json-ssh] to `config.json` to access a production image using a direct SSH connection. You may still access a production image by tunneling SSH through the {{ $names.company.lower }} VPN via the CLI (using `balena ssh <uuid>`) or the {{ $names.cloud.lower }} [web terminal][ssh-host]. To use SSH via the VPN, you need to have an SSH key configured on your development machine and [added][ssh-key-add] to the {{ $names.cloud.lower }} dashboard.
 
-Both Prod and Dev variants will also allow the setting of a custom hostname via the `config.json`, just add `"hostname": "my-new-hostname"`. Your device will then broadcast (via Avahi) on the network as `my-new-hostname.local`. If you don't set a custom hostname, the device will default to `<short-UUID>.local`.
+In both development and production versions of {{ $names.os.lower }}, logs are written to an 8 MB journald RAM buffer in order to avoid wear on the flash storage used by most of the supported boards.
 
-On the production variant, nothing is written to tty1, on boot up you should only see the {{ $names.company.lower }} logo on the HDMI screen and this will persist until your application code takes over the framebuffer. If you would like to replace the {{ $names.company.lower }} logo with your own custom splash logo, then you will need to replace splash/resin-logo.png file that you will find in the first partition of our images (boot partition or `resin-boot`) with your own image.
+To persist logs on the device, enable persistent logging via the [fleet configuration variable][fleet-configuration] in the {{ $names.cloud.lower }} dashboard, or prior to device provisioning setting the `"persistentLogging": true` [key][config-json-logging] in `config.json`. The logs can be accessed via the host OS at `/var/log/journal`. For versions of {{ $names.os.lower }} < 2.45.0, persistent logs are limited to 8 MB and stored in the state partition of the device. {{ $names.os.upper }} versions >= 2.45.0 store a maximum of 32 MB of persistent logs in the data partition of the device.
 
-__Note:__ As it currently stands plymouth expects the image to be named `resin-logo.png`.
+Both development and production versions of {{ $names.os.lower }} allow the setting of a custom [hostname][config-json-hostname] via `config.json`, by setting `"hostname": "my-new-hostname"`. Your device will then broadcast (via Avahi) on the network as `my-new-hostname.local`. If you don't set a custom hostname, the device will default to `<short-UUID>.local`. You can also set a custom hostname via the [Supervisor API][supervisor-api] on device.
+
+On production images, nothing is written to tty1, on boot you should only see the {{ $names.company.lower }} logo, and this will persist until your application code takes over the framebuffer. If you would like to replace the {{ $names.company.lower }} logo with your own custom splash logo, then you will need to replace the `splash/resin-logo.png` file that you will find in the [first partition][parition] of the image (boot partition or `resin-boot`) with your own logo.
+
+__Note:__ As it currently stands, plymouth expects the image to be named `resin-logo.png`.
+
+When a {{ $names.os.lower }} image is downloaded from the {{ $names.cloud.lower }} dashboard, it contains a provisioning key that allows devices flashed with the image to be added to a specific application, and a device API key generated. As such, you should handle such images downloaded from {{ $names.cloud.lower }} with care as anyone with access to the image can add a device to your application. You can find out more about the access restrictions of a device API key [here][security].
 
 ### Standalone {{ $names.os.lower }}
 
-{{ $names.os.upper }} also comes in a Standalone or "Unmanaged" variant. This variant is exactly the same as the `-dev` variant but **does not** have the {{ $names.company.lower }} supervisor agent and has the {{ $names.company.lower }} VPN service disabled, so it will never connect to the {{ $names.company.lower }} management system.
+Images downloaded via the CLI (using `os download`), via [balena.io/os][balena-io-os], or [manually built via Yocto][yocto-build] are the same {{ $names.os.lower }} images as those downloaded from {{ $names.cloud.lower }} but are unconfigured, and will not connect to the {{ $names.cloud.lower }} servers, but still make use of the Supervisor to keep the containers running. This version of {{ $names.os.lower }} is meant as an excellent way to get started with Docker containers on embedded systems, and you can read more about this at [balena.io/os][balena-io-os].
 
-The standalone version of {{ $names.os.lower }} is meant as an excellent way to get started with Docker containers on embedded systems and you can read more about this over at [balena.io/os](https://balena.io/os).
+Should you wish to add an unconfigured device to your {{ $names.cloud.lower }} application, you may migrate it using the interactive `balena join` [CLI command][cli-join] or update the `config.json` of an unconfigured device with a configuration file downloaded from the _Add device_ page of the {{ $names.cloud.lower }} dashboard.
 
 ## {{ $names.os.upper }} Components
 The {{ $names.os.lower }} userspace tries to package only the bare essentials for running containers while still offering a lot of flexibility. The philosophy is that software and services always default to being in a container, unless they are generically useful to all containers or they absolutely can’t live in a container.  The userspace consists of many open source components, but in this section we will just highlight some of the most important services.
@@ -107,12 +110,12 @@ This document will not go into detailed explanation about how the [Yocto Project
 | Codename | Yocto Project Version | Release Date | Current Version | Support Level | Poky Version | BitBake branch |
 |:--------:|:---------------------:|:------------:|:---------------:|:-------------:|:------------:|:--------------:|
 |   Pyro   |          2.3          |   Apr 2017   |                 |  Development  |              |                |
-|   Morty  |          2.2          |   Oct 2016   |      2.2.1      |     Stable    |     16.0     |      1.32      |
-|  Krogoth |          2.1          |   Apr 2016   |      2.1.2      |     Stable    |     15.0     |      1.30      |
+|  Morty   |          2.2          |   Oct 2016   |      2.2.1      |    Stable     |     16.0     |      1.32      |
+| Krogoth  |          2.1          |   Apr 2016   |      2.1.2      |    Stable     |     15.0     |      1.30      |
 |  Jethro  |          2.0          |   Nov 2015   |      2.0.3      |   Community   |     14.0     |      1.28      |
 |   Fido   |          1.8          |   Apr 2015   |      1.8.2      |   Community   |     13.0     |      1.26      |
-|   Dizzy  |          1.7          |   Oct 2014   |      1.7.3      |   Community   |     12.0     |      1.24      |
-|   Daisy  |          1.6          |   Apr 2014   |      1.6.3      |   Community   |     11.0     |      1.22      |
+|  Dizzy   |          1.7          |   Oct 2014   |      1.7.3      |   Community   |     12.0     |      1.24      |
+|  Daisy   |          1.6          |   Apr 2014   |      1.6.3      |   Community   |     11.0     |      1.22      |
 |   Dora   |          1.5          |   Oct 2013   |      1.5.4      |   Community   |     10.0     |      1.20      |
 
 We will start looking into {{ $names.os.lower }}’s composition from the core of the [Yocto Project](https://www.yoctoproject.org/), i.e. poky. Poky has released a whole bunch of versions and supporting all of them is not in the scope of our OS, but we do try to support its latest versions. This might sound unexpected as we do not currently support poky’s last version (i.e. 2.1/Krogoth), but this is only because we did not need this version yet. We tend to support versions of poky based on what our supported boards require and also do a yearly update to the latest poky version for all the boards that can run that version. Currently we support three poky versions: 2.0/Jethro, 1.8/Fido and 1.6/Daisy.
@@ -125,26 +128,36 @@ Now for the final piece of the puzzle, the board-specific meta-{{ $names.company
 
 Below is a representative example from the Raspberry Pi family, which helps explain [meta-{{ $names.company.lower }}-raspberrypi/conf/samples/bblayers.conf.sample]({{ $links.githubOS }}/balena-raspberrypi/blob/master/layers/meta-balena-raspberrypi/conf/samples/bblayers.conf.sample).
 
-| Layer Name                        | Repository                                                                      | Description                                                                           |
-|-----------------------------------|-------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
-| meta-{{ $names.company.lower }}                        | {{ $links.githubOS }}/meta-balena                                        | This repository enables building {{ $names.os.lower }} for various devices                         |
-| meta-{{ $names.company.lower }}-jethro                 | {{ $links.githubOS }}/meta-balena                                        | This layer enables building {{ $names.os.lower }} for jethro supported BSPs                        |
-| meta-{{ $names.company.lower }}-raspberrypi            | {{ $links.githubOS }}/{{ $names.company.lower }}-raspberrypi                                 | Enables building {{ $names.os.lower }} for chosen meta-raspberrypi machines.                        |
-| meta-raspberrypi                  | https://github.com/agherzan/meta-raspberrypi                                  | This is the general hardware specific BSP overlay for the Raspberry Pi device family. |
-| meta-openembedded                 | http://git.openembedded.org/meta-openembedded                                 | Collection of OpenEmbedded layers                                                     |
-| meta-openembedded/meta-oe         | https://github.com/openembedded/meta-openembedded/tree/master/meta-oe         |                                                                                       |
-| meta-openembedded/meta-python     | https://github.com/openembedded/meta-openembedded/tree/master/meta-python     | The home of python modules for OpenEmbedded.                                          |
-| meta-openembedded/meta-networking | https://github.com/openembedded/meta-openembedded/tree/master/meta-networking | Central point for networking-relatedpackages and configuration.                       |
-| oe-meta-go                        | https://github.com/mem/oe-meta-go                                             | OpenEmbedded layer for the Go programming language                                    |
-| poky/meta-yocto                   | https://git.yoctoproject.org/cgit/cgit.cgi/meta-yocto/                                   |                                                                                       |
-| poky/meta                         | https://git.yoctoproject.org/cgit/cgit.cgi/poky/                                         | Core functionality and configuration of Yocto Project                                 |
+| Layer Name                                  | Repository                                                                    | Description                                                                           |
+|---------------------------------------------|-------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
+| meta-{{ $names.company.lower }}             | {{ $links.githubOS }}/meta-balena                                             | This repository enables building {{ $names.os.lower }} for various devices            |
+| meta-{{ $names.company.lower }}-jethro      | {{ $links.githubOS }}/meta-balena                                             | This layer enables building {{ $names.os.lower }} for jethro supported BSPs           |
+| meta-{{ $names.company.lower }}-raspberrypi | {{ $links.githubOS }}/{{ $names.company.lower }}-raspberrypi                  | Enables building {{ $names.os.lower }} for chosen meta-raspberrypi machines.          |
+| meta-raspberrypi                            | https://github.com/agherzan/meta-raspberrypi                                  | This is the general hardware specific BSP overlay for the Raspberry Pi device family. |
+| meta-openembedded                           | http://git.openembedded.org/meta-openembedded                                 | Collection of OpenEmbedded layers                                                     |
+| meta-openembedded/meta-oe                   | https://github.com/openembedded/meta-openembedded/tree/master/meta-oe         |                                                                                       |
+| meta-openembedded/meta-python               | https://github.com/openembedded/meta-openembedded/tree/master/meta-python     | The home of python modules for OpenEmbedded.                                          |
+| meta-openembedded/meta-networking           | https://github.com/openembedded/meta-openembedded/tree/master/meta-networking | Central point for networking-relatedpackages and configuration.                       |
+| oe-meta-go                                  | https://github.com/mem/oe-meta-go                                             | OpenEmbedded layer for the Go programming language                                    |
+| poky/meta-yocto                             | https://git.yoctoproject.org/cgit/cgit.cgi/meta-yocto/                        |                                                                                       |
+| poky/meta                                   | https://git.yoctoproject.org/cgit/cgit.cgi/poky/                              | Core functionality and configuration of Yocto Project                                 |
 
-[resin]:{{ $links.mainSiteUrl }}/
-[yocto]:https://www.yoctoproject.org/
-[linux]:http://en.wikipedia.org/wiki/Linux
-[Docker]:https://www.docker.com/
+[balena-io-os]:{{ $links.osSiteUrl }}
+[cli-join]:/reference/cli/#join-deviceip
+[config-json-hostname]:/reference/OS/configuration/#hostname
+[config-json-logging]:/reference/OS/configuration/#persistentlogging
+[config-json-ssh]:/reference/OS/configuration/#sshkeys
 [containerisation]:http://en.wikipedia.org/wiki/Operating_system%E2%80%93level_virtualization
+[deploy-to-fleet]: /learn/deploy/deployment/
+[Docker]:https://www.docker.com/
 [Dockerfile]:http://docs.docker.com/reference/builder/
-[deploy-to-fleet]:/learn/deploy/deployment/
-[local-mode-link]:/learn/develop/local-mode/
+[fleet-configuration]:/learn/manage/configuration/#configuration-variables
+[linux]:http://en.wikipedia.org/wiki/Linux
+[local-mode]: /learn/develop/local-mode/
+[partition]:/reference/OS/overview/2.x/#stateless-and-read-only-rootfs
+[security]:/learn/welcome/security/#device-access
 [ssh-host]:/learn/manage/ssh-access/
+[ssh-key-add]:/learn/manage/ssh-access/#add-an-ssh-key-to-balenacloud
+[supervisor-api]:/reference/supervisor/supervisor-api/#patch-v1devicehost-config
+[yocto]: https://www.yoctoproject.org/
+[yocto-build]:{{ $links.osSiteUrl }}/docs/custom-build/


### PR DESCRIPTION
Lots of updates required on [this page](https://www.balena.io/docs/reference/OS/overview/2.x/) and here is the first batch (up to BalenaOS Components) which touches a number of existing open issues.

Change-type: patch
Connects-to: #1314
Connects-to: #1016
Connects-to: #1129
Connects-to: #1091
Signed-off-by: Gareth Davies <gareth@balena.io>