### PR TITLE
Mention compose file version in the supervisor docs

### DIFF
--- a/pages/reference/supervisor/docker-compose.md
+++ b/pages/reference/supervisor/docker-compose.md
@@ -5,6 +5,8 @@ excerpt: docker-compose.yml fields supported by {{ $names.company.lower }}
 
 # docker-compose.yml fields
 
+Our compose-file support is currently based on [version 2.2](https://docs.docker.com/compose/compose-file/compose-versioning/#version-22), as such any fields that depend on version >=2.3 are not supported.
+
 ## Supported fields
 
 Field | Details


### PR DESCRIPTION
Occasionally users try to use fields that are supported by v2 but have
different properties in version >=2.2 (like long syntax for ports/volumes) and
are surprised to get an error in response.
Clarify that our support is based on version 2.2

Change-type: patch
Signed-off-by: Robert Günzler <robertg@balena.io>


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
