### PR TITLE
coral-dev: Mention alternate sd-card bootswitch configuration

### DIFF
--- a/shared/getting-started/getDeviceOnDash/coral-dev.md
+++ b/shared/getting-started/getDeviceOnDash/coral-dev.md
@@ -2,6 +2,8 @@
 
 Unplug the **{{ $device.name }}** and [change the boot mode switches][boot-switches] to `1:on` `2:off` `3:on` `4:on` to boot from the SD card. Insert the SD card into your **{{ $device.name }}** and then power on the board using a 2-3A power cable connected to the USB-C port labeled "PWR".
 
+__Note:__ Some units reportedly need all boot switches to be in the `off` position for the SD-CARD image to boot. If you encounter issues booting the BalenaOS SD-CARD image, please try setting the boot switches to `1:off` `2:off` `3:off` `4:off`.
+
 __Warning:__ This will completely erase the internal storage media, so make a backup first.
 
 When flashing is complete, your board will shutdown. Unplug the power, remove the SD card, and reset the boot switches to eMMC mode setting them to `1:on` `2:off` `3:off` `4:off`. Then power on the **{{ $device.name }}** again to boot the device from eMMC. It will take a minute or two for the **{{ $device.name }}** to appear on your {{ $names.company.lower }} [dashboard][dashboard].


### PR DESCRIPTION
Some units will boot from the SD-CARD only
if all bootswitches are set to off, as
reported by some of our users. Let's include
this information in our docs as it might help
troubleshoot flashing.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>

Fixes: https://github.com/balena-io/docs/issues/1519