### PR TITLE
Adds shared Ethernet example for NM, under 'Networking'

### DIFF
--- a/shared/network/2.x.md
+++ b/shared/network/2.x.md
@@ -136,6 +136,28 @@ method=auto
 method=auto
 ```
 
+## Ethernet Setup
+
+Out of the box, Ethernet should work without requiring any specific configuration for **Network Manager**. There are some instances where you may wish to customize your configuration, such as with sharing a network connection from a WiFi access point to another device connected with Ethernet.
+
+Below is an example for sharing a network connection to another device attached by Ethernet:
+
+```
+[connection]
+id=shared-ethernet
+type=ethernet
+interface-name=eth0
+
+[ipv4]
+method=shared
+
+[ipv6]
+method=shared
+```
+
+__Note:__ Ensure to specify the `interface-name`, for instance `eth0`.
+
+
 ## Regulatory Domain
 
 By default, the WiFi regulatory domain for your device is not set until it is connected to a network. If you need your device to connect at first boot to channels that may be restricted in some countries, you can specify the regulatory domain in the `config.json` file (like the above WiFi settings, this is found in the boot partition). Regulatory domain is set using the `country` field.


### PR DESCRIPTION
Resolves issue #1659 for shared Ethernet example using Network Manager config file.

Change-type: minor
Signed-off-by: Alex Bucknall <alexbucknall@balena.io>