### PR TITLE
Prevent params in URL from breaking redirect rules

### DIFF
--- a/config/redirects.txt
+++ b/config/redirects.txt
@@ -7,7 +7,7 @@
 ^\/pages\/(.*) -> /$1
 (.*)\.md(.*) -> $1$2
 ^\/introduction\/introduction\/?(\?.+)?(#.+)?$ -> /learn/welcome/introduction/$1$2
-^\/$ -> /learn/welcome/introduction
+^\/?(\?.+)?(#.+)?$ -> /learn/welcome/introduction/$1$2
 ^\/installing\/gettingStarted\/?(\?.+)?(#.+)?$-> /learn/getting-started/raspberrypi3/nodejs/$1$2
 ^\/installing\/gettingStarted-BBB\/?(\?.+)?(#.+)?$ -> /learn/getting-started/beaglebone-black/nodejs/$1$2
 ^\/installing\/gettingStarted-Humming\/?(\?.+)?(#.+)?$ -> /learn/getting-started/hummingboard/nodejs/$1$2


### PR DESCRIPTION
The regex that matches root path did not match if any parameters were added. This caused the docs to redirect to 404 if you visit website.com/docs?thing=1.

I also made sure that parameters are added to the redirected URL.

Change-type: patch
Signed-off-by: Miguel Casqueira <miguel@balena.io>