### PR TITLE
2.x.md: fix broken nm-setting-ref link

### DIFF
--- a/shared/network/2.x.md
+++ b/shared/network/2.x.md
@@ -415,7 +415,7 @@ custom endpoints, the URL, expected response, and check interval can be set in `
 
 <!-- links -->
 
-[nm-setting-ref]:https://developer.gnome.org/NetworkManager/stable/nm-settings.html
+[nm-setting-ref]:https://developer.gnome.org/NetworkManager/stable/ref-settings.html
 [eduroam-ref]:https://www.eduroam.org
 [nm-gsm-setting-ref]:https://developer.gnome.org/NetworkManager/stable/settings-gsm.html
 [connman-link]:https://01.org/connman


### PR DESCRIPTION
[nm-settings-ref] was attempting to link to
https://developer.gnome.org/NetworkManager/stable/nm-settings.html
whereas the best match URL now seems to be
https://developer.gnome.org/NetworkManager/stable/ref-settings.html

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>