### PR TITLE
patch: Updated the list of domains that need to be whitelisted.

### DIFF
--- a/pages/faq/troubleshooting/faq.md
+++ b/pages/faq/troubleshooting/faq.md
@@ -77,6 +77,7 @@ Additionally, you should whitelist the following domains for the relevant ports 
 * `*.{{ $names.cloud_domain }}`
 * `*.docker.com`
 * `*.docker.io`
+* `*.amazonaws.com`
 
 ##### Can I use {{ $names.cloud.lower }} in countries with restrictive firewalls such as China?
 


### PR DESCRIPTION
In order for any device to be reachable via web-terminal or `balena ssh`, being able to reach balenaCloud VPN servers is indispensable.
Our VPN servers run on EC2 instances on AWS. It is safer & scalable to whitelist the entire amazonaws.com domain rather than whitelist individual EC2 instances or regions.

