### PR TITLE
Add device metrics docs

### DIFF
--- a/config/navigation.txt
+++ b/config/navigation.txt
@@ -118,6 +118,7 @@ Reference
 
   Device supervisor
     Supervisor API[/reference/supervisor/supervisor-api]
+    [/reference/supervisor/device-metrics]
     [/reference/supervisor/bandwidth-reduction]
     [/reference/supervisor/docker-compose]
     [/reference/supervisor/supervisor-upgrades]

--- a/pages/reference/supervisor/bandwidth-reduction.md
+++ b/pages/reference/supervisor/bandwidth-reduction.md
@@ -4,46 +4,52 @@ title: Reduce bandwidth usage
 
 # Reduce bandwidth usage
 
-In order to provide our users with a clear view of their devices, the {{ $names.company.lower }} device supervisor constantly keeps our API informed about the devices' conditions and applies any changes, like downloading new application updates or environment variable changes by negotiating with our API. While a quick reflection of actions is great during development, it comes at a cost of increased data usage.
+In order to provide users with essential information about their devices, the {{ $names.company.lower }} Supervisor on the device regularly keeps the API informed about the device's state. Upon receiving a target device state which differs from the current device state, the Supervisor applies changes, such as downloading new application updates or setting environment variables. While a quick response to actions is great during development, it also leads to of increased data usage.
 
-In order to give our power users control over data flow we enabled a few `BALENA_` [config environment variables](/management/env-vars).
+In order to give our power users control over data flow, we enabled a few `BALENA_` [configuration variables][configuration-variables].
 
-| Variable                              | Allowed Value     |   Action                                             | Default |
-|---------------------------------------|-------------------|------------------------------------------------------|---------|
-| `BALENA_SUPERVISOR_VPN_CONTROL`        | true/false        |  Enable / Disable VPN                                |   true  |
-| `BALENA_SUPERVISOR_CONNECTIVITY_CHECK` | true/false        |  Enable / Disable connectivity check VPN is disabled |   true  |
-| `BALENA_SUPERVISOR_POLL_INTERVAL`      | 600000 to 86400000 |  API Poll interval in milliseconds             |   600000 |
-| `BALENA_SUPERVISOR_LOG_CONTROL`        | true/false        |  Enable / Disable logs from being sent to API      |   true  |
+| Variable                               | Allowed Value      |   Action                                             | Default | Available with Supervisor Version |
+|----------------------------------------|--------------------|------------------------------------------------------|---------|-----------------------------------|
+| `BALENA_SUPERVISOR_VPN_CONTROL`        | true/false         |  Enable / Disable VPN                                |  true   |  v1.1.0                           |
+| `BALENA_SUPERVISOR_CONNECTIVITY_CHECK` | true/false         |  Enable / Disable VPN connectivity check             |  true   |  v1.3.0                           |
+| `BALENA_SUPERVISOR_POLL_INTERVAL`      | 600000 to 86400000 |  API Poll interval in milliseconds                   |  900000 |  v1.3.0                           |
+| `BALENA_SUPERVISOR_LOG_CONTROL`        | true/false         |  Enable / Disable logs from being sent to API        |  true   |  v1.3.0                           |
+| `BALENA_SUPERVISOR_HARDWARE_METRICS`   | true/false         |  Enable / Disable device hardware metrics reporting  |  true   |  v12.8.0                          |
 
-Side-effect/Warning
+Side Effects / Warnings
 -------------------
 
 `BALENA_SUPERVISOR_VPN_CONTROL`: This defines the ability to send instantaneous updates to the device. Turning off the VPN means that any application or environment variable update is reflected only when the device polls for these changes. The Web Terminal does not function when the VPN is disabled. This also disables the public URLs functionality.
 
 `BALENA_SUPERVISOR_CONNECTIVITY_CHECK`: Defines the device's ability to test and indicate (via an LED when available) that it has issues with connectivity.
 
