### PR TITLE
Intel NUC Getting Started secure boot note

### DIFF
--- a/shared/getting-started/getDeviceOnDash/intel-nuc.md
+++ b/shared/getting-started/getDeviceOnDash/intel-nuc.md
@@ -10,6 +10,8 @@ Press the F10 key while the **BIOS** is loading in order to enter the boot menu.
 
 Once the device boots, you should see it pop up on your {{ $names.company.lower }} dashboard. It will immediately go into a `flashing internal media` state. This means that the device is flashing the {{ $names.os.lower }} onto your internal flash media.
 
+__Note:__ You might encounter an error message when the device boots with the text, "Image Authorization Fail". This message appears when Secure Boot is enabled. Follow the steps present in the [Intel support document](https://www.intel.com/content/www/us/en/support/articles/000038401/intel-nuc/intel-nuc-kits.html) to access the BIOS setup screen and disable secure boot. After saving, press the F10 key once again when the NUC reboots to enter the boot menu and select to boot from USB/resinOS.
+
 After a few minutes, the OS will be fully flashed to the internal media and the device will shut itself down. At this point, you will see on the dashboard that the device is in a `Post-provisioning` state. You can now remove the USB drive and press the power button once again.
 
 Your NUC should now automatically boot into the {{ $names.company.lower }} OS and you should see the device online and in an `Idle` state on your dashboard, ready and waiting for some code to be deployed.

--- a/shared/getting-started/getDeviceOnDash/intel-nuc.md
+++ b/shared/getting-started/getDeviceOnDash/intel-nuc.md
@@ -6,7 +6,7 @@ __Warning:__ {{ $names.os.upper }} will completely overwrite the internal media 
 
 Now connect up the power supply and turn the device on. The power button may be a small round button on the top of the device or a square button on the front.
 
-Press the F10 key while the **BIOS** is loading in order to enter the boot menu. Next, select the `UEFI : USB` option from the boot menu so that the device will boot from your USB drive.
+Press the F10 key while the **BIOS** is loading in order to enter the boot menu. Next, select the `UEFI : USB` (or `resinOS`) option from the boot menu so that the device will boot from your USB drive.
 
 Once the device boots, you should see it pop up on your {{ $names.company.lower }} dashboard. It will immediately go into a `flashing internal media` state. This means that the device is flashing the {{ $names.os.lower }} onto your internal flash media.
 


### PR DESCRIPTION
As described in #1816, my brand new Intel NUC 8i5BEH arrived with Secure Boot enabled, which resulted in an error at boot time. I don't know how likely it is for a user to encounter this error, but the severity is high because you can't even install the OS. 

This PR adds a Note to the Getting Started instructions that describes how to use the BIOS utility to disable secure boot and continue with balena OS installation. I also added another small commit to reflect the name shown for the USB device in the Intel Boot Menu.

I don't know our policy on documenting an error like this. Does the chance of a user encountering it justify breaking the flow for other users on the success path? I wrote the PR, so I'd say Yes, but leave it to the reviewers for a judgement.

Closes #1816