### PR TITLE
Remove IoT2000 from Getting Started Guide

### DIFF
--- a/config/dictionaries/device.json
+++ b/config/dictionaries/device.json
@@ -1118,26 +1118,6 @@
     ]
   },
   {
-    "id": "iot2000",
-    "name": "Siemens IOT2000",
-    "arch": "i386-nlp",
-    "bootMedia": "SD card",
-    "state": "NEW",
-    "machine": "iot2000",
-    "community": false,
-    "icon": "/img/device/iot2000.svg",
-    "instructions": [{
-        "i": "Write the OS file you downloaded to an SD card. We recommend using <a href=\"http://www.etcher.io/\">Etcher</a>."
-      },
-      {
-        "i": "Insert the freshly burnt SD card into the Siemens IOT2000."
-      },
-      {
-        "i": "Connect your Siemens IOT2000 to the internet, then power it up."
-      }
-    ]
-  },
-  {
     "id": "ts4900",
     "name": "Technologic TS-4900",
     "arch": "armv7hf",


### PR DESCRIPTION
Based on the internal discussion here: https://www.flowdock.com/app/rulemotion/resin-devices/threads/kpB0Ea03TYV973gdqY_WPAUOkAL

Change-type: patch
Signed-off-by: Gareth Davies <gareth@balena.io>