### PR TITLE
Improve device status page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3236,7 +3236,7 @@
         },
         "htmlparser2": {
           "version": "3.8.3",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+          "resolved": "http://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
           "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
           "requires": {
             "domelementtype": "1",
@@ -3271,7 +3271,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",

--- a/pages/learn/manage/device-statuses.md
+++ b/pages/learn/manage/device-statuses.md
@@ -5,13 +5,13 @@ excerpt: Determine the status and connectivity of a device
 
 # Device statuses
 
-Device statuses are displayed on the devices page, and the device summary page. An overview of the devices statuses of an application is shown on the applications page. Each device can have one of the following statuses:
+Device statuses are displayed on the Devices page and the Device Summary page. An overview of the device statuses of an application is shown on the Applications page. Each device can have one of the following statuses:
 
 <img src="/img/common/main_dashboard/application_device_status.png" alt="Application device status" width="40%" >
 
 | Status                     | Description                                                                                                                                                     |
 |----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Online**                 | The device is online and is communicating with the cloud within the correct interval. In this state, the device is connected to the VPN, and has recent API communications. |
+| **Online**                 | The device is online and is communicating with the cloud within the correct interval. In this state, the device is connected to the VPN and has had recent API communications. |
 | **Online (VPN&#160;Only)**<sup>1</sup>      | The device is online, is connected to the VPN, but has **no recent API communications**.                                                       |
 | **Online (Heartbeat&#160;Only)**<sup>2</sup>| The device is online, has recent API communications, but is **not connected to the VPN**.                                                      |
 | **Offline**                | The device is offline.                                                                                                                                          |
@@ -25,19 +25,17 @@ Device statuses are displayed on the devices page, and the device summary page. 
 
 ![Device connectivity indicators](/img/common/main_dashboard/device_status.png)
 
-In addition to the device status, there are indicators to show if the device is having any partial connectivity issue. These indicators can be used to identify common issues, such as a firewall blocking VPN traffic or an inability of the device to communicate with the {{ $names.cloud.lower }} API.
-
-Some statuses may indicate partial connectivity issues:
+A device's status may include indicators of partial connectivity issues on the device, such as a firewall blocking VPN traffic or a device's inability to communicate with the {{ $names.cloud.lower }} API. These indicators are as follows:
  
 <sup>1</sup> `Online (VPN Only)` indicates that the device is unable to communicate with the {{ $names.cloud.lower }} API. 
 
-<sup>2</sup> `Online (Heartbeat Only)` indicates that device is unable to connect to the {{ $names.cloud.lower }} VPN (e.g. a firewall is blocking VPN traffic) and wouldn't be able to provide remote SSH connections to the device.
+<sup>2</sup> `Online (Heartbeat Only)` indicates that device is unable to connect to the {{ $names.cloud.lower }} VPN (e.g. a firewall is blocking VPN traffic), and won't be able to provide remote SSH connections.
 
 __Note:__ If the device is powered off or loses all network connectivity, it will remain in the `Online (Heartbeat Only)` state until the last target state fetch exceeds the device [API polling interval][poll-interval].
 
 ## Debugging Device Status
 
-If you find your device to be displaying a status which is unclear even with the above notes, visit the [device status][debugging-masterclass#device-status] section in [device debugging masterclass][debugging-masterclass] for more information and what it means for your application.
+If you find your device to be displaying a status which is unclear even with the above notes, visit the [device status][debugging-masterclass#device-status] section in the[device debugging masterclass][debugging-masterclass] for more information.
 
 [deactivated]: /learn/manage/billing/#inactive-devices
 [poll-interval]: /learn/manage/configuration/#variable-list

--- a/pages/learn/manage/device-statuses.md
+++ b/pages/learn/manage/device-statuses.md
@@ -5,35 +5,44 @@ excerpt: Determine the status and connectivity of a device
 
 # Device statuses
 
-The application overview page shows the status of each device in the application.
+Device statuses are displayed on the devices page, and the device summary page. An overview of the devices statuses of an application is shown on the applications page. Each device can have one of the following statuses:
 
 <img src="/img/common/main_dashboard/application_device_status.png" alt="Application device status" width="40%" >
 
-Each device can have one of the following statuses:
+| Status                     | Description                                                                                                                                                     |
+|----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Online**                 | The device is online and is communicating with the cloud within the correct interval. In this state, the device is connected to the VPN, and has recent API communications. |
+| **Online (VPN&#160;Only)**<sup>1</sup>      | The device is online, is connected to the VPN, but has **no recent API communications**.                                                       |
+| **Online (Heartbeat&#160;Only)**<sup>2</sup>| The device is online, has recent API communications, but is **not connected to the VPN**.                                                      |
+| **Offline**                | The device is offline.                                                                                                                                          |
+| **Configuring**            | The device is applying OS configuration.                                                                                                                        |
+| **Updating**               | The device is updating to a new application release.                                                                                                            |
+| **Post Provisioning**      | The device has been [provisioned][device-provisioning] but has not yet come online.                                                                             |
+| **Inactive**               | The device has been [deactivated][deactivated] or has been [preregistered][preregistered] but has not yet connected to the {{ $names.cloud.lower }} API.        |
+| **Frozen**                 | The device has been frozen because it's outside the organization's allowance, or is in a paid [application type][application type] on a free tier organization. |
 
-| Status            | Description                                                                                                                                                     |
-|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Online            | The device is online and is connected to the VPN or has recent API communications.                                                                              |
-| Configuring       | The device is applying OS configuration.                                                                                                                        |
-| Updating          | The device is updating to a new application release.                                                                                                            |
-| Offline           | The device is offline and is not connected to VPN and has not any recent API communications.                                                                    |
-| Post Provisioning | The device has been [provisioned][device-provisioning] but has not yet come online.                                                                             |
-| Inactive          | The device has been [deactivated][deactivated] or has been [preregistered][preregistered] but has not yet connected to the {{ $names.cloud.lower }} API.        |
-| Frozen            | The device has been frozen because it's outside the organization's allowance, or is in a paid [application type][application type] on a free tier organization. |
-
-## Device connectivity
+## Device Connectivty states
 
 ![Device connectivity indicators](/img/common/main_dashboard/device_status.png)
 
 In addition to the device status, there are indicators to show if the device is having any partial connectivity issue. These indicators can be used to identify common issues, such as a firewall blocking VPN traffic or an inability of the device to communicate with the {{ $names.cloud.lower }} API.
 
-For example, in case a device is connected to the API only, indicated by a status of Online (Heartbeat Only), you may still see logs being sent. This case indicates that the device is unable to connect to the {{ $names.cloud.lower }} VPN.
+Some statuses may indicate partial connectivity issues:
+ 
+<sup>1</sup> `Online (VPN Only)` indicates that the device is unable to communicate with the {{ $names.cloud.lower }} API. 
 
-**Note:** If the device is powered off or loses all network connectivity, it will remain in the Online (Heartbeat Only) state for an extended time based on the device [API polling interval][poll-interval].
+<sup>2</sup> `Online (Heartbeat Only)` indicates that device is unable to connect to the {{ $names.cloud.lower }} VPN (e.g. a firewall is blocking VPN traffic) and wouldn't be able to provide remote SSH connections to the device.
+
+__Note:__ If the device is powered off or loses all network connectivity, it will remain in the `Online (Heartbeat Only)` state until the last target state fetch exceeds the device [API polling interval][poll-interval].
+
+## Debugging Device Status
+
+If you find your device to be displaying a status which is unclear even with the above notes, visit the [device status][debugging-masterclass#device-status] section in [device debugging masterclass][debugging-masterclass] for more information and what it means for your application.
 
 [deactivated]: /learn/manage/billing/#inactive-devices
-[host-os-updates]: /reference/OS/updates/self-service/
 [poll-interval]: /learn/manage/configuration/#variable-list
 [device-provisioning]: /learn/welcome/primer/#device-provisioning
 [preregistered]: /learn/more/masterclasses/advanced-cli/#52-preregistering-a-device
 [application type]: /learn/manage/app-types
+[debugging-masterclass]:/learn/more/masterclasses/device-debugging
+[debugging-masterclass#device-status]:/learn/more/masterclasses/device-debugging#12-Device-connectivity-status


### PR DESCRIPTION
Attempted to make the device status page clearer for users, and to include more explicitly the `VPN Only` and `Heartbeat Only` statuses.

Moved images to end of document, as they don't seem to be very useful, other than an example.

Change-type: patch
Signed-off-by: Scott Lowe <scott@balena.io>


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
