### PR TITLE
Make explicit which key to use to determine NTP synchronization

### DIFF
--- a/pages/learn/develop/runtime.md
+++ b/pages/learn/develop/runtime.md
@@ -149,6 +149,8 @@ method return time=1474008856.507103 sender=:1.12 -> destination=:1.11 serial=4 
    ]
 ```
 
+The entry `NTPSynchronized` shows `true`, so the device is NTP synchronized.  (The key `NTP` only shows whether the device is using the systemd service `systemd-timesyncd`; starting from balenaOS 2.13.1, the `chrony` service is used for time management.)
+
 __Note:__ For additional dbus examples see the [{{$names.os.lower}} masterclass][os-masterclass]
 
 ### Blacklisting kernel modules won't work


### PR DESCRIPTION
This makes explicit which key should be used to determine whether a device is synchronized via NTP:  `NTPSynchronized`, not `NTP`.  This reflects the info at https://www.balena.io/docs/reference/OS/time/ -- however, that page refers to this one to show the DBus query to run to check synchronization, so it's good to have it here as well.

Change-type: patch
Signed-off-by: Hugh Brown <hugh@balena.io>