### PR TITLE
Added dependabot config to format commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  commit-message:
+    prefix: patch
+  rebase-strategy: disabled


### PR DESCRIPTION
This is so we can easily merge PRs from dependabot like https://github.com/balena-io/docs/pull/1914 without having to checkout the branch and fix versionbot.

dependabot config options https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates