### PR TITLE
Resume checking for rate-limit return codes

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -32,7 +32,6 @@ jobs:
           args: >
             --exclude-mail
             --exclude
-            --accept 429
             localhost
             127.0.0.1
             https://github.com/balena-io-library/base-images


### PR DESCRIPTION
We don't want to exclude return code 429 as that may
mask issues with dead links.

Also, the way this flag was added broke the usage of
the --exclude flag by mistake.

See: https://github.com/balena-io/docs/issues/1972
Partially reverts: https://github.com/balena-io/docs/pull/1964

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
