### PR TITLE
Fix MS Azure link in the sidebar

### DIFF
--- a/config/navigation.txt
+++ b/config/navigation.txt
@@ -49,7 +49,7 @@ Learn
       Amazon AWS IoT[/learn/develop/integrations/aws]
       Google IoT[/learn/develop/integrations/google-iot]
       IBM Bluemix[/learn/develop/integrations/bluemix]
-      Microsoft Azure[/learn/develop/integrations/azure]
+      Microsoft Azure[/learn/develop/integrations/azure-iot-hub]
 
   DEPLOY
     [/learn/deploy/deployment]


### PR DESCRIPTION
component: Fix `Microsoft Azure` link in the sidebar

Change-type: patch
Signed-off-by: Genadi Naydenov <genadi@balena.com>

Resolves #1631 