-`BALENA_SUPERVISOR_POLL_INTERVAL`: This defines the time interval when any changes made to the application, i.e either new code pushes or environment variables changes or VPN control changes are propagated to the device. Think of it as the interval when the device checks in with {{ $names.company.lower }} API to ask for new updates. Making this interval long, would mean that any change is only reflected in the device after this interval, if the VPN is not operational. (We suggest limiting this to less than 24 hours)
+`BALENA_SUPERVISOR_POLL_INTERVAL`: This defines the time interval when any changes made to the application, i.e either new code pushes or environment variables changes or VPN control changes are propagated to the device. Think of it as the interval when the device checks in with {{ $names.company.lower }} API to ask for new updates. Making this interval long, would mean that any change is only reflected in the device after this interval, if the VPN is not operational. (We suggest limiting this to less than 24 hours.)
 
-`BALENA_SUPERVISOR_LOG_CONTROL`: Any logs written by the user container or the device Agent are not sent to the dashboard when this variable is set to False.
+`BALENA_SUPERVISOR_LOG_CONTROL`: Any logs written by the user container or the device Agent are not sent to the dashboard when this variable is set to false.
 
+`BALENA_SUPERVISOR_HARDWARE_METRICS`: [Device metrics][device-metrics] such as CPU temperature and memory usage won't be reported to the API, and won't be displayed on the summary page of the device dashboard.
 
 Data usage impact
 -----------------
 
-| Service                                             | Usage (Including DNS overhead) | Control Variable               |
-|-----------------------------------------------------|--------------------------------|--------------------------------|
-| API poll (Once per 10m)                             | 6650 Bytes per request         | BALENA_SUPERVISOR_POLL_INTERVAL   |
-| {{ $names.company.lower }} supervisor update poll (Once every 24 hours)       | 6693 Bytes per request         | Not configurable via variables |
-| VPN enabled                                         | 43 Bytes / second              | BALENA_SUPERVISOR_VPN_CONTROL   |
-| TCP check cost (When VPN disabled)                  | 47.36 Bytes / second           | BALENA_SUPERVISOR_CONNECTIVITY_CHECK |
-
+| Service                                                                 | Usage (Including DNS overhead)                          | Related Configuration Variable       |
+|-------------------------------------------------------------------------|---------------------------------------------------------|--------------------------------------|
+| API poll (Once per 15min)                                               | 6650 Bytes per request                                  | BALENA_SUPERVISOR_POLL_INTERVAL      |
+| {{ $names.company.lower }} Supervisor update poll (Once every 24 hours) | 6693 Bytes per request                                  | Not configurable via variables       |
+| VPN enabled                                                             | 43 Bytes / second                                       | BALENA_SUPERVISOR_VPN_CONTROL        |
+| TCP check cost (When VPN disabled)                                      | 47.36 Bytes / second                                    | BALENA_SUPERVISOR_CONNECTIVITY_CHECK |
+| Hardware metrics reporting                                              | ~66 Bytes every 10 seconds when there have been changes | BALENA_SUPERVISOR_HARDWARE_METRICS   |
 
 Example minimum bandwidth settings
 ----------------------------------
 
-The following settings tune the data usage to approximately 1.3MB per month:
+The following settings lead to data usage of approximately 1.3MB per month:
 
-* Disable VPN
-* Disable CONNECTIVITY CHECK
-* Change POLL interval to 24 hours
-* Disable LOGS
+* Disable `BALENA_SUPERVISOR_VPN_CONTROL`
+* Disable `BALENA_SUPERVISOR_CONNECTIVITY_CHECK`
+* Change `BALENA_SUPERVISOR_POLL_INTERVAL` to 24 hours (86400000 ms)
+* Disable `BALENA_SUPERVISOR_LOG_CONTROL`
+* Disable `BALENA_SUPERVISOR_HARDWARE_METRICS`
+
+[device-metrics]:/reference/supervisor/device-metrics
+[configuration-variables]:/learn/manage/configuration

