### PR TITLE
yocto: Update Yocto references for hostOS

### DIFF
--- a/shared/overview/2.x.md
+++ b/shared/overview/2.x.md
@@ -124,45 +124,37 @@ A diagram of our read-only rootfs can be seen below:
 
 ![Read only rootFS](/img/common/balenaos/read-only-rootfs.png)
 
-## OS Yocto Composition
+## {{ $names.os.upper }} Yocto Composition
 
-The OS is composed of multiple Yocto layers. The [Yocto Project](https://www.yoctoproject.org/) build system uses these layers to compile {{ $names.os.lower }} for the various [supported platforms](/reference/hardware/devices/).
-This document will not go into detailed explanation about how the [Yocto Project](https://www.yoctoproject.org/) works, but will require from the reader a basic understanding of its internals and release versioning/codename.
+{{ $names.os.upper }} is composed of multiple [Yocto][yocto] layers. The Yocto Project build system uses these layers to compile {{ $names.os.lower }} for the various [supported devices](/reference/hardware/devices/). Below is an example from the [Raspberry Pi family][raspberry-pi-conf].
 
-| Codename | Yocto Project Version | Release Date | Current Version | Support Level | Poky Version | BitBake branch |
-|:--------:|:---------------------:|:------------:|:---------------:|:-------------:|:------------:|:--------------:|
-|   Pyro   |          2.3          |   Apr 2017   |                 |  Development  |              |                |
-|  Morty   |          2.2          |   Oct 2016   |      2.2.1      |    Stable     |     16.0     |      1.32      |
-| Krogoth  |          2.1          |   Apr 2016   |      2.1.2      |    Stable     |     15.0     |      1.30      |
-|  Jethro  |          2.0          |   Nov 2015   |      2.0.3      |   Community   |     14.0     |      1.28      |
-|   Fido   |          1.8          |   Apr 2015   |      1.8.2      |   Community   |     13.0     |      1.26      |
-|  Dizzy   |          1.7          |   Oct 2014   |      1.7.3      |   Community   |     12.0     |      1.24      |
-|  Daisy   |          1.6          |   Apr 2014   |      1.6.3      |   Community   |     11.0     |      1.22      |
-|   Dora   |          1.5          |   Oct 2013   |      1.5.4      |   Community   |     10.0     |      1.20      |
+__Note:__ Instructions for building your own version of {{ $names.os.lower }} are available [here][yocto-build].
 
-We will start looking into {{ $names.os.lower }}’s composition from the core of the [Yocto Project](https://www.yoctoproject.org/), i.e. poky. Poky has released a whole bunch of versions and supporting all of them is not in the scope of our OS, but we do try to support its latest versions. This might sound unexpected as we do not currently support poky’s last version (i.e. 2.1/Krogoth), but this is only because we did not need this version yet. We tend to support versions of poky based on what our supported boards require and also do a yearly update to the latest poky version for all the boards that can run that version. Currently we support three poky versions: 2.0/Jethro, 1.8/Fido and 1.6/Daisy.
+| Layer Name                                                                         | Repository                                                                                              | Description                                                                  |
+|------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|
+| poky/meta                                                                          | https://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta                                               | Poky build tools and metadata.                                               |
+| poky/meta-poky                                                                     | https://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta-poky                                          |                                                                              |
+| meta-openembedded/meta-oe                                                          | https://github.com/openembedded/meta-openembedded/tree/master/meta-oe                                   | Base layer for OpenEmbedded build system.                                    |
+| meta-openembedded/meta-filesystems                                                 | https://github.com/openembedded/meta-openembedded/tree/master/meta-filesystems                          | OpenEmbedded filesystems layer.                                              |
+| meta-openembedded/meta-networking                                                  | https://github.com/openembedded/meta-openembedded/tree/master/meta-networking                           | OpenEmbedded networking-related packages and configuration.                  |
+| meta-openembedded/meta-python                                                      | https://github.com/openembedded/meta-openembedded/tree/master/meta-python                               | Layer containing Python modules for OpenEmbedded.                            |
+| meta-raspberrypi                                                                   | https://github.com/agherzan/meta-raspberrypi                                                            | General hardware specific BSP overlay for the Raspberry Pi device family.    |
+| meta-{{ $names.company.lower }}/meta-{{ $names.company.lower }}-common             | {{ $links.githubOS }}/meta-balena/tree/development/meta-balena-common                                   | Enables building {{ $names.os.lower }} for supported machines.               |
+| meta-{{ $names.company.lower }}/meta-{{ $names.company.lower }}-warrior            | {{ $links.githubOS }}/meta-balena/tree/development/meta-balena-warrior                                  | Enables building {{ $names.os.lower }} for Warrior supported BSPs.           |
+| {{ $names.company.lower }}-raspberrypi/meta-{{ $names.company.lower }}-raspberrypi | {{ $links.githubOS }}/{{ $names.company.lower }}-raspberrypi/tree/master/layers/meta-balena-raspberrypi | Enables building {{ $names.os.lower }} for chosen meta-raspberrypi machines. |
+| meta-rust                                                                          | https://github.com/meta-rust/meta-rust                                                                  | OpenEmbedded/Yocto layer for Rust and Cargo.                                 |
 
-On top of poky we add the collection of packages from meta-openembedded.
-Now that we are done with setting up the build system let’s add Board Support Packages (BSP), these layers are here to provide board-specific configuration and packages (e.g. bootloader, kernel), thus enabling building physical hardware (not emulators). These types of layers are the ones one should be looking for if one wants to add support for a board; if you already have this layer your job should be fairly straightforward, if you do not have it you might be looking into a very cumbersome job.
-At this point we have all the bits and pieces in place to build an OS.
-The core code of {{ $names.os.lower }} resides in meta-{{ $names.company.lower }}. This layer handles a lot of functionality but the main thing that one should remember now is that here one will find the `resin-image.bb` recipe. This layer also needs a poky version-specific layer to combine with (e.g. meta-{{ $names.company.lower }}-jethro), these two layers will give you the necessary framework for the abstract {{ $names.os.lower }} generation.
-Now for the final piece of the puzzle, the board-specific meta-{{ $names.company.lower }} configuration layer. This layer goes hand in hand with a BSP layer, for example for the Raspberry Pi family (i.e. rpi0, rpi1, rpi2, rpi3) that is supported by the meta-raspberrypi BSP, we provide a meta-{{ $names.company.lower }}-raspberrypi layer that configures meta-{{ $names.company.lower }} to the raspberrypi's needs.
+At the base is [Poky][yocto-poky], the Yocto Project's reference distribution. Poky contains the OpenEmbedded Build System (BitBake and OpenEmbedded-Core) as well as a set of metadata.  On top of Poky, we add the collection of packages from meta-openembedded.
 
-Below is a representative example from the Raspberry Pi family, which helps explain [meta-{{ $names.company.lower }}-raspberrypi/conf/samples/bblayers.conf.sample]({{ $links.githubOS }}/balena-raspberrypi/blob/master/layers/meta-balena-raspberrypi/conf/samples/bblayers.conf.sample).
+The next layer adds the Board Support Package (BSP). This layer provides board-specific configuration and packages (e.g., bootloader and kernel), thus enabling building for physical hardware (not emulators).
 
-| Layer Name                                  | Repository                                                                    | Description                                                                           |
-|---------------------------------------------|-------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
-| meta-{{ $names.company.lower }}             | {{ $links.githubOS }}/meta-balena                                             | This repository enables building {{ $names.os.lower }} for various devices            |
-| meta-{{ $names.company.lower }}-jethro      | {{ $links.githubOS }}/meta-balena                                             | This layer enables building {{ $names.os.lower }} for jethro supported BSPs           |
-| meta-{{ $names.company.lower }}-raspberrypi | {{ $links.githubOS }}/{{ $names.company.lower }}-raspberrypi                  | Enables building {{ $names.os.lower }} for chosen meta-raspberrypi machines.          |
-| meta-raspberrypi                            | https://github.com/agherzan/meta-raspberrypi                                  | This is the general hardware specific BSP overlay for the Raspberry Pi device family. |
-| meta-openembedded                           | http://git.openembedded.org/meta-openembedded                                 | Collection of OpenEmbedded layers                                                     |
-| meta-openembedded/meta-oe                   | https://github.com/openembedded/meta-openembedded/tree/master/meta-oe         |                                                                                       |
-| meta-openembedded/meta-python               | https://github.com/openembedded/meta-openembedded/tree/master/meta-python     | The home of python modules for OpenEmbedded.                                          |
-| meta-openembedded/meta-networking           | https://github.com/openembedded/meta-openembedded/tree/master/meta-networking | Central point for networking-relatedpackages and configuration.                       |
-| oe-meta-go                                  | https://github.com/mem/oe-meta-go                                             | OpenEmbedded layer for the Go programming language                                    |
-| poky/meta-yocto                             | https://git.yoctoproject.org/cgit/cgit.cgi/meta-yocto/                        |                                                                                       |
-| poky/meta                                   | https://git.yoctoproject.org/cgit/cgit.cgi/poky/                              | Core functionality and configuration of Yocto Project                                 |
+The core code of {{ $names.os.lower }} resides in the meta-{{ $names.company.lower }}-common layer. This layer also needs a Poky version-specific layer (e.g., meta-{{ $names.company.lower }}-warrior) based on the requirements of the BSP layer.
+
+Next is the board-specific meta-{{ $names.company.lower }} configuration layer. This layer works in conjunction with a BSP layer. For example, the Raspberry Pi family is supported by the meta-raspberrypi BSP layer and the corresponding meta-{{ $names.company.lower }}-raspberrypi layer configures {{ $names.os.lower }} to the Raspberry Pi's needs
+
+The final meta-rust layer enables support for the rust compiler and the cargo package manager.
+
+__Note:__ Instructions for adding custom board support may be found [here][custom-build].
 
 [avahi]:https://wiki.archlinux.org/index.php/Avahi
 [balena-engine]:https://www.balena.io/engine/
@@ -174,6 +166,7 @@ Below is a representative example from the Raspberry Pi family, which helps expl
 [config-json-ssh]:/reference/OS/configuration/#sshkeys
 [containerisation]:http://en.wikipedia.org/wiki/Operating_system%E2%80%93level_virtualization
 [chrony]:https://chrony.tuxfamily.org/
+[custom-build]:{{ $links.osSiteUrl }}/docs/custom-build/#Supporting-your-Own-Board
 [deploy-to-fleet]:/learn/deploy/deployment/
 [dnsmasq]:https://wiki.archlinux.org/index.php/Dnsmasq
 [Docker]:https://www.docker.com/
@@ -188,6 +181,7 @@ Below is a representative example from the Raspberry Pi family, which helps expl
 [open-ssh]:https://www.openssh.com/
 [open-vpn]:https://community.openvpn.net/openvpn
 [partition]:/reference/OS/overview/2.x/#stateless-and-read-only-rootfs
+[raspberry-pi-conf]:{{ $links.githubOS }}/balena-raspberrypi/blob/master/layers/meta-balena-raspberrypi/conf/samples/bblayers.conf.sample
 [security]:/learn/welcome/security/#device-access
 [ssh-host]:/learn/manage/ssh-access/
 [ssh-key-add]:/learn/manage/ssh-access/#add-an-ssh-key-to-balenacloud
@@ -195,4 +189,6 @@ Below is a representative example from the Raspberry Pi family, which helps expl
 [supervisor-api]:/reference/supervisor/supervisor-api/#patch-v1devicehost-config
 [systemd]:https://www.freedesktop.org/wiki/Software/systemd/
 [yocto]:https://www.yoctoproject.org/
-[yocto-build]:{{ $links.osSiteUrl }}/docs/custom-build/
+[yocto-build]:{{ $links.osSiteUrl }}/docs/custom-build/#Bake-your-own-Image
+[yocto-poky]:https://www.yoctoproject.org/software-item/poky/
+[yocto-releases]:https://wiki.yoctoproject.org/wiki/Releases


### PR DESCRIPTION
Refreshing the final section of this page https://www.balena.io/docs/reference/OS/overview/2.x/ for Yocto.

I've tried to simplify what was there but suggestions and feedback for anything else that needs to be covered in this brief overview are welcome.

Change-type: patch
Connects-to: #1035
Signed-off-by: Gareth Davies gareth@balena.io