### PR TITLE
Make clear that python-dbus is only included in -build images

### DIFF
--- a/pages/reference/base-images/legacy-base-images.md
+++ b/pages/reference/base-images/legacy-base-images.md
@@ -1344,7 +1344,7 @@ This is a set of images with node.js binary installed. The node images come in m
 Python is an interpreted, interactive, object-oriented, open-source programming language. It incorporates modules, exceptions, dynamic typing, very high level dynamic data types, and classes. Python combines remarkable power with very clear syntax. It has interfaces to many system calls and libraries, as well as to various window systems, and is extensible in C or C++. It is also usable as an extension language for applications that need a programmable interface. Finally, Python is portable: it runs on many Unix variants, on the Mac, and on Windows 2000 and later.
 [wikipedia.org/wiki/Python_(programming_language)][python-wiki]
 
-__Note:__ `pip, python-dbus, virtualenv, setuptools` are preinstalled in all python images.
+__Note:__ `pip, virtualenv, setuptools` are preinstalled in all python images.  `python-dbus` is preinstalled in all python -build images.
 
 #### Variants:
 

--- a/shared/network/2.x.md
+++ b/shared/network/2.x.md
@@ -287,7 +287,7 @@ WiFi Connect enables the device to create a wireless access point called `WiFi C
 
 Under the hood, WiFi Connect is interacting with **NetworkManager** via its [DBUS][dbus-link] API. The DBUS API is a useful way to interact with the {{ $names.os.lower }} host NetworkManager, and there are DBUS bindings for most languages. Below is a minimal Python example from the [**NetworkManager** examples][network-manager-examples], which creates a new **NetworkManager** connection file that can be used to enable connecting to a new WiFi access point.
 
-__Note:__ You will need to install the `dbus` module in order to run this example (`apt-get install python-dbus`) and make sure `DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket` is exported in the environment. This ensures that DBUS calls are directed to the system bus that the host OS is listening on rather than the DBUS bus in your container. If you are using our [Python base images][python-base-images], then you do not have to install the `dbus` module, since it is already included there.
+__Note:__ You will need to install the `dbus` module in order to run this example (`apt-get install python-dbus`) and make sure `DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket` is exported in the environment. This ensures that DBUS calls are directed to the system bus that the host OS is listening on rather than the DBUS bus in your container. If you are using our [Python build images][python-build-images], then you do not have to install the `dbus` module, since it is already included there.
 
 ```
 #!/usr/bin/env python
@@ -429,5 +429,6 @@ custom endpoints, the URL, expected response, and check interval can be set in `
 [redsocks]:https://github.com/darkk/redsocks
 [redsocks-conf-example]:https://github.com/darkk/redsocks/blob/master/redsocks.conf.example
 [python-base-images]:/reference/base-images/base-images/
+[python-build-images]:/reference/base-images/base-images/#run-vs-build
 [nm-connectivity]:https://manpages.debian.org/jessie/network-manager/NetworkManager.conf.5.en.html#CONNECTIVITY_SECTION
 [meta-balena-connectivity]:{{ $links.githubOS }}/meta-balena#connectivity


### PR DESCRIPTION
This clarifies that the `python-dbus` module is only included in python `-build` image.

Change-type: patch
Connects-to: #1505
Connects-to: https://github.com/balena-os/balena-os/issues/552
Signed-off-by: Hugh Brown <hugh@balena.io>