### PR TITLE
Adding detailed CLI installation instructions to getting-started

### DIFF
--- a/pages/learn/getting-started.md
+++ b/pages/learn/getting-started.md
@@ -76,7 +76,7 @@ Alternatively, by clicking on the toggle section of the download button, you als
 
 ## Install {{ $names.cli.lower }}
 
-Now that we have a device or two connected to a {{ $names.company.lower }} fleet, It's time to install the {{ $names.cli.lower }}. This recommended way to deploy code. Follow the instructions below according to your machines operating system.
+Now that we have a device or two connected to a {{ $names.company.lower }} fleet, It's time to install the {{ $names.cli.lower }}. This is the recommended way to deploy code to your devices. Follow the instructions below according to your machine's operating system.
 
 {{import "getting-started/cliInstructions"}}
 
@@ -110,7 +110,7 @@ __Note:__ Other authentication methods include using your username and password 
 
 ## Add release
 
-After logging in, test out the {{ $names.cli.lower }} by running the `{{ $names.company.lower }} fleets` command, which should return information about the fleet you created in the previous step. Take a note of the `FLEET NAME` as you'll need this in the next step to push the code to all devices in that fleet.
+After logging in, test out the {{ $names.cli.lower }} by running the `{{ $names.company.lower }} fleets` command, which should return information about the fleet you created in the previous step. Take note of the `FLEET NAME` as you'll need this in the next step to push your code to all devices in that fleet.
 
 ```shell
 $ {{ $names.company.lower }} fleets

--- a/pages/learn/getting-started.md
+++ b/pages/learn/getting-started.md
@@ -76,7 +76,7 @@ Alternatively, by clicking on the toggle section of the download button, you als
 
 ## Install the {{ $names.cli.lower }}
 
-Now that we have a device or two connected to a {{ $names.company.lower }} fleet, it's time to deploy code. The recommended way to deploy code is to use {{ $names.cli.lower }}. Follow the instructions below to install {{ $names.cli.lower }} to your machine's operating system.
+Now that we have a device or two connected to a {{ $names.company.lower }} fleet, it's time to deploy some code. We will use the {{ $names.cli.lower }} for this. Follow the instructions below to install it on your computer (development workstation). Choose the tab for your operating system.
 
 {{import "getting-started/cliInstructions"}}
 

--- a/pages/learn/getting-started.md
+++ b/pages/learn/getting-started.md
@@ -76,7 +76,7 @@ Alternatively, by clicking on the toggle section of the download button, you als
 
 ## Install the {{ $names.cli.lower }}
 
-Now that we have a device or two connected to a {{ $names.company.lower }} fleet, it's time to install the {{ $names.cli.lower }}. This is the recommended way to deploy code to your devices. Follow the instructions below according to your machine's operating system.
+Now that we have a device or two connected to a {{ $names.company.lower }} fleet, it's time to deploy code. The recommended way to deploy code is to use {{ $names.cli.lower }}. Follow the instructions below to install {{ $names.cli.lower }} to your machine's operating system.
 
 {{import "getting-started/cliInstructions"}}
 

--- a/pages/learn/getting-started.md
+++ b/pages/learn/getting-started.md
@@ -74,13 +74,13 @@ Alternatively, by clicking on the toggle section of the download button, you als
 <!-- This section is heavily customized based on the device -->
 {{import "getting-started/getDeviceOnDash"}}
 
-## Install {{ $names.cli.lower }}
+## Install the {{ $names.cli.lower }}
 
-Now that we have a device or two connected to a {{ $names.company.lower }} fleet, It's time to install the {{ $names.cli.lower }}. This is the recommended way to deploy code to your devices. Follow the instructions below according to your machine's operating system.
+Now that we have a device or two connected to a {{ $names.company.lower }} fleet, it's time to install the {{ $names.cli.lower }}. This is the recommended way to deploy code to your devices. Follow the instructions below according to your machine's operating system.
 
 {{import "getting-started/cliInstructions"}}
 
-After {{ $names.cli.lower }} is installed, login to your {{ $names.company.lower}} account
+After the {{ $names.cli.lower }} is installed, login to your {{ $names.company.lower}} account
 with the `{{ $names.company.lower }} login` command on the terminal:
 
 ```shell

