### PR TITLE
networking: devices no longer require access to DockerHub

### DIFF
--- a/shared/network/2.x.md
+++ b/shared/network/2.x.md
@@ -358,8 +358,6 @@ Each of these should work with outward only (and inward once outward connection 
 
 Additionally, you should whitelist the following domains for the relevant ports above:
 * `*.{{ $names.cloud_domain }}`
-* `*.docker.com`
-* `*.docker.io`
 
 NTP / UDP packets (port 123) are exchanged with:
 
@@ -372,7 +370,7 @@ NTP / UDP packets (port 123) are exchanged with:
 default and in addition to DNS servers obtained via DHCP (balenaOS may issue queries to multiple
 DNS servers simultaneously, for the quickest response to be used). If additional DNS servers are
 configured via DHCP or other means, it is OK for the local network to block requests to `8.8.8.8`.
-To avoid any requests being made to `8.8.8.8` by balenaOS, modify the 
+To avoid any requests being made to `8.8.8.8` by balenaOS, modify the
 [dnsServers setting]({{ $links.githubOS }}/meta-balena#dnsservers) in `config.json`.
 
 __Note:__ {{>"general/country-firewall"}}


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Matthew McGinn <matthew@balena.io>