### PR TITLE
Heroku: Install jq as part of the build runtime.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test-spelling": "find . -iname \"*.*md\" -not -path \"./CHANGELOG*\" -not -path \"./node_modules/*\" | ./tools/test-spelling.sh",
     "build": "./tools/prepare.sh && ./tools/build.sh && webpack -p",
     "build:fast": "./tools/build.sh && webpack -p",
+    "heroku-prebuild": "apt update && apt install jq -y && apt clean",
     "watch-pages": "watch ./tools/build.sh pages shared templates config",
     "watch-assets": "webpack -w",
     "watch": "npm run watch-pages & npm run watch-assets"

--- a/tools/fetch-external.sh
+++ b/tools/fetch-external.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # This script pulls in external documentation that should be edited in the corresponding upstream repo
 
+# Use node-jq if jq is not pre-installed in the environment nor set in path
+which jq && JQ="$(which jq)" || JQ="../../node_modules/node-jq/bin/jq"
+
 # get latest CLI docs
 cd pages/reference/ && {
   curl -O -L https://github.com/balena-io/balena-cli/raw/master/doc/cli.markdown
@@ -80,9 +83,9 @@ cd pages/learn/more/masterclasses/ && {
 cd shared/projects/ && {
   echo "Name|Description
 ---|---" | tee balena-labs-projects.md balena-example-projects.md balenablocks.md >/dev/null
-  curl https://api.github.com/orgs/balenalabs/repos?per_page=30 | ../../node_modules/node-jq/bin/jq -r 'sort_by(-.stargazers_count) |  (.[] | [.name,.html_url,.description] | "[\(.[0])](\(.[1]))|\(.[2] // "")") ' >>balena-labs-projects.md
-  curl https://api.github.com/orgs/balena-io-examples/repos?per_page=100 | ../../node_modules/node-jq/bin/jq -r 'sort_by(-.stargazers_count) |  (.[] | [.name,.html_url,.description] | "[\(.[0])](\(.[1]))|\(.[2] // "")") ' >>balena-example-projects.md
-  curl https://api.github.com/orgs/balenablocks/repos?per_page=30 | ../../node_modules/node-jq/bin/jq -r 'sort_by(-.stargazers_count) |  (.[] | [.name,.html_url,.description] | "[\(.[0])](\(.[1]))|\(.[2] // "")") ' >>balenablocks.md
+  curl https://api.github.com/orgs/balenalabs/repos?per_page=30 | $JQ -r 'sort_by(-.stargazers_count) |  (.[] | [.name,.html_url,.description] | "[\(.[0])](\(.[1]))|\(.[2] // "")") ' >>balena-labs-projects.md
+  curl https://api.github.com/orgs/balena-io-examples/repos?per_page=100 | $JQ -r 'sort_by(-.stargazers_count) |  (.[] | [.name,.html_url,.description] | "[\(.[0])](\(.[1]))|\(.[2] // "")") ' >>balena-example-projects.md
+  curl https://api.github.com/orgs/balenablocks/repos?per_page=30 | $JQ -r 'sort_by(-.stargazers_count) |  (.[] | [.name,.html_url,.description] | "[\(.[0])](\(.[1]))|\(.[2] // "")") ' >>balenablocks.md
   cd -
 } &
 


### PR DESCRIPTION
Adds the jq installation as part of the heroku-prebuild script.

Change-type: patch
Signed-off-by: Carlo Miguel Cruz <carloc@balena.io>