### PR TITLE
Redirect Upgrade Policy links to self-service upgrades

### DIFF
--- a/config/redirects.txt
+++ b/config/redirects.txt
@@ -55,6 +55,7 @@
 ^\/docs\/learn\/deploy\/release-strategy\/update-locking\/API\/?(\?.+)?(#.+)?$ -> /reference/supervisor/supervisor-api/$1$2
 ^\/learn\/more\/masterclass\/?(\?.+)?(#.+)?$ -> /learn/more/masterclasses/overview/$1$2
 ^\/learn\/manage\/serv-vars\/?(\?.+)?(#.+)?$ -> /learn/manage/variables/$1$2
+^\/reference\/supervisor\/upgrade-policy\/?(\?.+)?(#.+)?$ -> /reference/supervisor/supervisor-upgrades/$1$2
 
 # Restructure
 ^\/introduction\/?(\?.+)?(#.+)?$ -> /learn/welcome/introduction/$1$2


### PR DESCRIPTION
Because of https://github.com/balena-io/docs/pull/2068 any links to the upgrade policy will 404 and I think that page is probably linked enough to warrant a redirect which I didn't think of until after.

Redirects https://balena.io/docs/reference/supervisor/upgrade-policy -> https://www.balena.io/docs/reference/supervisor/supervisor-upgrades/