### PR TITLE
meta: Updating links to config.json to use docs site

### DIFF
--- a/shared/general/container-ssh.md
+++ b/shared/general/container-ssh.md
@@ -83,5 +83,5 @@ $ ssh -p 4321 root@127.0.0.1
 [balena-openssh]:{{ $links.githubPlayground }}/balena-openssh
 [github-ssh]:https://help.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent
 [add-ssh-key]:/learn/manage/ssh-access/#add-an-ssh-key-to-balenacloud
-[config-json-ssh]:{{ $links.githubOS }}/meta-balena#configjson
+[config-json-ssh]:/reference/OS/configuration/#sshkeys
 [development-image]:/reference/OS/overview/2.x/#dev-vs-prod-images

--- a/shared/general/host-ssh.md
+++ b/shared/general/host-ssh.md
@@ -125,5 +125,5 @@ Note that the [filesystem layout][filesystem] may look slightly different from w
 [network]:/reference/OS/network/2.x
 [filesystem]:/reference/OS/overview/2.x/#stateless-and-read-only-rootfs
 [labels]:/learn/develop/multicontainer/#labels
-[config-json]:{{ $links.osSiteUrl }}/meta-balena#configjson
+[config-json]:/reference/OS/configuration/
 [balena-engine]:{{ $links.engineSiteUrl }}


### PR DESCRIPTION
Updating links to point to the docs site which expands the content of `config.json` and will pull in the upstream content (when #1317 lands and https://github.com/balena-os/meta-balena/pull/1804 reaches master)

Change-type: patch
Signed-off-by: Gareth Davies gareth@balena.io