### PR TITLE
Pull external files before running link-checker

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   unit:
-    name: Run link checker
     runs-on: ubuntu-latest
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine

--- a/lychee.toml
+++ b/lychee.toml
@@ -70,7 +70,16 @@ exclude = [
     "https://raw.githubusercontent.com/balena-os/meta-balena",
     "https://github.com/myorg/myapp",
     "https://index.docker.io/v2/",
-    "https://api.balena-cloud.com/",
+    "https://api.balena-(cloud|staging).com/",
+    "https://delta.balena-(cloud|staging).com/",
+    "https://builder.balena-(cloud|staging).com/",
+    "https://dashboard.balena-(cloud|staging).com/devices/",
+    ".balenadevice.io",
+    "https://index.docker.io/v1/",
+    "http://api.resin.io",
+    ".local",
+    "http://backend:1234",
+    "http:/%25s:%25s",
     "git://github.com/",
 ]
 

--- a/pages/learn/develop/integrations.md
+++ b/pages/learn/develop/integrations.md
@@ -9,7 +9,7 @@ excerpt: Guides to integrate {{ $names.company.lower }} with a variety of IoT pl
 
 ### Guides
 
-* [Amazon AWS IoT](aws/)
-* [Azure IoT Hub](azure-iot-hub/)
-* [Google IoT](google-iot/)
-* [IBM BlueMix](bluemix/)
+* [Amazon AWS IoT](/learn/develop/integrations/aws/)
+* [Azure IoT Hub](/learn/develop/integrations/azure-iot-hub/)
+* [Google IoT](/learn/develop/integrations/google-iot/)
+* [IBM BlueMix](/learn/develop/integrations/bluemix/)

--- a/shared/general/host-ssh.md
+++ b/shared/general/host-ssh.md
@@ -118,7 +118,7 @@ In some cases, you may need to examine the contents of certain directories or fi
 
 Note that the [filesystem layout][filesystem] may look slightly different from what you’d expect—for example, the two locations mentioned above are found at `/mnt/data` and `/mnt/boot` respectively.
 
-[forums]:{{$names.forums_domain}}/c/product-support
+[forums]:{{ $names.forums_domain }}/c/product-support
 [engine-link]:{{ $links.engineSiteUrl }}
 [nmcli]:https://fedoraproject.org/wiki/Networking/CLI
 [mmcli]:https://www.freedesktop.org/software/ModemManager/man/1.8.0/mmcli.8.html

--- a/shared/getting-started/whatYouNeed/var-som-mx6.md
+++ b/shared/getting-started/whatYouNeed/var-som-mx6.md
@@ -1,11 +1,12 @@
 <img style="float: right;padding-left: 10px;" src="/img/{{ $device.id }}/{{ $device.id }}.jpg" width="30%">
 
 * A [{{ $device.name }}][device-link] module. See our [supported devices list][supportedDevicesList] for other boards.
-* A carrier board, in this case the [VAR-SOLOCustomboard](carrier-link)
+* A carrier board, in this case the [VAR-SOLOCustomboard][carrier-link]
 * A micro SD card.
 * **[Optional]** An ethernet cable.
 * A [{{ $names.company.lower }} account][link-to-signup].
- [device-link]:{{ $device.link }}
- [carrier-link]:https://www.variscite.com/products/single-board-computers/var-solocustomboard/
+
+[device-link]:{{ $device.link }}
+[carrier-link]:https://www.variscite.com/products/single-board-computers/var-solocustomboard/
 [supportedDevicesList]:/hardware/devices/
 [link-to-signup]:{{ $links.dashboardUrl }}/signup


### PR DESCRIPTION
Pull external files before running link-checker.

This actually finds a lot of dead URLs we were previously missing so the exceptions have been updated as well.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
Resolves: https://github.com/balena-io/docs/issues/2107
