### PR TITLE
Remove unsupported docker-compose property ("init")

### DIFF
--- a/pages/reference/supervisor/docker-compose.md
+++ b/pages/reference/supervisor/docker-compose.md
@@ -32,7 +32,6 @@ Field | Details
 [healthcheck](https://docs.docker.com/compose/compose-file/compose-file-v2/#healthcheck) |
 [hostname](https://docs.docker.com/compose/compose-file/compose-file-v2/#cpu-and-other-resources) |
 [image](https://docs.docker.com/compose/compose-file/compose-file-v2/#image) |
-[init](https://docs.docker.com/compose/compose-file/compose-file-v2/#init) |
 [ipc](https://docs.docker.com/compose/compose-file/compose-file-v2/#cpu-and-other-resources) |
 [labels](https://docs.docker.com/compose/compose-file/compose-file-v2/#labels-1) |
 [mac_address](https://docs.docker.com/compose/compose-file/compose-file-v2/#cpu-and-other-resources) |


### PR DESCRIPTION
I tried using it and got an error with `...should NOT have additional properties`. This is because `init` is part of DC `2.2` and we use `2.1`

Change-type: patch
Signed-off-by: Stevche Radevski <stevche@balena.io>