### PR TITLE
Make it clearer that "balena ssh" requires adding an SSH key to balenaCloud.

### DIFF
--- a/pages/learn/deploy/deployment.md
+++ b/pages/learn/deploy/deployment.md
@@ -127,7 +127,7 @@ The `--source` flag allows you do define a path to your source code folder. You 
 
 The `git push {{$names.company.lower}} master` method of deployment is the original deployment mechanism for {{$names.cloud.lower}}. While we continue to support git push, it is considered a legacy method for pushing code to an application, and if possible you should use [{{$names.company.lower}} push](#balena-push) as it makes for a consistent workflow and methodology.
 
-The `git push` workflow requires that you have [git][git] installed on your development machine and that you have an SSH key setup on your {{$names.cloud.lower}} account.
+The `git push` workflow requires that you have [git][git] installed on your development machine and that you have an SSH key [setup on your {{$names.cloud.lower}} account][add-ssh-key].
 
 ![how git push works](/img/common/deployment/git-push.png)
 
@@ -283,8 +283,9 @@ Much like with the device list, [filters][filters] can be added to the release l
 
 [Saved views][saved-views] can also be created to return to a specific collection of filters.
 
-[api]:/reference/api/overview/
+[add-ssh-key]:/learn/manage/ssh-access/#add-an-ssh-key-to-balenacloud
 [amd64]:https://en.wikipedia.org/wiki/X86-64
+[api]:/reference/api/overview/
 [app-types]:/learn/manage/app-types
 [arm]:https://en.wikipedia.org/wiki/ARM_architecture
 [continuous-deployment]:https://en.wikipedia.org/wiki/Continuous_deployment

--- a/shared/general/container-ssh.md
+++ b/shared/general/container-ssh.md
@@ -18,7 +18,7 @@ __Note:__ To copy and paste in the terminal window, you cannot use the normal Ct
 
 __Note:__ `balena ssh` to application services/containers requires CLI version 11 or above.
 
-If you prefer to work from the command line, you can use [`{{ $names.company.short }} ssh`][balena-ssh] to connect to your application containers and the host OS. First, you will need to install the [{{ $names.company.lower }} Command Line Interface (CLI)](/tools/cli/). Once that is set up, run the following in your development machine's terminal:
+If you prefer to work from the command line, you can use [`{{ $names.company.short }} ssh`][balena-ssh] to connect to your application containers and the host OS. First, you will need to install the [{{ $names.company.lower }} Command Line Interface (CLI)](/tools/cli/). Next, you must have a SSH key configured on your development machine and [added to the {{ $names.cloud.lower }} dashboard][add-ssh-key]. Once that is set up, run the following in your development machine's terminal:
 
 ```shell
 $ {{ $names.company.short }} ssh <device-uuid>
@@ -34,7 +34,7 @@ This also works in multicontainer applications, simply pass the name of the appr
 
 __Note:__ To run a command in a non-interactive way, you can pipe commands to the CLI's stdin. For example, `echo "uptime; exit;" | balena ssh <device-uuid>`.
 
-When an application name or device UUID is used as above, `{{ $names.company.short }}` ssh uses the {{ $names.company.short }} VPN to create a secure tunnel to the device and then forward SSH traffic between the device and your development machine. For this method, you must have a SSH key configured on your development machine and [added to the {{ $names.cloud.lower }} dashboard][add-ssh-key].
+When an application name or device UUID is used as above, `{{ $names.company.short }}` ssh uses the {{ $names.company.short }} VPN to create a secure tunnel to the device and then forward SSH traffic between the device and your development machine.
 
 If an IP address or a .local hostname is used (instead of an application name or device UUID), `{{ $names.company.short }}` ssh establishes a direct connection that does not rely on the {{ $names.company.short }} VPN:
 


### PR DESCRIPTION
Also, link to the procedure on how to add an SSH key to the account.

Change-type: patch
Signed-off-by: Carlo Miguel Cruz <carloc@balena.io>