### PR TITLE
Pull variable lists from Supervisor repository docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ pages/reference/balena-cli.md
 pages/reference/sdk/node-sdk.md
 pages/reference/sdk/python-sdk.md
 pages/reference/supervisor/supervisor-api.md
+pages/reference/supervisor/configuration-variables.md
 pages/reference/supervisor/upgrade-policy.md
 pages/learn/deploy/release-strategy/update-locking.md
 pages/reference/diagnostics.md

--- a/config/index.coffee
+++ b/config/index.coffee
@@ -5,7 +5,7 @@ PARTIALS_DIR = 'shared'
 DYNAMIC_DOCS = /.*(getting-started|overview|network).*/
 
 # These files are pulled in externally and so cannot be edited in the base repo
-EXTERNAL_DOCS = /.*(python-sdk|node-sdk|balena-cli|supervisor-api|update-locking|diagnostics|google-iot|azure-iot-hub|cli-masterclass|advanced-cli|host-os-masterclass|services-masterclass|fleet-management|device-debugging|docker-masterclass).*/
+EXTERNAL_DOCS = /.*(configuration-variables|python-sdk|node-sdk|balena-cli|supervisor-api|update-locking|diagnostics|google-iot|azure-iot-hub|cli-masterclass|advanced-cli|host-os-masterclass|services-masterclass|fleet-management|device-debugging|docker-masterclass).*/
 
 FB_APP_ID = '221218511385682'
 

--- a/config/links.coffee
+++ b/config/links.coffee
@@ -40,6 +40,7 @@ module.exports =
     "node-sdk": 'https://github.com/balena-io/balena-sdk/edit/master/DOCUMENTATION.md'
     "balena-cli": 'https://github.com/balena-io/balena-cli/blob/master/CONTRIBUTING.md#editing-documentation-files-readme-install-reference-website'
     "supervisor-api": 'https://github.com/balena-io/balena-supervisor/edit/master/docs/API.md'
+    "configuration-variables": 'https://github.com/balena-io/balena-supervisor/edit/master/docs/configurations.md'
     "update-locking": "https://github.com/balena-io/balena-supervisor/edit/master/docs/update-locking.md"
     "diagnostics": "https://github.com/balena-io/device-diagnostics/edit/master/diagnostics.md"
     "google-iot": "https://github.com/balenalabs/google-iot/edit/master/README.md"

--- a/config/navigation.txt
+++ b/config/navigation.txt
@@ -122,6 +122,7 @@ Reference
     [/reference/supervisor/bandwidth-reduction]
     [/reference/supervisor/docker-compose]
     [/reference/supervisor/supervisor-upgrades]
+    [/reference/supervisor/configuration-variables]
 
   Base images
     [/reference/base-images/base-images]

--- a/pages/learn/manage/configuration.md
+++ b/pages/learn/manage/configuration.md
@@ -1,34 +1,16 @@
 ---
-title: Configuration variables
+title: Configuration
 ---
 
-# Configuration variables
+# Configuration
 
-Configuration variables allow you to provide runtime configuration to the host OS and supervisor. These variables all begin with `{{ $names.company.allCaps}}_` or `RESIN_`. Beginning with supervisor v7.0.0, a number of them appear automatically in your dashboard when your device is provisioned.
+Beyond [service variables][service-variables], you can also configure a lot of the device's behaviour with Supervisor and device specific variables.
 
-Configuration variables can be managed at both the fleet and device level.
+To see the complete list of variables available go to the [Configuration Variables][configuration-reference] reference. 
 
-__Note:__ Configuration variables defined in the dashboard will not apply to devices in [local mode][local-mode].
+**Note:** Some of these settings can potentially brick your device so we encourage that you read our [Advanced boot settings][boot-config-guide] guide.  
 
