### PR TITLE
Stop generating lunr index as we no longer use it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 contents/
 node_modules/
 server/nav.json
-server/lunr_index.json
 npm-debug.log
 static/dist
 

--- a/config/doxx.coffee
+++ b/config/doxx.coffee
@@ -23,6 +23,6 @@ module.exports = {
   layoutLocals: config.layoutLocals
   parseNav: true
   serializeNav: path.join(root, 'server', 'nav.json')
-  buildLunrIndex: path.join(root, 'server', 'lunr_index.json')
+  buildLunrIndex: false
   pathPrefix: config.pathPrefix
 }

--- a/server/index.coffee
+++ b/server/index.coffee
@@ -36,8 +36,6 @@ app.use (req, res, next) ->
 getLocals = (extra) ->
   doxx.getLocals({ nav: navTree }, extra)
 
-doxx.loadLunrIndex()
-
 console.error('serving everything under pathPrefix:', "#{config.pathPrefix}")
 app.use("#{config.pathPrefix}/", express.static(contentsDir))
 


### PR DESCRIPTION
This should significantly speed up builds

Change-type: patch