### PR TITLE
Specify "currently supported *devices*" to make it easier to search for

### DIFF
--- a/templates/devices.html
+++ b/templates/devices.html
@@ -6,7 +6,7 @@
   to discuss our custom hardware support packages.
 </div>
 
-<h2>Currently supported</h2>
+<h2>Currently supported devices</h2>
 
 <table>
   <thead>


### PR DESCRIPTION
I was searching for supported devices on the docs and could only find the ESR list, with this change it should be much easier to find the list of regular supported devices