### PR TITLE
Add caveat for building ARM containers on x86

### DIFF
--- a/pages/reference/base-images/base-images.md
+++ b/pages/reference/base-images/base-images.md
@@ -237,7 +237,7 @@ This is a unique feature of balenalib ARM base images that allows you to run the
 ```Dockerfile
 FROM balenalib/armv7hf-debian
 
-RUN [ "cross-build-start" ]ilt
+RUN [ "cross-build-start" ]
 
 RUN apt-get update
 RUN apt-get install python-pip

--- a/pages/reference/base-images/base-images.md
+++ b/pages/reference/base-images/base-images.md
@@ -237,7 +237,7 @@ This is a unique feature of balenalib ARM base images that allows you to run the
 ```Dockerfile
 FROM balenalib/armv7hf-debian
 
-RUN [ "cross-build-start" ]
+RUN [ "cross-build-start" ]ilt
 
 RUN apt-get update
 RUN apt-get install python-pip
@@ -246,7 +246,7 @@ RUN pip install virtualenv
 RUN [ "cross-build-end" ]
 ```
 
-can be run on your x86 machine and there will be no `Exec format error`, which is the error when you run an ARM binary on x86. More details can be found in our [blog post here]({{ $links.mainSiteUrl }}/blog/building-arm-containers-on-any-x86-machine-even-dockerhub/). You can find the full source code for the two cross-build scripts [here]({{ $links.githubPlayground }}/armv7hf-debian-qemu).
+can run on your x86 machine and there will be no `Exec format error`, which is the error when you run an ARM binary on x86. This approach works only if the image is being built on x86 systems. Use the [`--emulated`](https://www.balena.io/docs/learn/deploy/deployment/#--emulated--e) flag in `balena push` to trigger a qemu emulated build targetting the x86 architecture. More details can be found in our [blog post here]({{ $links.mainSiteUrl }}/blog/building-arm-containers-on-any-x86-machine-even-dockerhub/). You can find the full source code for the two cross-build scripts [here]({{ $links.githubPlayground }}/armv7hf-debian-qemu).
 
 [udevd-link]:https://linux.die.net/man/8/udevd
 [entry-sh-link]:{{ $links.githubLibrary }}/base-images/blob/master/balena-base-images/armv7hf/debian/stretch/run/entry.sh


### PR DESCRIPTION
Pushing an ARM arch app with this config on native builders lead to errors. To avoid this we recommend users to not push this to balena builders, instead build the image on x86 systems.

Change-type: patch
@ab77 :eyes: 
Solves #1134 