### PR TITLE
Update time management UDP port details

### DIFF
--- a/pages/reference/OS/time.md
+++ b/pages/reference/OS/time.md
@@ -51,7 +51,7 @@ When you first provision a device, as a fallback, `/var/lib/systemd/clock` is se
 
 There are certain networking requirements to ensure that the NTP service can properly function, and the device time may be kept synchronized.
 
-The NTP service requires UDP port `123` to be open. See more [network requirements here](/deployment/network/2.0.0/#network-requirements).
+The NTP service requires UDP port `123` to be open for outgoing connections from the device. See more [network requirements here](/deployment/network/2.0.0/#network-requirements).
 
 Starting from {{ $names.os.lower }} 2.0.7, the devices connect to the following NTP servers:
 


### PR DESCRIPTION
Add a clarification to the time management documentation stating that UDP port 123 only needs to be open for outgoing connections from the device.

Change-type: patch
Signed-off-by: Mark Corbin <mark@balena.io>


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