--- a/pages/learn/getting-started.md
+++ b/pages/learn/getting-started.md
@@ -74,12 +74,13 @@ Alternatively, by clicking on the toggle section of the download button, you als
 <!-- This section is heavily customized based on the device -->
 {{import "getting-started/getDeviceOnDash"}}
 
-## Add release
+## Install {{ $names.cli.lower }}
 
-Now that we have a device or two connected to a {{ $names.company.lower }} fleet, let's deploy some code.
+Now that we have a device or two connected to a {{ $names.company.lower }} fleet, It's time to install the {{ $names.cli.lower }}. This recommended way to deploy code. Follow the instructions below according to your machines operating system.
 
-The recommended way to deploy code is to use the {{ $names.cli.lower }}. Follow the [installation
-instructions][cli-install]. After it is installed, login to your {{ $names.company.lower}} account
+{{import "getting-started/cliInstructions"}}
+
+After {{ $names.cli.lower }} is installed, login to your {{ $names.company.lower}} account
 with the `{{ $names.company.lower }} login` command on the terminal:
 
 ```shell
@@ -107,7 +108,9 @@ authorize the CLI, click the _Authorize_ button and head back to the terminal.
 
 __Note:__ Other authentication methods include using your username and password credentials or obtaining an [authentication token][token] from the dashboard. Authentication tokens come in two types, API tokens, and JSON Web Token (JWT) session tokens. While API tokens do not expire, JWT session tokens do after 7 days.
 
-After logging in, test out the {{ $names.company.lower }} CLI by running the `{{ $names.company.lower }} fleets` command, which should return information about the fleet you created in the previous step. Take a note of the `FLEET NAME` as you'll need this in the next step to push the code to all devices in that fleet.
+## Add release
+
+After logging in, test out the {{ $names.cli.lower }} by running the `{{ $names.company.lower }} fleets` command, which should return information about the fleet you created in the previous step. Take a note of the `FLEET NAME` as you'll need this in the next step to push the code to all devices in that fleet.
 
 ```shell
 $ {{ $names.company.lower }} fleets

--- a/shared/getting-started/cliInstructions/_default.md
+++ b/shared/getting-started/cliInstructions/_default.md
@@ -9,7 +9,7 @@
       <p>
         <ol>
           <li>
-            Download the latest CLI installer <a href="test" class="cli-download-link">here</a>.
+            Download the latest CLI installer <a href="" class="cli-download-link">here</a>.
           </li>
           <li>
             Double click the downloaded file to run the installer. After the installation is complete, close and re-open any open command terminal windows so that changes made by the installer to the PATH environment variable can take effect.
@@ -27,7 +27,7 @@
       <p>
         <ol>
           <li>
-            Download the latest CLI installer <a href="test" class="cli-download-link">here</a>.
+            Download the latest CLI installer <a href="" class="cli-download-link">here</a>.
           </li>
           <li>
             Double click the downloaded file to run the installer. After the installation is complete, close and re-open any open command terminal windows so that changes made by the installer to the PATH environment variable can take effect.
@@ -48,7 +48,7 @@
       <p>
         <ol>
           <li>
-            Download the latest CLI installer <a href="test" class="cli-download-link">here</a>.
+            Download the latest CLI installer <a href="" class="cli-download-link">here</a>.
           </li>
           <li>
             Extract the contents of the zip file to any folder you choose, for example <code>/home/james</code>. The extracted contents will include a <code>balena-cli</code> folder.

--- a/shared/getting-started/cliInstructions/_default.md
+++ b/shared/getting-started/cliInstructions/_default.md
@@ -1,8 +1,8 @@
 <div>
   <ul class="nav nav-tabs" role="tablist">
-    <li role="presentation" class="active"><a href="#cli-osx" aria-controls="cli-osx" role="tab" data-toggle="tab">macOS</a></li>
-    <li role="presentation"><a href="#cli-windows" aria-controls="cli-windows" role="tab" data-toggle="tab">Windows</a></li>
-    <li role="presentation"><a href="#cli-linux" aria-controls="cli-linux" role="tab" data-toggle="tab">Linux</a></li>
+    <li role="presentation"><a id="cli-osx-tab" href="#cli-osx" aria-controls="cli-osx" role="tab" data-toggle="tab">macOS</a></li>
+    <li role="presentation"><a id="cli-windows-tab" href="#cli-windows" aria-controls="cli-windows" role="tab" data-toggle="tab">Windows</a></li>
+    <li role="presentation" class="active"><a id="cli-osx-linux" href="#cli-linux" aria-controls="cli-linux" role="tab" data-toggle="tab">Linux</a></li>
   </ul>
   <div class="tab-content">
     <div role="tabpanel" class="tab-pane active" id="cli-osx">
