### PR TITLE
Rename resin-logo.png to balena-logo.png

### DIFF
--- a/pages/reference/OS/advanced.md
+++ b/pages/reference/OS/advanced.md
@@ -119,7 +119,7 @@ dtoverlay=i2c-rtc,ds1307
 
 To disable the Raspberry Pi rainbow splash screen, add the `disable_splash=1` entry to `config.txt`.
 
-__Note:__ This setting disables the Raspberry Pi rainbow splash screen but does not disable the {{ $names.company.lower }} logo splash screen. If you would like to replace the {{ $names.company.lower }} logo with your custom splash logo, replace `splash/resin-logo.png` located in the [boot partition][boot-partition] of the image.
+__Note:__ This setting disables the Raspberry Pi rainbow splash screen but does not disable the {{ $names.company.lower }} logo splash screen. If you would like to replace the {{ $names.company.lower }} logo with your custom splash logo, replace `splash/balena-logo.png` located in the [boot partition][boot-partition] of the image. Note that this file may be called `resin-logo.png` on older releases.
 
 [boot-partition]:/reference/OS/overview/2.x/#image-partition-layout
 [cli]:/reference/cli/reference/balena-cli/#envs

--- a/shared/overview/2.x.md
+++ b/shared/overview/2.x.md
@@ -42,9 +42,9 @@ To persist logs on the device, enable persistent logging via the [fleet configur
 
 Both development and production versions of {{ $names.os.lower }} allow the setting of a custom [hostname][config-json-hostname] via `config.json`, by setting `"hostname": "my-new-hostname"`. Your device will then broadcast (via Avahi) on the network as `my-new-hostname.local`. If you don't set a custom hostname, the device will default to `<short-UUID>.local`. You can also set a custom hostname via the [Supervisor API][supervisor-api] on device.
 
-On production images, nothing is written to tty1, on boot you should only see the {{ $names.company.lower }} logo, and this will persist until your application code takes over the framebuffer. If you would like to replace the {{ $names.company.lower }} logo with your own custom splash logo, then you will need to replace the `splash/resin-logo.png` file that you will find in the [first partition][partition] of the image (boot partition or `resin-boot`) with your own logo.
+On production images, nothing is written to tty1, on boot you should only see the {{ $names.company.lower }} logo, and this will persist until your application code takes over the framebuffer. If you would like to replace the {{ $names.company.lower }} logo with your own custom splash logo, then you will need to replace the `splash/balena-logo.png` file that you will find in the [first partition][partition] of the image (boot partition or `resin-boot`) with your own logo.
 
-__Note:__ As it currently stands, plymouth expects the image to be named `resin-logo.png`.
+__Note:__ As it currently stands, plymouth expects the image to be named `balena-logo.png`. This file was called `resin-logo.png` on older releases.
 
 When a {{ $names.os.lower }} image is downloaded from the {{ $names.cloud.lower }} dashboard, it contains a provisioning key that allows devices flashed with the image to be added to a specific application, and a device API key generated. As such, you should handle such images downloaded from {{ $names.cloud.lower }} with care as anyone with access to the image can add a device to your application. You can find out more about the access restrictions of a device API key [here][security].
 


### PR DESCRIPTION
The OS is rebranding the splash image file from v2.51 onwards.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>