### PR TITLE
meta: Update masterclass links to point to docs site

### DIFF
--- a/pages/learn/deploy/release-strategy/release-policy.md
+++ b/pages/learn/deploy/release-strategy/release-policy.md
@@ -43,7 +43,7 @@ Using [device tags][device-tags], you can quickly select a group of devices and 
 
 __Note:__ For more details about using the API to manage the release policy see the [Fleet Management Masterclass][masterclass].
 
-[masterclass]:https://github.com/balena-io/balena-fleet-management-masterclass/blob/master/README.md#6-Release-Policy
+[masterclass]:/learn/more/masterclasses/fleet-management/#6-release-policy
 [canary]:/learn/welcome/production-plan/#canary-deployments
 [api]:/reference/api/overview/
 [sdk]:/reference/sdk/node-sdk/

--- a/pages/learn/develop/local-mode.md
+++ b/pages/learn/develop/local-mode.md
@@ -234,7 +234,7 @@ Sample secrets YAML file:
 [compose-remote]:{{ $links.githubPlayground }}/{{ $names.company.short }}os-compose
 [troubleshooting]:/learn/manage/ssh-access/#troubleshooting-with-host-os-access
 [configuration]:/learn/manage/configuration/
-[cli-masterclass]:{{ $links.githubBase }}/{{ $names.company.short }}-cli-masterclass#6-using-local-mode-to-develop-applications
+[cli-masterclass]:/learn/more/masterclasses/cli-masterclass/#6-using-local-mode-to-develop-applications
 [livepush]:{{ $links.githubModules }}/livepush
 [ssh]:/learn/manage/ssh-access/
 [avahi]:https://linux.die.net/man/8/avahi-daemon

--- a/pages/learn/develop/runtime.md
+++ b/pages/learn/develop/runtime.md
@@ -346,5 +346,5 @@ Note that currently it's not possible to share a mounted device across multiple 
 [multicontainer]:{{ $links.githubLabs }}/multicontainer-getting-started
 [network-ipam]:https://docs.docker.com/compose/compose-file/compose-file-v2/#network-configuration-reference
 [network-aliases]:https://docs.docker.com/compose/compose-file/compose-file-v2/#aliases
-[services-masterclass]:{{ $links.githubMain }}/services-masterclass#4-networking-types
+[services-masterclass]:/learn/more/masterclasses/services-masterclass/#4-networking-types
 [host-os]:/reference/OS/overview/2.x/

--- a/pages/learn/more/anti-patterns.md
+++ b/pages/learn/more/anti-patterns.md
@@ -79,7 +79,7 @@ During app development, pinning versions of various components as much as possib
 [logging-solutions]:{{ $links.blogSiteUrl }}/how-to-create-a-custom-logging-system-for-longer-log-retention/
 [networking-reqs]:/reference/OS/network/2.x/#network-requirements
 [sd-cards]:/learn/welcome/production-plan/#hardware
-[services-mc]:{{ $links.githubMain }}/services-masterclass
+[services-mc]:/learn/more/masterclasses/services-masterclass/
 [supervisor-api]:/reference/supervisor/supervisor-api/#cleanup-volumes-with-no-references
 [time-sync]:/reference/OS/time/#time-management
 [watchdog]:{{ $links.blogSiteUrl }}/keeping-your-system-running-watchdog/

--- a/pages/learn/welcome/production-plan.md
+++ b/pages/learn/welcome/production-plan.md
@@ -137,5 +137,5 @@ For more information about common anti-patterns, see [Anti-patterns, or how to b
 [staged-releases]:{{ $links.githubLabs }}/staged-releases
 [tags]:/learn/manage/filters-tags/#device-tags
 [filters]:/learn/manage/filters-tags/#device-filters
-[cli-advanced-masterclass]:{{ $links.githubMain }}/balena-cli-advanced-masterclass#5-preloading-and-preregistering
+[cli-advanced-masterclass]:/learn/more/masterclasses/advanced-cli/#5-preloading-and-preregistering
 [anti-patterns]:/learn/more/anti-patterns

--- a/pages/reference/OS/configuration.md
+++ b/pages/reference/OS/configuration.md
@@ -73,6 +73,6 @@ The following example provides all customizable configuration options available 
 [configuration]: /learn/manage/configuration/
 [nm-connectivity]: https://developer.gnome.org/NetworkManager/stable/NetworkManager.conf.html
 [configizer]:{{ $links.githubPlayground }}/configizer
-[masterclass-os]:{{ $links.githubMain }}/balenaos-masterclass#12-advanced-editing-configjson-by-hand
+[masterclass-os]:/learn/more/masterclasses/host-os-masterclass/#12-advanced-editing-configjson-by-hand
 [provisioned]:/learn/welcome/primer/#device-provisioning
 [supervisor]:/reference/supervisor/supervisor-api/

--- a/shared/general/host-ssh.md
+++ b/shared/general/host-ssh.md
@@ -129,4 +129,4 @@ Note that the [filesystem layout][filesystem] may look slightly different from w
 [labels]:/learn/develop/multicontainer/#labels
 [config-json]:/reference/OS/configuration/
 [balena-engine]:{{ $links.engineSiteUrl }}
-[debugging-masterclass]:{{ $links.githubMain }}/debugging-masterclass
+[debugging-masterclass]:/learn/more/masterclasses/device-debugging/


### PR DESCRIPTION
Updates to keep links to masterclasses on the docs site.

Change-type: patch
Signed-off-by: Gareth Davies gareth@balena.io