### PR TITLE
Specify File Location for NM

### DIFF
--- a/shared/network/2.x.md
+++ b/shared/network/2.x.md
@@ -15,7 +15,9 @@
 
 With {{ $names.os.lower }} 2.0, connectivity management changed from **[ConnMan][connman-link]** to **[NetworkManager][networkmanager-link]**. **NetworkManager** allows {{ $names.os.lower }} more flexibility when configuring the network setup, and, in conjunction with **[ModemManager][modemmanager-link]**, allows {{ $names.os.lower }} to offer first class [GSM/Cellular support](#setup-a-cellular-connection).
 
-All of the network configuration for {{ $names.os.lower }} can be done though files in the boot partition of your device. If you have a freshly downloaded {{ $names.os.lower }} `.img`, you can mount it and inspect the `resin-boot` or `resin-flash` (for devices that boot from eMMC) partition. In the boot partition you will find a directory called `system-connections`.
+All of the network configuration for {{ $names.os.lower }} can be done through files in the boot partition of your device. If you have a freshly downloaded {{ $names.os.lower }} `.img`, you can mount it and inspect the `resin-boot` or `resin-flash` (for devices that boot from eMMC) partition. In the boot partition you will find a directory called `system-connections`.
+
+__Note:__ When editing files for connectivity in the boot partition, make sure you're in the `/mnt/boot/system-connections` folder so that they persist after reboot.
 
 The `system-connections` directory consists of a set of connection files—one file per connection. The file `resin-sample.ignore` is a template or example file which you can copy to create new connections. If you added a WiFi connection from the dashboard when you downloaded your image, you should see its configuration file already created for you under the name `resin-wifi`. You will notice that there is no file for ethernet, this is because **NetworkManager** will always set up a default ethernet connection. If you want a specific configuration for the ethernet connection you will need to create a new connection file for it. Most of the allowed options for these connection files can be found in the [**NetworkManager** settings reference][nm-setting-ref]
 


### PR DESCRIPTION
To prevent customers being confused about the location of files they need to edit in the boot partition, I've specified the location in a note below the second paragraph.