### PR TITLE
WIP meta: Adding support for copying a code block

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -14,7 +14,7 @@ body {
 .content-wrapper {
   min-height: 1371px;
   background: white;
-  border-right: 1px solid #E7E9EC;
+  border-right: 1px solid #e7e9ec;
 }
 
 .page-content-wrapper {
@@ -178,8 +178,8 @@ article .headroom {
 }
 
 .sidebar .nav-menu .in-page-nav li.active a {
- font-weight: bold;
- color: #6b6d73;
+  font-weight: bold;
+  color: #6b6d73;
 }
 
 .sidebar .search-wrapper .algolia-wrapper {
@@ -187,7 +187,7 @@ article .headroom {
   border-right: 1px solid #e6e8eb;
   padding: 10px;
   padding-bottom: 9px;
-  background: #F7F7F7;
+  background: #f7f7f7;
 }
 
 .sidebar .search-wrapper .algolia-wrapper .algolia-autocomplete {
@@ -228,7 +228,9 @@ article .headroom {
   color: #606060;
 }
 
-.page-content p, ul, ol {
+.page-content p,
+ul,
+ol {
   margin-bottom: 30px;
 }
 
@@ -341,20 +343,24 @@ article .headroom {
 }
 
 .colorbox-img-wrappper {
-  outline: none!important;
+  outline: none !important;
 }
 
 .hash {
   display: none;
 }
 
-h2:hover .hash, h3:hover .hash, h4:hover .hash, h5:hover .hash, h6:hover .hash {
+h2:hover .hash,
+h3:hover .hash,
+h4:hover .hash,
+h5:hover .hash,
+h6:hover .hash {
   display: inline-block;
 }
 
 .headroom {
   top: 0;
-  transition: all .3s ease-in-out;
+  transition: all 0.3s ease-in-out;
 }
 
 .headroom--unpinned {
@@ -371,24 +377,24 @@ h2:hover .hash, h3:hover .hash, h4:hover .hash, h5:hover .hash, h6:hover .hash {
 }
 
 .sticky {
-  position: fixed!important;
-  top: 0!important;
-  box-shadow: 0px -1px 6px 0px rgba(194,194,194,1);
+  position: fixed !important;
+  top: 0 !important;
+  box-shadow: 0px -1px 6px 0px rgba(194, 194, 194, 1);
   z-index: 100;
 }
 
 header.sticky {
-  box-shadow: 2px -1px 6px 0px rgba(194,194,194,1);
+  box-shadow: 2px -1px 6px 0px rgba(194, 194, 194, 1);
 }
 
 .btn-info {
-  background-color: #3C9DD0;
-  border-color: #3C9DD0;
+  background-color: #3c9dd0;
+  border-color: #3c9dd0;
   border-radius: 3px;
 }
 .btn-info:hover {
-  background-color: #2F8CBD;
-  border-color: #2F8CBD;
+  background-color: #2f8cbd;
+  border-color: #2f8cbd;
 }
 
 .btn-primary {
@@ -401,7 +407,6 @@ header.sticky {
   background-color: #c99a00;
   border-color: #bf9200;
 }
-
 
 /* dynamic-switch */
 .dynamic-switch {
@@ -466,8 +471,48 @@ header.sticky {
 }
 
 img.device_icon {
-  display: inline-block; 
-  text-align: center; 
-  margin: 0; 
-  height: 1em 
+  display: inline-block;
+  text-align: center;
+  margin: 0;
+  height: 1em;
+}
+
+/* "Copy" code block button */
+pre {
+  position: relative;
+}
+
+pre .btnIcon {
+  position: absolute;
+  top: 4px;
+  z-index: 2;
+  cursor: pointer;
+  border: 1px solid transparent;
+  padding: 0;
+  color: #fff;
+  background-color: transparent;
+  height: 30px;
+  transition: all 0.25s ease-out;
+}
+
+pre .btnIcon:hover {
+  text-decoration: none;
+}
+
+.btnIcon__body {
+  align-items: center;
+  display: flex;
+}
+
+.btnIcon svg {
+  fill: currentColor;
+  margin-right: 0.4em;
+}
+
+.btnIcon__label {
+  font-size: 11px;
+}
+
+.btnClipboard {
+  right: 10px;
 }

--- a/templates/_copy_code_block.html
+++ b/templates/_copy_code_block.html
@@ -1,0 +1,49 @@
+<script src="//cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.6/clipboard.min.js" type="text/javascript"></script>
+<script type="text/javascript">
+  window.addEventListener('load', function () {
+    function button(label, ariaLabel, icon, className) {
+      const btn = document.createElement('button');
+      btn.classList.add('btnIcon', className);
+      btn.setAttribute('type', 'button');
+      btn.setAttribute('aria-label', ariaLabel);
+      btn.innerHTML =
+        '<div class="btnIcon__body">' +
+        icon +
+        '<strong class="btnIcon__label">' +
+        label +
+        '</strong>' +
+        '</div>';
+      return btn;
+    }
+
+    function addButtons(codeBlockSelector, btn) {
+      document.querySelectorAll(codeBlockSelector).forEach(function (code) {
+        code.parentNode.appendChild(btn.cloneNode(true));
+      });
+    }
+
+    const copyIcon =
+      '<svg width="12" height="12" viewBox="340 364 14 15" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M342 375.974h4v.998h-4v-.998zm5-5.987h-5v.998h5v-.998zm2 2.994v-1.995l-3 2.993 3 2.994v-1.996h5v-1.995h-5zm-4.5-.997H342v.998h2.5v-.997zm-2.5 2.993h2.5v-.998H342v.998zm9 .998h1v1.996c-.016.28-.11.514-.297.702-.187.187-.422.28-.703.296h-10c-.547 0-1-.452-1-.998v-10.976c0-.546.453-.998 1-.998h3c0-1.107.89-1.996 2-1.996 1.11 0 2 .89 2 1.996h3c.547 0 1 .452 1 .998v4.99h-1v-2.995h-10v8.98h10v-1.996zm-9-7.983h8c0-.544-.453-.996-1-.996h-1c-.547 0-1-.453-1-.998 0-.546-.453-.998-1-.998-.547 0-1 .452-1 .998 0 .545-.453.998-1 .998h-1c-.547 0-1 .452-1 .997z" fill-rule="evenodd"/></svg>';
+
+    addButtons(
+      '.hljs',
+      button('Copy', 'Copy code to clipboard', copyIcon, 'btnClipboard'),
+    );
+
+    const clipboard = new ClipboardJS('.btnClipboard', {
+      target: function (trigger) {
+        return trigger.parentNode.querySelector('code');
+      },
+    });
+
+    clipboard.on('success', function (event) {
+      event.clearSelection();
+      const textEl = event.trigger.querySelector('.btnIcon__label');
+      textEl.textContent = 'Copied';
+      setTimeout(function () {
+        textEl.textContent = 'Copy';
+      }, 2000);
+    });
+  });
+
+</script>

--- a/templates/default.html
+++ b/templates/default.html
@@ -73,8 +73,10 @@
     <script src="/dist/main.js"></script>
     {% include "_track.html" %}
     {% include "_algolia.html" %}
+    {% include "_copy_code_block.html" %}
     {% if extras == "devices-js" %}
       {% include "_devices.html" %}
     {% endif %}
+    
   </body>
 </html>


### PR DESCRIPTION
Quick Hack Friday project implementing a copy code button based on the Docusaurus implementation here https://gist.github.com/yangshun/55db997ed0f8f4e6527571fc3bee4675. Simply adds a Copy button to any fenced code block as shown below.

![copy-code](https://user-images.githubusercontent.com/135382/76107701-15906200-5f8e-11ea-8efa-8861696c5965.gif)

Change-type: patch
Connects-to: #633
Signed-off-by: Gareth Davies <gareth@balena.io>