### PR TITLE
Patch fetch-external script to not parallelize SDK docs

### DIFF
--- a/tools/fetch-external.sh
+++ b/tools/fetch-external.sh
@@ -8,21 +8,6 @@ cd pages/reference/ && {
   cd -
 } &
 
-# get latest node SDK docs
-cd pages/reference/sdk/ && {
-  curl -O -L https://github.com/balena-io/balena-sdk/raw/master/DOCUMENTATION.md
-  echo "# Balena Node.js SDK" >node-sdk.md
-  tail -n +2 DOCUMENTATION.md >>node-sdk.md
-  cd -
-} &
-
-# get latest python SDK docs
-cd pages/reference/sdk/ && {
-  curl -O -L https://github.com/balena-io/balena-sdk-python/raw/master/DOCUMENTATION.md
-  mv DOCUMENTATION.md python-sdk.md
-  cd -
-} &
-
 # get SDK README
 cd shared/sdk/ && {
   curl -O -L https://raw.githubusercontent.com/balena-io/balena-sdk/master/README.md
@@ -90,5 +75,20 @@ cd pages/learn/more/masterclasses/ && {
   mv README.md docker-masterclass.md
   cd -
 } &
+
+# get latest node SDK docs
+cd pages/reference/sdk/ && {
+  curl -O -L https://github.com/balena-io/balena-sdk/raw/master/DOCUMENTATION.md
+  echo "# Balena Node.js SDK" >node-sdk.md
+  tail -n +2 DOCUMENTATION.md >>node-sdk.md
+  cd -
+} 
+
+# get latest python SDK docs
+cd pages/reference/sdk/ && {
+  curl -O -L https://github.com/balena-io/balena-sdk-python/raw/master/DOCUMENTATION.md
+  mv DOCUMENTATION.md python-sdk.md
+  cd -
+} 
 
 wait


### PR DESCRIPTION
By parallelizing downloads, we ended up going so fast that DOCUMENATION.md files downloaded from the sources ended up being overwritten before being moved to their right location. This led us into a weird state of the Python SDK having NodeSDK docuentation. Resolved it by moving SDK download out of the parallel download.

Change-type: patch
Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>