-## Variable list
-
-This list contains configuration variables that can be used with {{ $names.company.lower }} devices, some of which will automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the dashboard, most of these variables can still be used with older supervisor versions, so be sure to check the *Valid from* column:
-
-Name | Default | Description | Valid from
---- | --- | --- | ---
-BALENA_OVERRIDE_LOCK | 0 | When set to 1 overrides any existing [update lock][update-locking] on the device. Allows updating devices in the case that the release locked updates but is stuck in an invalid state. | v1.0.0
-BALENA_SUPERVISOR_CONNECTIVITY_CHECK | true | Enable / Disable VPN connectivity check | v1.3.0
-BALENA_SUPERVISOR_LOCAL_MODE | false | Enable / Disable [local mode][local-mode] | v4.0.0
-BALENA_SUPERVISOR_LOG_CONTROL | true | Enable / Disable logs being sent to the {{ $names.company.lower }} API | v1.3.0
-BALENA_SUPERVISOR_POLL_INTERVAL | 900000 | Define the {{ $names.company.lower }} API poll interval in milliseconds. This interval will only matter if the device is not connected to the VPN at the time an update is pushed, or if BALENA_SUPERVISOR_INSTANT_UPDATE_TRIGGER is set to false. Starting from supervisor v9.13.0, the supervisor will use a random time between 0.5 and 1.5 times this poll interval each time it checks the balenaCloud API. The minimum value for this variable is defined by the balenaCloud backend, and may vary. | v1.3.0
-BALENA_SUPERVISOR_VPN_CONTROL | true | Enable / Disable VPN | v1.3.0
-BALENA_SUPERVISOR_INSTANT_UPDATE_TRIGGER | true | Enable / Disable instant triggering of updates when a new release is deployed. If set to false, the device will ignore the notification that is triggered when the device's target state has changed. In this case, the device will rely on polling to apply updates. Coupled with a large BALENA_SUPERVISOR_POLL_INTERVAL, this allows spreading out updates in large fleets to avoid overloading local networks when there is a large number of devices at one location. | v9.13.0
-
-In addition to these values, there may be some device-type specific configuration variables that can be set. For example, these are a few of the values that apply to Raspberry Pi devices, corresponding to the contents of the [Raspberry Pi `config.txt` file](https://www.raspberrypi.org/documentation/configuration/config-txt/README.md):
-
-{{> "general/config-variables-pi" }}
-
-You can find more information on updating `config.txt` through configuration variables in our [Advanced Boot Configuration Guide][boot-config-guide].
+Setting these values can be done much like service variables in that you can manage them at the fleet or device level.
 
 ## Managing fleet configuration variables
 
@@ -76,4 +58,6 @@ You can override the value of a custom fleet configuration variable by clicking 
 
 [local-mode]:/learn/develop/local-mode
 [update-locking]:/learn/deploy/release-strategy/update-locking
-[boot-config-guide]:/reference/OS/advanced/#modifying-configtxt-remotely
+[boot-config-guide]:/reference/OS/advanced
+[service-variables]:/learn/manage/variables
+[configuration-reference]:/reference/supervisor/configuration-variables

--- a/pages/reference/OS/advanced.md
+++ b/pages/reference/OS/advanced.md
@@ -9,9 +9,7 @@ __Warning:__ This page contains details of advanced configuration options that e
 
 ## Raspberry Pi
 
-The Raspberry Pi exposes device [configuration options][config-txt] via a text file on the [boot partition][boot-partition] named [`config.txt`][config-txt]. You can change boot options in this file, either by manually editing it before the device's first boot or editing the device [configuration variables][config-vars]. By default, the following values are set for Raspberry Pi devices:
-
-{{> "general/config-variables-pi" }}
+The Raspberry Pi exposes device configuration options via a text file on the [boot partition][boot-partition] named [`config.txt`][config-txt-docs]. You can change boot options in this file, either by manually editing it before the device's first boot or editing the default [configuration][config-vars-config-txt] values. 
 
 The boot partition is mounted on the device at `/mnt/boot`, and so on the device, the file is located at `/mnt/boot/config.txt`. For example, to view the contents of `config.txt` on a provisioned device use the following commands:
 
@@ -26,7 +24,7 @@ Before the device is [provisioned][device-provisioning], you may edit `config.tx
 
 ### Modifying `config.txt` using configuration variables
 
-After the device has been [provisioned][device-provisioning], you can modify the values in `config.txt` using [configuration variables][config-vars].
+After the device has been [provisioned][device-provisioning], you can modify the values in `config.txt` using [configuration variables][config-vars-config-txt].
 
 __Note:__ After modifying a `config.txt` variable, the device supervisor will apply the changes and reboot the device.
 
@@ -36,7 +34,7 @@ Variables that start with the `BALENA_HOST_CONFIG_` or `RESIN_HOST_CONFIG_` pref
 start_x=1
 ```
 
-To manage configuration variables via the dashboard, add/edit variables via the *Fleet Configuration* page for [fleet-wide config variables][config-vars-fleet] and *Device Configuration* for [device specific variables][config-vars-device]. The device-specific variables, if defined, will override the fleet-wide variables of the same name. See the [configuration variables documentation][config-vars] for more details.
+To manage configuration variables via the dashboard, add/edit variables via the *Fleet Configuration* page for [fleet-wide config variables][config-fleet] and *Device Configuration* for [device specific variables][config-device]. The device-specific variables, if defined, will override the fleet-wide variables of the same name. See the [configuration variables documentation][config] for more details.
 
 Configuration values that are prepopulated may be edited or toggled (enabled/disabled):
 
@@ -80,7 +78,7 @@ This has a number of consequences for users of the serial interface:
   - 16550 like registers.
   - Baudrate derived from system clock.
 
-The mini UART is enabled by default for development images. For production images either enable it using [configuration variables][config-vars] or before device provisioning by adding the following entry to `config.txt`:
+The mini UART is enabled by default for development images. For production images either enable it using [configuration variables][config] or before device provisioning by adding the following entry to `config.txt`:
 
 ```
 enable_uart=1
@@ -123,10 +121,11 @@ __Note:__ This setting disables the Raspberry Pi rainbow splash screen but does 
 
 [boot-partition]:/reference/OS/overview/2.x/#image-partition-layout
 [cli]:/reference/cli/reference/balena-cli/#envs
-[config-txt]:https://www.raspberrypi.org/documentation/configuration/config-txt/
-[config-vars]:/learn/manage/configuration
-[config-vars-fleet]:/learn/manage/configuration/#managing-fleet-configuration-variables
-[config-vars-device]:/learn/manage/configuration/#managing-device-configuration-variables
+[config-txt-docs]:https://www.raspberrypi.org/documentation/configuration/config-txt/
+[config]:/learn/manage/configuration
+[config-fleet]:/learn/manage/configuration/#managing-fleet-configuration-variables
+[config-device]:/learn/manage/configuration/#managing-device-configuration-variables
+[config-vars-config-txt]:/reference/supervisor/configuration-variables/#configtxt
 [device-provisioning]:/learn/welcome/primer/#device-provisioning
 [device-tree-overlay]:https://github.com/raspberrypi/linux/blob/rpi-4.19.y/arch/arm/boot/dts/overlays/README
 [gpu-memory]:https://www.raspberrypi.org/documentation/configuration/config-txt/memory.md

--- a/shared/general/config-variables-pi.md
+++ b/shared/general/config-variables-pi.md
@@ -1,5 +1,0 @@
-Name | Default | Description
---- | --- | ---
-BALENA_HOST_CONFIG_disable_splash | 1 | Enable / Disable the Raspberry Pi rainbow splash screen
-BALENA_HOST_CONFIG_dtparam | "i2c_arm=on","spi=on","audio=on" | Define DT parameters
-BALENA_HOST_CONFIG_gpu_mem | 16 | Define device GPU memory in megabytes

--- a/tools/fetch-external.sh
+++ b/tools/fetch-external.sh
@@ -18,6 +18,9 @@ cd shared/sdk/ && {
 # get latest supervisor API docs
 curl -o pages/reference/supervisor/supervisor-api.md -L https://github.com/balena-io/balena-supervisor/raw/master/docs/API.md &
 
+# get latest configuration variable docs
+curl -o pages/reference/supervisor/configuration-variables.md -L https://github.com/balena-io/balena-supervisor/raw/master/docs/configurations.md & 
+
 # get latest diagnostics docs
 curl -o pages/reference/diagnostics.md -L https://github.com/balena-io/device-diagnostics/raw/master/diagnostics.md &
 


### PR DESCRIPTION
Rather then use a local copy of possible configurations values, this pulls [configruations.md](https://github.com/balena-os/balena-supervisor/blob/master/docs/configurations.md) directly from the source that actually implements them (the Supervisor).

I modified the advance boot settings to not include config.txt values because I want them to all be in a single place.

Another benefit of this PR is the side menu has more headings:

![image](https://user-images.githubusercontent.com/3946250/131725558-7edcda47-ff98-4f21-9b3c-0beb584dbf45.png)

and the reference menu:

![image](https://user-images.githubusercontent.com/3946250/131725618-3923aec2-365a-4d2f-b356-2c9775338dcf.png)

