### PR TITLE
Revert using S3 images for supported device types

### DIFF
--- a/templates/_devices.html
+++ b/templates/_devices.html
@@ -43,7 +43,7 @@
             }
             tableCell =
               "<tr> <td>" +
-              `<img class='device_icon' src="${deviceType.logo}" />` +
+              "<img class='device_icon' src='/docs/img/device/" + deviceType.slug + ".svg' />" +
               "</td> <td>" +
               deviceType.name +
               "</td> <td>" +


### PR DESCRIPTION
Earlier I didn't run it in watch mode and I thought all of them work :/
It turns out we still don't have logos in S3 for all device types (when I ran it without watch mode, it seemed like there are for all of them), and half-baked solution will only make it more messy than it already is.
Once we resolve the issue on where the images are stored and we have fully
migrated to it, I'll revisit this.

Change-type: patch
Signed-off-by: Stevche Radevski <stevche@balena.io>