### PR TITLE
Remove old resin dashboard screenshot

### DIFF
--- a/shared/getting-started/getDeviceOnDash/beaglebone-black.md
+++ b/shared/getting-started/getDeviceOnDash/beaglebone-black.md
@@ -12,8 +12,6 @@ After a short while you should see your device pop up in the dashboard. It will 
 
 After the internal media has been flashed, your device will shut itself down. At this point you will see the device in a `Post-Provisioning` state and all its LEDs should be off. Before booting the device again, *make sure to remove the SD card*. You may then simply press the power button situated nearest to the ethernet port or pull out and replug the power cable.
 
-<img src="/img/beaglebone-black/beaglebone_device_dash_post_provisioning.png" width="80%">
-
 Your device should now start booting from internal eMMC and in a minute or so you should have a happy Beaglebone device in the `Idle` state on your dashboard. From here on you can deploy code to your device with ease.
 
 __Note:__ If you have an HDMI screen attached (Beaglebone Black only), you should see `"Booted - Check your {{ $names.company.lower }} dashboard."` on the screen when the device boots. If instead you see rainbow colors or a blank screen, it could mean that the SD card was not burned correctly or is corrupted. Try [burning the SD card](#create-a-bootable-sd-card) again. If the issue persists, come and get [help from our support team](/support/).


### PR DESCRIPTION
Remove old resin dashboard screenshot from Getting Started Guide

Change-type: patch