### PR TITLE
Update proxy documentation section

### DIFF
--- a/shared/network/2.x.md
+++ b/shared/network/2.x.md
@@ -377,31 +377,36 @@ __Note:__ {{>"general/country-firewall"}}
 
 ## Connecting Behind a Proxy
 
-We use **[redsocks][redsocks]** to connect your device to {{ $names.company.lower }} from behind a proxy. To enable, a `redsocks.conf` file should be added at `/mnt/boot/system-proxy/`, specifying the needed proxy configuration:
+We use **[redsocks](https://github.com/darkk/redsocks)** to connect your device to {{ $names.company.lower }} from behind a proxy. There are two ways to enable redsocks proxy. The preferred method is through Supervisor's `GET/PATCH /v1/device/host-config` endpoints - more info may be found <a href="https://www.balena.io/docs/reference/supervisor/supervisor-api/#patch-v1devicehost-config" target="_blank">here</a>. 
 
-```
+Alternatively, a `redsocks.conf` file should be added at `/mnt/boot/system-proxy/`, specifying the needed proxy configuration:
+
+```apache
 base {
-log_debug = off;
-log_info = on;
-log = "syslog:local7";
-daemon = off;
-redirector = iptables;
+    log_debug = off;
+    log_info = on;
+    log = stderr;
+    daemon = off;
+    redirector = iptables;
 }
 
 redsocks {
-type = socks5;
-ip = <SERVER IP>;
-port = 8123;
-local_ip = 127.0.0.1;
-local_port = 12345;
+    type = socks5;
+    ip = <SERVER IP>;
+    port = 8123;
+    local_ip = 127.0.0.1;
+    local_port = 12345;
+    login = "<YOUR_USERNAME>";
+	password = "<YOUR_PASSWORD>";
 }
 ```
 
-Be sure that:
+Note that:
 
-— File logging (`log = "file:/var/log/redsocks";`) is not used. It will lead to permission problems.
+- File logging (`log = "file:/var/log/redsocks";`) is not used. It will lead to permission problems.
 - `daemon = off` is set, so that **redsocks** doesn’t fork.
 - `local_port = 12345` is set, so that the iptables rules and **redsocks** port match.
+- Available redsocks types include `socks4`, `socks5`, `http-connect`, and `http-relay`.
 
 Additionally, a `/mnt/boot/system-proxy/no_proxy` file can be added with a newline-separated list of IPs or subnets to not route through the proxy.
 


### PR DESCRIPTION
Section should now reflect that the preferred method for enabling
redsocks is through the related Supervisor endpoints. Links have
been added. If the user prefers to not use the endpoints, the docs
for adding redsocks without touching the Supervisor API have also
been clarified.

Change-type: patch
Signed-off-by: Christina Wang <christina@balena.io>