### PR TITLE
Updated ESR List

### DIFF
--- a/pages/reference/OS/extended-support-release.md
+++ b/pages/reference/OS/extended-support-release.md
@@ -40,11 +40,11 @@ __Note:__ Once updated to an ESR version, it is not possible to update from an E
 
 ESR host OS versions are currently available for the following devices with additional device support planned:
 
-* Raspberry Pi (v1 and Zero)
+* Raspberry Pi (v1 / Zero / Zero W)
 * Raspberry Pi 3
 * Raspberry Pi 4
-* Beaglebone
-* Balena Fin
+* Beaglebone Black
+* Balena Fin (CM3)
 * Intel NUC
 * Nvidia Jetson TX2
 


### PR DESCRIPTION
Added details:
* RPi v1 / Zero (+ /ZeroW)
* specified BB Black (not Green, etc.)
* specified Fin CM3 (in anticipation of CM4 model)

ESR support for Nano does not appear to exist though, so keeping it excluded from the list for now. Have asked for confirmation of where he saw support from reporter (dtischler) and will submit another PR if it is indeed supported.