### PR TITLE
Added heading to describe balenaCloud API resource page

### DIFF
--- a/templates/api.html
+++ b/templates/api.html
@@ -1,6 +1,7 @@
 {% extends "default.html" %}
 
 {% block "contents" %}
+	<h1 id="balenacloud-api-resources">balenaCloud API Resources</h1>
 	<div style="display: flex;">
 		<div style="float: left; width: 40%; padding-right: 10px;">
 			<h2>Available fields</h2>


### PR DESCRIPTION
The only way to navigate to this page is by going to Reference -> API -> Resources. This is extremely unintuitive since I personally keep forgetting the path and always just find things in the docs via the search bar. This page is not indexed in the search by correctly because the page does not mention what it is. This PR adds a heading which will allow the search bar to index the page and return it when someone enters "API", "balenacloud api" "cloud api" etc.