### PR TITLE
Pull in SDK deprecation policy

### DIFF
--- a/config/navigation.txt
+++ b/config/navigation.txt
@@ -133,5 +133,6 @@ Reference
   SDKs
     Node.js SDK[/reference/sdk/node-sdk]
     Python SDK[/reference/sdk/python-sdk]
+    Deprecation Policy[/reference/sdk/deprecation-policy] 
 
   Device Diagnostics[/reference/diagnostics]

--- a/pages/reference/sdk/.gitignore
+++ b/pages/reference/sdk/.gitignore
@@ -1,1 +1,0 @@
-!.gitignore

--- a/pages/reference/sdk/deprecation-policy.md
+++ b/pages/reference/sdk/deprecation-policy.md
@@ -1,0 +1,7 @@
+---
+title: {{ $names.company.upper }} SDK deprecation policy
+---
+
+# {{ $names.company.upper }} SDK deprecation policy
+
+{{>"sdk/deprecation-policy"}}

--- a/shared/sdk/.gitignore
+++ b/shared/sdk/.gitignore
@@ -1,0 +1,1 @@
+!gitignore

--- a/tools/fetch-external.sh
+++ b/tools/fetch-external.sh
@@ -23,6 +23,14 @@ cd pages/reference/sdk/ && {
   cd -
 }
 
+# get SDK README
+cd shared/sdk/ && {
+  curl -O -L https://raw.githubusercontent.com/balena-io/balena-sdk/master/README.md
+  # Extract deprecation text
+  ../../tools/extract-markdown.sh "Deprecation policy" < README.md > deprecation-policy.md
+  cd -
+}  
+
 # get latest supervisor API docs
 cd pages/reference/supervisor/ && {
   curl -O -L https://github.com/balena-io/balena-supervisor/raw/master/docs/API.md


### PR DESCRIPTION
Depends-on: https://github.com/balena-io/balena-sdk/pull/892

This will pull in the SDK deprecation policy as a partial. Requires balena-io/balena-sdk/pull/892 to be merged as pulling from master. Tested the above branch and looks like this:

<img width="1563" alt="CleanShot 2020-04-23 at 12 53 59@2x" src="https://user-images.githubusercontent.com/135382/80143461-b0a2c280-8561-11ea-9b8c-38d035a8d727.png">

Change-type: patch
Signed-off-by: Gareth Davies <gareth@balena.io>