### PR TITLE
meta: remove some outgoing codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @shaunmulligan @xginn8 @jtonello @vipulgupta2048
+*       @xginn8 @vipulgupta2048


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Matthew McGinn <matthew@balena.io>