--- a/pages/reference/supervisor/device-metrics.md
+++ b/pages/reference/supervisor/device-metrics.md
@@ -1,0 +1,33 @@
+---
+title: Device Metrics
+---
+
+# Device Metrics
+
+The {{ $names.company.lower }} Supervisor reports metrics about your device to the cloud. These metrics are available on your balenaCloud dashboard, on the device summary page:
+
+![Device Metrics](https://www.balena.io/blog/content/images/2020/09/device-metrics-1.png)
+
+You can also fetch device metrics data through {{ $names.company.lower }}'s [open API][api], [Node SDK][node-sdk], and [Python SDK][python-sdk]. This allows you to port metrics data to a custom dashboard in order to monitor the utilization and health of your fleet. Note that device metrics are available with {{ $names.os.lower }} v2.56.0+rev1 and higher, running Supervisor v11.14.0 and higher.
+
+The following table has descriptions for each metric reported by the {{ $names.company.lower }} Supervisor:
+
+| Name                    | Type         | Description | API Slug | Optional? |
+|-------------------------|--------------|-------------|----------|-----------|
+| CPU utilization         | integer (%)  | Utilization percentage of the CPU. Receive updates when the "bucket" of the CPU usage changes past certain milestones in increments of 20%. | `cpu_usage` | Y |
+| CPU temperature         | integer (°C) | CPU temperature in degrees Centigrade in boundaries of 3 degrees, subject to bandwidth saving transfer strategies. | `cpu_temp` | Y |
+| Memory usage/total      | integer (Mb) | RAM usage on the device in megabytes. | `memory_usage` / `memory_total` | Y |
+| Disk storage used/total | integer (Mb) | Utilized storage and total storage in megabytes. | `storage_usage` / `storage_total` | Y |
+| CPU ID                  | string       | CPU serial number provided by manufacturer. | `cpu_id` | Y |
+| Undervoltage            | boolean      | Detect power supply insufficiency. Not supplying enough power most commonly leads to power brownouts or disk corruption. Will *not* toggle back to false after true has been reported until reboot occurs. See the [FAQs][choose-power-supply-unit] for tips on choosing a power supply unit. | `is_undervolted` | N |
+
+## Toggling Metrics Reporting
+
+In the table above, you may have noticed that some metrics are optional while others are not. From the perspective of the Supervisor, hardware metrics reported from the device are divided into two categories: optional system metrics, and non-optional system checks. Starting with Supervisor v12.8.0, you can control whether optional metrics are reported to the cloud to save bandwidth by toggling `BALENA_SUPERVISOR_HARDWARE_METRICS`. When metrics reporting is enabled, metrics are reported as part of device state at most every 10 seconds when metrics changes have occurred. When metrics reporting is disabled, optional metrics are not reported, but system checks are still reported. 
+
+__Note__: The `BALENA_SUPERVISOR_HARDWARE_METRICS` configuration variable may be toggled on an application or device-specific level from `Fleet Variables` or `Device Configuration` tabs on the dashboard respectively. By default, metrics reporting is enabled.
+
+[api]:/reference/api/overview/
+[node-sdk]:/reference/sdk/node-sdk/
+[python-sdk]:/reference/sdk/python-sdk/
+[choose-power-supply-unit]:/faq/troubleshooting/faq/#what-to-keep-in-mind-when-choosing-power-supply-units


### PR DESCRIPTION
Metrics include CPU temp, CPU usage, memory usage/total,
storage usage/total, CPU ID. Metrics are categorized by optional
system metrics that aren't reported when SUPERVISOR_HARDWARE_METRICS
is false, and system checks that are always reported regardless of
SUPERVISOR_HARDWARE_METRICS's value.

Closes: #1901
Change-type: patch
Signed-off-by: Christina Wang <christina@balena.io>

---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*