### PR TITLE
Rework the build/deploy section

### DIFF
--- a/pages/learn/deploy/deployment.md
+++ b/pages/learn/deploy/deployment.md
@@ -25,101 +25,25 @@ Once the cloud builder has successfully completed building all the images in the
 
 It should be noted that `{{$names.company.lower}} push` is independent of git, so you are free to use any version control system you wish. This also means that it is possible to use [git submodules][git-submodules] in your project when deploying with `{{$names.company.lower}} push`.
 
-### Additional Options
-
-#### `--source, -s <source>`
-
-The `--source` flag allows you do define a path to your source code folder. This flag directs `push` to send that directory to be built on either the [cloud builder](#the-balenacloud-build-server) or [local device][local-mode]. You should ensure your folder follows the [standard {{$names.company.lower}} project structure](#project-structure).
-
-#### `--emulated, -e`
-
-The `--emulated` flag will force the [{{$names.cloud.lower}} builder](#the-balenacloud-build-server) to run an [qemu][qemu] emulated build. This means that your build will be executed on an `x86_64` CPU that emulates the target architecture of your application, rather than running on the native architecture of your device. You can see if the build is emulated in the first few lines of the builder output as below:
-
-```shell
-$ {{$names.company.lower}} push myApp --emulated
-[Info]     Starting build for myApp, user {{$names.company.lower}}_projects
-[Info]     Dashboard link: https://dashboard.balena-cloud.com/apps/1426783/devices
-[Info]     Running locally emulated build
-[Info]     Pulling previous images for caching purposes...
-[Success]  Successfully pulled cache images
-[main]     Step 1/2 : FROM {{$names.company.lower}}/secret_sauce
-[main]      ---> 6e48e49f10a6
-[main]     Step 2/2 : CMD cat /etc/os-release
-```
-
-__Note:__ The `--emulated` option is not available when pushing to a [localMode][local-mode] device.
-
-The emulated builds will also happen on the rare occasion that the native ARM builder is overloaded or unavailable.
-
-#### `--nocache, -c`
-
-The `--nocache` flag causes a fresh image build to take place, preventing the use of cached imaged layers from previous builds of this project. This is useful to
-ensure that the latest base image and packages are pulled. Note that the build logs may still display the message _"Pulling previous images for caching purposes,"_ because the cloud builder needs the previous images in order to prepare [delta updates](https://www.balena.io/docs/learn/deploy/delta/). When `--nocache` is used, the build logs will not display the "Using cache" lines for each build step of a Dockerfile.
+__Note:__ Refer to the [`{{$names.company.lower}} push` command reference][cli-push-reference] for additional documentation.
 
 ## {{$names.company.upper}} Build & Deploy
 
 ### Overview
 
-The `{{$names.company.lower}} deploy` command is functionally very similar to [{{$names.company.lower}} push](#balena-push) but it avoids pushing any source code to the [{{$names.cloud.lower}} build server](#the-balenacloud-build-server). It allows you more control over how and where your container images are built. `{{$names.company.lower}} deploy` can fairly easily be integrated into your own [CI/CD][continuous-deployment] build system.
-
-In `{{$names.company.lower}} deploy` the container images are built on your laptop or development machine, and depending on your fleet's targeted CPU architecture, has the option to run [qemu][qemu] emulated builds.
+The `{{$names.company.lower}} deploy` is functionally very similar to [{{$names.company.lower}} push](#balena-push) but avoids pushing any source code to the [{{$names.cloud.lower}} build server](#the-balenacloud-build-server). It gives more control over how and where your container images are built, allowing for `{{$names.company.lower}} deploy` to be integrated into your own [CI/CD][continuous-deployment] build system.
 
 ![How {{$names.company.lower}} deploy works](/img/common/deployment/balena-deploy.jpg)
 
-`{{$names.company.lower}} deploy` will build all your container images on the machine the command is run on (or on a specified docker daemon), and upon success, it will upload the images to the {{$names.cloud.lower}} image registry and then create a release entry in the [{{$names.company.lower}} API][api] database. The devices in the application will then be notified of a new release and download it. In order to build containers you will need to have [Docker installed][docker-install] on your development machine, and you should be able to execute [Docker commands as a non-root user][docker-post-install]. It is not necessary to install Docker on your development machine if you choose to use a device running {{$names.os.lower}} to build the images (a [development image][development-image] is then required), by specifying a docker daemon's IP address and port number with the relevant command-line options.
+With `{{$names.company.lower}} build` container images are built on your development machine or on a remote machine, by specifying a docker daemon's IP address and port number with the relevant command-line options (for example a device running a {{$names.os.lower}} [development image][development-image]). Depending on your fleet's targeted CPU architecture builds will be run emulated via [qemu][qemu].
+
+If you are building your own container images, `{{$names.company.lower}} deploy` will upload the images to the {{$names.cloud.lower}} image registry and then create a release entry in the [{{$names.company.lower}} API][api] database. The devices in the application will then be notified of a new release and download it. Should `{{$names.company.lower}} deploy` not find the required images on the specified docker daemon it will automatically trigger a build.
 
 Like `{{$names.company.lower}} push` it is also independent of git, and you can use any version control system you wish. It is also possible to make use of [private base images](#private-base-images).
 
 __Note:__ Currently `{{$names.company.lower}} deploy` does not support the [build time secrets](#build-time-secrets-and-variables) feature.
 
-It's also possible to use the `{{$names.company.lower}} build` command without actually deploying. This command has all the same functionality as `{{$names.company.lower}} deploy`, but it does not upload the images to the registry or create a release on the API. This command can be useful if you want your CI/CD system to first run built images through some testing and validation stage before finally doing the deploy.
-
-### Additional Options
-
-#### `--projectName, -n <projectName>`
-
-The `--projectName` option allows you to specify an alternate project name. By default, the project name is set to the directory name. The images created will be named with the format `<projectName>_<serviceName>`.
-
-For example running `$ {{$names.company.lower}} deploy myApp --projectName projectName` for a multicontainer application with 2 services.
-
-```shell
-$ docker images
-REPOSITORY                                                       TAG                    IMAGE ID            CREATED             SIZE
-projectName_service1                                             latest                 e4c9585eb6a5        8 minutes ago       135MB
-projectName_service2                                             latest                 7bed253dada2        8 minutes ago       102MB
-```
-
-__Note:__ by default docker image names need to be lower case, so any `projectName` will be converted to lower case as `projectname`.
-
-#### `--build, -b`
-
-This option on `{{$names.company.lower}} deploy` will always force a build of the images before uploading and deploying. In the case when you don't specify the build option, `{{$names.company.lower}} deploy` will use the images that already exist locally (you can see these by running `docker images`). Note that `--build` will not do a clean build every time and will make use of the local docker layer cache. If you want to do a full clean build, you need to specify both the `--build` and `--nocache` flags (see below).
-
-#### `--nocache`
-
-The `--nocache` flag only applies when the `--build` flag is specified, and it will cause Docker to build the images from scratch, ignoring any layer cache from previous builds.
-
-#### `--buildArg, -B <arg>`
-
-Set a build-time variable (eg. `-B "ARG=value"`), which can be specified multiple times.
-
-__Warning:__ It is not recommended to use build-time variables for passing secrets like GitHub keys, user credentials etc. Build-time variable values are visible to any user of the image with the `docker history` command. For this type of sensitive data, it is recommended to use [build time secrets](#build-time-secrets-and-variables).
-
-#### `--emulated, -e`
-
-The `--emulated` flag enables you to run an emulated build using [qemu][qemu] on your development machine. This should allow you to build `armv7l` binaries for devices like the Raspberry Pi on your development machine.
-
-#### `--logs`
-
-This option will stream the Docker build log output for all your services to the terminal where you run deploy. These are the same logs that will be available on the [release logs page](#view-past-deployments). Note that if `{{$names.company.lower}} deploy` is run without the `--build` flag, no logs will be output because no build will occur.
-
-#### `--nologupload`
-
-This option disables the uploading of all the service build logs to {{$names.cloud.lower}}, so they will not be visible on the [release logs page](#view-past-deployments).
-
-#### `--source, -s <source>`
-
-The `--source` flag allows you do define a path to your source code folder. You should ensure your folder follows the [standard {{$names.company.lower}} project structure](#project-structure).
+__Note__: Refer to the [`{{$names.company.lower}} build`][cli-build-reference] and [`{{$names.company.lower}} deploy`][cli-deploy-reference] command references for additional documentation.
 
 ## Git Push
 
@@ -290,6 +214,10 @@ Much like with the device list, [filters][filters] can be added to the release l
 [arm]:https://en.wikipedia.org/wiki/ARM_architecture
 [continuous-deployment]:https://en.wikipedia.org/wiki/Continuous_deployment
 [cli]:/reference/cli/#install-the-cli
+[cli-reference]:/reference/balena-cli/#deprecation-policy
+[cli-push-reference]:/reference/balena-cli/#push-applicationordevice
+[cli-build-reference]:/reference/balena-cli/#build-source
+[cli-deploy-reference]:/reference/balena-cli/#build-source
 [cli-masterclass]:/learn/more/masterclasses/cli-masterclass/
 [development-image]:/reference/OS/overview/2.x/#development-vs-production-images
 [device-types]:/reference/base-images/devicetypes/


### PR DESCRIPTION
I moved around a bunch of text and made sure not to mix the features of
`build` into the sections about `deploy` (even though functionally that
makes sense).
Also linked to the cli reference at the end of each part (since that
documents the options in much greater detail).

Change-type: patch
Connects-to: https://github.com/balena-io/docs/issues/550
Connects-to: https://github.com/balena-io/balena-cli/pull/2272
Signed-off-by: Robert Günzler <robertg@balena.io>
