### PR TITLE
Pin the base image to nodejs 14 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM node:latest
+FROM node:14
 
 WORKDIR /src
 
-COPY package.json package-lock.json ./ 
+COPY package.json package-lock.json ./
 RUN npm ci
 
 COPY . .

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "5.10.6",
   "engines": {
-    "node": "^10.0.0"
+    "node": "^14.0.0"
   },
   "description": "This repo contains our public-facing documentation.",
   "main": "index.js",


### PR DESCRIPTION
This avoids potential issues with unexpectedly updating the nodejs
version

Change-type: patch