### PR TITLE
Add supervisor upgrades doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ pages/reference/balena-cli.md
 pages/reference/sdk/node-sdk.md
 pages/reference/sdk/python-sdk.md
 pages/reference/supervisor/supervisor-api.md
+pages/reference/supervisor/supervisor-upgrades.md
 pages/learn/deploy/release-strategy/update-locking.md
 pages/reference/diagnostics.md
 pages/learn/develop/integrations/google-iot.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ This will allow the system to automatically version the documentation using the 
 It is also worth noting that some of the reference documentation is sourced from the individual component repositories and should be updated at the source.
 
 Currently the following reference material is pulled from other repos:
-- [Device Supervisor API](https://www.balena.io/docs/reference/supervisor/supervisor-api/) sourced from https://github.com/balena-io/balena-supervisor/tree/master/docs
+- [Device Supervisor API](https://www.balena.io/docs/reference/supervisor/supervisor-api/) and [Device Supervisor upgrades](https://www.balena.io/docs/reference/supervisor/supervisor-upgrades), sourced from https://github.com/balena-io/balena-supervisor/tree/master/docs
 - [CLI](https://www.balena.io/docs/reference/cli/) sourced from https://github.com/balena-io/balena-cli/blob/master/doc/cli.markdown
 - [Node SDK](https://www.balena.io/docs/reference/sdk/node-sdk/) sourced from https://github.com/balena-io/balena-sdk/blob/master/DOCUMENTATION.md
 - [Python SDK](https://www.balena.io/docs/reference/sdk/python-sdk/) sourced from https://github.com/balena-io/balena-sdk-python/blob/master/DOCUMENTATION.md

--- a/config/index.coffee
+++ b/config/index.coffee
@@ -5,7 +5,7 @@ PARTIALS_DIR = 'shared'
 DYNAMIC_DOCS = /.*(getting-started|overview|network).*/
 
 # These files are pulled in externally and so cannot be edited in the base repo
-EXTERNAL_DOCS = /.*(python-sdk|node-sdk|balena-cli|supervisor-api|update-locking|diagnostics|google-iot|azure-iot-hub|cli-masterclass|advanced-cli|host-os-masterclass|services-masterclass|fleet-management|device-debugging|docker-masterclass).*/
+EXTERNAL_DOCS = /.*(python-sdk|node-sdk|balena-cli|supervisor-api|supervisor-upgrades|update-locking|diagnostics|google-iot|azure-iot-hub|cli-masterclass|advanced-cli|host-os-masterclass|services-masterclass|fleet-management|device-debugging|docker-masterclass).*/
 
 FB_APP_ID = '221218511385682'
 

--- a/config/links.coffee
+++ b/config/links.coffee
@@ -33,6 +33,7 @@ module.exports =
     "node-sdk": 'https://github.com/balena-io/balena-sdk/edit/master/DOCUMENTATION.md'
     "balena-cli": 'https://github.com/balena-io/balena-cli/edit/master/doc/cli.markdown'
     "supervisor-api": 'https://github.com/balena-io/balena-supervisor/edit/master/docs/API.md'
+    "supervisor-upgrades": 'https://github.com/balena-io/balena-supervisor/edit/master/docs/upgrades.md'
     "update-locking": "https://github.com/balena-io/balena-supervisor/edit/master/docs/update-locking.md"
     "diagnostics": "https://github.com/balena-io/device-diagnostics/edit/master/diagnostics.md"
     "google-iot": "https://github.com/balenalabs/google-iot/edit/master/README.md"

--- a/config/navigation.txt
+++ b/config/navigation.txt
@@ -120,6 +120,7 @@ Reference
     Supervisor API[/reference/supervisor/supervisor-api]
     [/reference/supervisor/bandwidth-reduction]
     [/reference/supervisor/docker-compose]
+    Upgrade Policy[/reference/supervisor/supervisor-upgrades]
 
   Base images
     [/reference/base-images/base-images]

--- a/tools/fetch-external.sh
+++ b/tools/fetch-external.sh
@@ -38,6 +38,13 @@ cd pages/reference/supervisor/ && {
   cd -
 }
 
+# get latest supervisor upgrade docs
+cd pages/reference/supervisor/ && {
+  curl -O -L https://github.com/balena-io/balena-supervisor/raw/master/docs/upgrades.md
+  mv upgrades.md supervisor-upgrades.md
+  cd -
+}
+
 # get latest diagnostics docs
 cd pages/reference/ && {
   curl -O -L https://github.com/balena-io/device-diagnostics/raw/master/diagnostics.md


### PR DESCRIPTION
This includes documentation about supervisor upgrades in the docs website; this documentation was introduced [here](https://github.com/balena-io/balena-supervisor/pull/1376).

Note: instructions about how to perform the upgrade, along with a discussion of version constraints, will be added once https://github.com/balena-io/balena-ui/pull/3434 is merged.    

Connects-to: https://github.com/balena-io/balena/issues/2157
Change-type: minor
Signed-off-by: Hugh Brown <hugh@balena.io>