### PR TITLE
Use S3 logo URL for supported device types

### DIFF
--- a/templates/_devices.html
+++ b/templates/_devices.html
@@ -43,7 +43,7 @@
             }
             tableCell =
               "<tr> <td>" +
-              "<img class='device_icon' src='/docs/img/device/" + deviceType.slug + ".svg' />" +
+              `<img class='device_icon' src="${deviceType.logo}" />` +
               "</td> <td>" +
               deviceType.name +
               "</td> <td>" +


### PR DESCRIPTION
The getting started still uses a .json as a source of truth, but at least this one is out of the way.

Change-type: patch
Signed-off-by: Stevche Radevski <stevche@balena.io>