### PR TITLE
Add proxy-tunnel project reference

### DIFF
--- a/shared/network/2.x.md
+++ b/shared/network/2.x.md
@@ -499,6 +499,8 @@ Note that:
 
 Additionally, a `/mnt/boot/system-proxy/no_proxy` file can be added with a newline-separated list of IPs or subnets to not route through the proxy.
 
+We've published an example [here](https://github.com/balenalabs/proxy-tunnel) demonstrating how to implement this on devices.
+
 ## Checking connectivity
 
 You can configure a connectivity check using NetworkManager's builtin [feature][nm-connectivity]. In order to configure


### PR DESCRIPTION
* includes example app to configure on-device proxy automatically
* includes examples hosting the proxy server on AWS and DigitalOcean

Change-type: patch


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
