### PR TITLE
Clarify where deployments are performed

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,7 @@ One can open or check existing issues on [GitHub issues](https://github.com/bale
 
 ## Deploying
 
-After a PR has been created, a member of the balena team will review and merge the PR. The pull request will undergo CI/CD checks to verify if everything is correct. For example: if a Change-type has been added. More information present in the [CONTRIBUTING document](CONTRIBUTING.md)
-
-Shortly after merging the PR to the `master` branch, it'll automatically be deployed to our [production environment](https://www.balena.io/docs/) (This should only take a few minutes).
-
-If the feature/change needs to be reviewed, a member of the balena team can/will deploy the PR to staging to check the changes. If everything looks good, then the PR would be merged into the `master` branch promptly in line for the changes to be deployed to production.
+Shortly after merging a PR to the `master` branch, the Heroku app which hosts the [production instance](https://www.balena.io/docs/) will pick up the changes and deploy them. This should only take a few minutes.
 
 ## Style manual
 


### PR DESCRIPTION
I felt this was needed to clarify whereto  find the mechanism which deploys the docs and how to go about making modifications if needed. Previously the readme just mentioned that the docs will be deployed automatically without explaining how.
