### PR TITLE
Add a periodic GitHub action to scan markdown files for broken hyperlinks

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,0 +1,52 @@
+name: Periodic link checker
+
+on:
+  # Check links once a week on Monday
+  schedule:
+    - cron: "0 0 * * 1"
+
+jobs:
+  unit:
+    name: Run link checker
+    runs-on: ubuntu-latest
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.0.6
+        with:
+          # balena base images account for ~1400 request to GitHub, they are
+          # omitted to avoid being rate limited.
+          # See https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting
+          # The openvpn link is omitted as trying to auto chek it results in
+          # a 503, even when it is available.
+          # The meta-balena link is included in parameterized scripts and as
+          # a result will always produce a failing link.
+          # The myorg/myapp link is a dummy address used in an example contract,
+          # so is omitted.
+          args: >
+            --exclude-mail
+            --exclude
+            localhost
+            127.0.0.1
+            https://github.com/balena-io-library/base-images
+            https://community.openvpn.net/openvpn
+            https://raw.githubusercontent.com/balena-os/meta-balena
+            https://github.com/myorg/myapp
+            https://index.docker.io/v2/
+            git://github.com/
+            --verbose
+            --no-progress
+            --max-concurrency 20
+            --github-token ${{ secrets.GITHUB_TOKEN }}
+            **/*.md
+
+      - name: Create Issue From File
+        uses: peter-evans/create-issue-from-file@v2
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue


### PR DESCRIPTION

Fixes #1621

This PR adds a GitHub action that will scan the codebase for broken
links once a week on Monday.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>