@@ -15,19 +15,16 @@
             Double click the downloaded file to run the installer and follow the installer's instructions.
           </li>
           <li>
-            To run balena CLI commands, open the Terminal app ([Terminal User Guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
+            To run balena CLI commands, open the Terminal app (<a href="https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac" target="_blank">Terminal User Guide</a>).
           </li>
         </ol>
-      </p>
-      <p>
-        For more detailed information, visit the <a href="https://github.com/balena-io/balena-cli/blob/master/INSTALL-MAC.md" target="_blank">detailed OSX installation instructions</a>. 
       </p>
 	  </div>
     <div role="tabpanel" class="tab-pane" id="cli-windows">
       <p>
         <ol>
           <li>
-            Download the latest CLI installer <a href="" class="cli-download-link">here</a>.
+            <a href="" class="cli-download-link">Download the CLI installer</a>.
           </li>
           <li>
             Double click the downloaded file to run the installer and follow the installer's instructions.
@@ -42,16 +39,13 @@
       <p>
         <ol>
           <li>
-            Download the latest CLI installer <a href="" class="cli-download-link">here</a>.
+             <a href="" class="cli-download-link">Download the standalone CLI</a>.
           </li>
           <li>
             Extract the contents of the zip file to any folder you choose, for example <code>/home/james</code>. The extracted contents will include a <code>balena-cli</code> folder.
           </li>
           <li>
             Add that folder (e.g. <code>/home/james/balena-cli</code>) to the PATH environment variable. Check this <a href="https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix" target="_blank">StackOverflow</a> post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
-          </li>
-          <li>
-            Check that the installation was successful by running <code>balena version</code>.
           </li>
         </ol>
       </p>
@@ -63,6 +57,10 @@
 </div>
 <script type="text/javascript">
   window.addEventListener('load', function () {
+    var appVersion = navigator.appVersion
+    if (appVersion.indexOf('Mac')!== -1) jQuery('#cli-osx-tab').tab('show')
+    if (appVersion.indexOf('Win')!== -1) jQuery('#cli-windows-tab').tab('show')
+    if (appVersion.indexOf('Linux')!== -1 || appVersion.indexOf('X11')!== -1) jQuery('#cli-linux-tab').tab('show')
     jQuery.getJSON('https://api.github.com/repos/balena-io/balena-cli/releases/latest', function (results) {
       var baseDownloadString = `https://github.com/balena-io/balena-cli/releases/download/${results.tag_name}/balena-cli-${results.tag_name}`
       jQuery('#cli-osx .cli-download-link').attr('href', `${baseDownloadString}-macOS-x64-installer.pkg`)

--- a/shared/getting-started/cliInstructions/_default.md
+++ b/shared/getting-started/cliInstructions/_default.md
@@ -1,0 +1,81 @@
+<div>
+  <ul class="nav nav-tabs" role="tablist">
+    <li role="presentation" class="active"><a href="#cli-osx" aria-controls="cli-osx" role="tab" data-toggle="tab">Mac OSX</a></li>
+    <li role="presentation"><a href="#cli-windows" aria-controls="cli-windows" role="tab" data-toggle="tab">Windows</a></li>
+    <li role="presentation"><a href="#cli-linux" aria-controls="cli-linux" role="tab" data-toggle="tab">Linux</a></li>
+  </ul>
+  <div class="tab-content">
+    <div role="tabpanel" class="tab-pane active" id="cli-osx">
+      <p>
+        <ol>
+          <li>
+            Download the latest CLI installer <a href="test" class="cli-download-link">here</a>
+          </li>
+          <li>
+            Double click the downloaded file to run the installer. After the installation completes, close and re-open any open command terminal windows (so that the changes made by the installer to the PATH environment variable can take effect).
+          </li>
+          <li>
+            Check that the installation was successful by running <code>balena version</code>
+          </li>
+        </ol>
+      </p>
+      <p>
+        For more detailed information, visit the <a href="https://github.com/balena-io/balena-cli/blob/master/INSTALL-MAC.md" target="_blank">detailed OSX installation instructions</a>. 
+      </p>
+	  </div>
+    <div role="tabpanel" class="tab-pane" id="cli-windows">
+      <p>
+        <ol>
+          <li>
+            Download the latest CLI installer <a href="test" class="cli-download-link">here</a>
+          </li>
+          <li>
+            Double click the downloaded file to run the installer. After the installation completes, close and re-open any open command terminal windows (so that the changes made by the installer to the PATH environment variable can take effect).
+          </li>
+          <li>
+            Check that the installation was successful by running <code>balena version</code>
+          </li>
+        </ol>
+      </p>
+      <p>
+        For more detailed information, visit the <a href="https://github.com/balena-io/balena-cli/blob/master/INSTALL-WINDOWS.md" target="_blank">detailed Windows installation instructions</a>. 
+      </p>
+    </div>
+    <div role="tabpanel" class="tab-pane" id="cli-linux">
+      <p>
+        These instructions are suitable for most Linux distributions on Intel x86, except notably for Linux Alpine or Busybox. For these distros or for the ARM architecture, follow the <a href="https://github.com/balena-io/balena-cli/blob/master/INSTALL-ADVANCED.md#npm-installation" target="_blank">NPM Installation</a> method.
+      </p>
+      <p>
+        <ol>
+          <li>
+            Download the latest CLI installer <a href="test" class="cli-download-link">here</a>
+          </li>
+          <li>
+            Extract the zip file contents to any folder you choose, for example <code>/home/james</code>. The extracted contents will include a <code>balena-cli</code> folder.
+          </li>
+          <li>
+            Add that folder (e.g. <code>/home/james/balena-cli</code>) to the PATH environment variable. Check this <a href="https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix" target="_blank">StackOverflow</a> post for instructions. Close and reopen the terminal window so that the changes to PATH can take effect.
+          </li>
+          <li>
+            Check that the installation was successful by running <code>balena version</code>
+          </li>
+        </ol>
+      </p>
+      <p>
+        For more detailed information, visit the <a href="https://github.com/balena-io/balena-cli/blob/master/INSTALL-LINUX.md" target="_blank">detailed Linux installation instructions</a>. 
+      </p>
+    </div>
+  </div>
+</div>
+<script type="text/javascript">
+  window.addEventListener('load', function () {
+    jQuery.getJSON('https://api.github.com/repos/balena-io/balena-cli/releases/latest', function (results) {
+      var baseDownloadString = `https://github.com/balena-io/balena-cli/releases/download/${results.tag_name}/balena-cli-${results.tag_name}`
+      jQuery('#cli-osx .cli-download-link').attr('href', `${baseDownloadString}-macOS-x64-installer.pkg`)
+      jQuery('#cli-windows .cli-download-link').attr('href', `${baseDownloadString}-windows-x64-installer.exe`)
+      jQuery('#cli-linux .cli-download-link').attr('href', `${baseDownloadString}-linux-x64-standalone.zip`)
+    })
+  })
+</script>
+
+<hr />

--- a/shared/getting-started/cliInstructions/_default.md
+++ b/shared/getting-started/cliInstructions/_default.md
@@ -1,6 +1,6 @@
 <div>
   <ul class="nav nav-tabs" role="tablist">
-    <li role="presentation" class="active"><a href="#cli-osx" aria-controls="cli-osx" role="tab" data-toggle="tab">Mac OSX</a></li>
+    <li role="presentation" class="active"><a href="#cli-osx" aria-controls="cli-osx" role="tab" data-toggle="tab">macOS</a></li>
     <li role="presentation"><a href="#cli-windows" aria-controls="cli-windows" role="tab" data-toggle="tab">Windows</a></li>
     <li role="presentation"><a href="#cli-linux" aria-controls="cli-linux" role="tab" data-toggle="tab">Linux</a></li>
   </ul>
@@ -9,13 +9,13 @@
       <p>
         <ol>
           <li>
-            Download the latest CLI installer <a href="" class="cli-download-link">here</a>.
+            <a href="" class="cli-download-link">Download the CLI installer</a>.
           </li>
           <li>
-            Double click the downloaded file to run the installer. After the installation is complete, close and re-open any open command terminal windows so that changes made by the installer to the PATH environment variable can take effect.
+            Double click the downloaded file to run the installer and follow the installer's instructions.
           </li>
           <li>
-            Check that the installation was successful by running <code>balena version</code>.
+            To run balena CLI commands, open the Terminal app ([Terminal User Guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
           </li>
         </ol>
       </p>
@@ -30,21 +30,15 @@
             Download the latest CLI installer <a href="" class="cli-download-link">here</a>.
           </li>
           <li>
-            Double click the downloaded file to run the installer. After the installation is complete, close and re-open any open command terminal windows so that changes made by the installer to the PATH environment variable can take effect.
+            Double click the downloaded file to run the installer and follow the installer's instructions.
           </li>
           <li>
-            Check that the installation was successful by running <code>balena version</code>.
+            To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
           </li>
         </ol>
       </p>
-      <p>
-        For more detailed information, visit the <a href="https://github.com/balena-io/balena-cli/blob/master/INSTALL-WINDOWS.md" target="_blank">detailed Windows installation instructions</a>. 
-      </p>
     </div>
     <div role="tabpanel" class="tab-pane" id="cli-linux">
-      <p>
-        These instructions are suitable for most Linux distributions on Intel x86, except notably for Linux Alpine or Busybox. For these distros or for the ARM architecture, follow the <a href="https://github.com/balena-io/balena-cli/blob/master/INSTALL-ADVANCED.md#npm-installation" target="_blank">NPM Installation</a> method.
-      </p>
       <p>
         <ol>
           <li>

--- a/shared/getting-started/cliInstructions/_default.md
+++ b/shared/getting-started/cliInstructions/_default.md
@@ -9,13 +9,13 @@
       <p>
         <ol>
           <li>
-            Download the latest CLI installer <a href="test" class="cli-download-link">here</a>
+            Download the latest CLI installer <a href="test" class="cli-download-link">here</a>.
           </li>
           <li>
-            Double click the downloaded file to run the installer. After the installation completes, close and re-open any open command terminal windows (so that the changes made by the installer to the PATH environment variable can take effect).
+            Double click the downloaded file to run the installer. After the installation is complete, close and re-open any open command terminal windows so that changes made by the installer to the PATH environment variable can take effect.
           </li>
           <li>
-            Check that the installation was successful by running <code>balena version</code>
+            Check that the installation was successful by running <code>balena version</code>.
           </li>
         </ol>
       </p>
@@ -27,13 +27,13 @@
       <p>
         <ol>
           <li>
-            Download the latest CLI installer <a href="test" class="cli-download-link">here</a>
+            Download the latest CLI installer <a href="test" class="cli-download-link">here</a>.
           </li>
           <li>
-            Double click the downloaded file to run the installer. After the installation completes, close and re-open any open command terminal windows (so that the changes made by the installer to the PATH environment variable can take effect).
+            Double click the downloaded file to run the installer. After the installation is complete, close and re-open any open command terminal windows so that changes made by the installer to the PATH environment variable can take effect.
           </li>
           <li>
-            Check that the installation was successful by running <code>balena version</code>
+            Check that the installation was successful by running <code>balena version</code>.
           </li>
         </ol>
       </p>
@@ -48,16 +48,16 @@
       <p>
         <ol>
           <li>
-            Download the latest CLI installer <a href="test" class="cli-download-link">here</a>
+            Download the latest CLI installer <a href="test" class="cli-download-link">here</a>.
           </li>
           <li>
-            Extract the zip file contents to any folder you choose, for example <code>/home/james</code>. The extracted contents will include a <code>balena-cli</code> folder.
+            Extract the contents of the zip file to any folder you choose, for example <code>/home/james</code>. The extracted contents will include a <code>balena-cli</code> folder.
           </li>
           <li>
-            Add that folder (e.g. <code>/home/james/balena-cli</code>) to the PATH environment variable. Check this <a href="https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix" target="_blank">StackOverflow</a> post for instructions. Close and reopen the terminal window so that the changes to PATH can take effect.
+            Add that folder (e.g. <code>/home/james/balena-cli</code>) to the PATH environment variable. Check this <a href="https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix" target="_blank">StackOverflow</a> post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
           </li>
           <li>
-            Check that the installation was successful by running <code>balena version</code>
+            Check that the installation was successful by running <code>balena version</code>.
           </li>
         </ol>
       </p>


### PR DESCRIPTION
This adds more information to the `Getting Started` guide by breaking out the CLI into it's own section. Each OS specific section has links to the latest CLI release tag pulled from github.

![image](https://user-images.githubusercontent.com/1727112/131176303-f9fd13e0-0d98-4750-8b00-6828b3d5b949.png)


> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
