### PR TITLE
Remove "Upgrade Policy" link for device Supervisor

### DIFF
--- a/config/navigation.txt
+++ b/config/navigation.txt
@@ -122,7 +122,6 @@ Reference
     [/reference/supervisor/bandwidth-reduction]
     [/reference/supervisor/docker-compose]
     [/reference/supervisor/supervisor-upgrades]
-    Upgrade policy[/reference/supervisor/upgrade-policy]
 
   Base images
     [/reference/base-images/base-images]


### PR DESCRIPTION
Removed this link because it's been superseded by https://github.com/balena-io/docs/blob/master/pages/reference/supervisor/supervisor-upgrades.md#upgrade-paths