### PR TITLE
apiGeneral: calls: clarify internal IDs

### DIFF
--- a/shared/apiGeneral/calls.md
+++ b/shared/apiGeneral/calls.md
@@ -46,6 +46,8 @@ curl -X GET "{{ $links.apiBase }}/v5/device(<ID>)" \
 -H "Authorization: Bearer <AUTH_TOKEN>"
 ```
 
+## Resource IDs
+
 Many times, however, you won't know the internal ID used by the API, and you'll want to use some other piece of information to find the appropriate resource. In these cases, you can use the `$filter` method to select resources based on any field. For example, if you are looking for a specific device, it's more likely that you'll have the device UUID than the device ID:
 
 ```shell
@@ -56,6 +58,10 @@ curl -X GET \
 ```
 
 Notice the construction here: `$filter=` is used to define the field, and then the value is specified after the `eq` keyword. This is the most straightforward example—there are many other ways to build filters, which you can find in the OData documentation.
+
+The resource returned from this call contains the internal ID you can use to make subsequent calls, under the "id" key.
+
+`{"d":[{"id":1234567, ...`
 
 A final tip for constructing API calls: for some of the fields in the API response, a link to another resource is provided rather than the complete information about that resource. For example, if you make a call requesting information about a specific device, the `belongs_to__application` field will return a link to an application, but not all the information about that application. To get all the fields for the application resource, you can use the `$expand` method:
 


### PR DESCRIPTION
Also add a header above the section detailing usage of internal IDs for
permalinking.

Signed-off-by: Joseph Kogut <joseph@balena.io>

A user of the API encountered some confusion over usage of internal IDs. Searching yielded the linked issue already describing the problem, and the need to clarify usage of internal IDs. Reading through the docs yielded a page that mostly already clarifies this, but it's part of a larger page on constructing API calls, and can't be linked to on the section for finding and using resource IDs.

Add an H2 header to enable linking, and add a sentence explaining which field for a returned resource is the internal ID.

Related-to: https://github.com/balena-io/docs/issues/1881