### PR TITLE
fix broken links

### DIFF
--- a/shared/getting-started/whatYouNeed/odroid-xu4.md
+++ b/shared/getting-started/whatYouNeed/odroid-xu4.md
@@ -2,7 +2,7 @@ __Warning:__ HDMI is currently not supported on the Odroid XU4.
 
 <img style="float: right;padding-left: 10px;" src="/img/odroid-xu4/odroid-xu4.jpg">
 
-* An [Odroid XU4][odroidXU4-link] Cortex-A7 quad core from [Hardkernel][hardkernel-link] (the same process will work for the older [Odroid XU3][xu3-link]).
+* An [Odroid XU4][odroidXU4-link] Cortex-A7 quad core from [Hardkernel][hardkernel-link] (the same process will work for the older Odroid XU3).
 * A 4GB or larger SD card. The [Odroid XU4][odroidXU4-link] uses a microSD card. The [speed class][speed_class] of the card also matters - this determines its maximum transfer rate. We strongly recommend you get hold of a class 10 card or above.
 * A 5V, 4 Amp power supply unit from [Hardkernel][hardkernel-link] like this [one][XU4-PSU-link].
 * An ethernet cable or WiFi adapter to connect your device to the internet.


### PR DESCRIPTION
Fixes broken links from #1744

Does not fix:

Errors in pages/reference/base-images/base-images-ref.md
✗ https://hub.docker.com/r/balenalib/kitra520-debian-dotnet/tags (429 Too Many Requests)

Errors in pages/learn/develop/local-mode.md
✗ simple-server-node@1.0.0 (Invalid mail address: simple-server-node@1.0.0)
✗ ejs@3.0.1 (Invalid mail address: ejs@3.0.1)

Errors in pages/learn/deploy/deploy-with-balena-button.md
✗ https://raw.githubusercontent.com/myorg/myapp/main/logo.png (404 Not Found)

As they were not actual broken links.

Further notes:

* Banana Pi M1 is no longer being manufactured, so I just liked to the wiki page.
* C1+ is being discontinued


Change-type: patch