### PR TITLE
Fix link to Supervisor API reference

### DIFF
--- a/pages/learn/develop/runtime.md
+++ b/pages/learn/develop/runtime.md
@@ -362,7 +362,7 @@ Note that currently it's not possible to share a mounted device across multiple 
 [openrc-link]:https://en.wikipedia.org/wiki/OpenRC
 [supervisor-api-link]:/runtime/supervisor-api/
 [security-docs-link]:/learn/welcome/security/
-[supervisor-api-device-host-config]:/reference/supervisor/supervisor-api/#patch-v1-device-host-config
+[supervisor-api-device-host-config]:/reference/supervisor/supervisor-api/#patch-v1devicehost-config
 [expressjs-link]:http://expressjs.com/
 [projects-github]:{{ $links.githubLabs }}
 [systemd-base-image-link]:https://hub.docker.com/r/{{ $names.company.short }}/raspberrypi-python/


### PR DESCRIPTION
The current link takes you to the correct page, but the anchor tag for the section is incorrect.

Change-type: patch
Signed-off-by: Mark Corbin <mark@balena.io>


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
