### PR TITLE
Add missing genericx86-64-ext device type

### DIFF
--- a/shared/general/deviceTypeNames.md
+++ b/shared/general/deviceTypeNames.md
@@ -19,6 +19,7 @@
 | Dart                            | imx6ul-var-dart                           | armv7hf                           | [Link]({{ $links.githubBaseImages }}/imx6ul-var-dart)       |
 | Generic AARCH64                 | generic-aarch64                           | aarch64                           | [Link]({{ $links.githubBaseImages }}/generic-aarch64)       |
 | Generic ARMv7-a HF              | generic-armv7ahf                          | armv7hf                           | [Link]({{ $links.githubBaseImages }}/generic-armv7ahf)      |
+| Generic x86_64                  | genericx86-64-ext                         | amd64                             | [Link]({{ $links.githubBaseImages }}/genericx86-64-ext)     |
 | Hummingboard                    | hummingboard                              | armv7hf                           | [Link]({{ $links.githubBaseImages }}/hummingboard)          |
 | Intel Edison                    | intel-edison                              | i386                              | [Link]({{ $links.githubBaseImages }}/intel-edison)          |
 | Intel NUC                       | intel-nuc                                 | amd64                             | [Link]({{ $links.githubBaseImages }}/intel-nuc)             |


### PR DESCRIPTION
See: https://jel.ly.fish/support-thread-documentation-need-updated-amd64-genericx86-64-ext-1b5828a
Change-type: patch
Signed-off-by: Andrea Rosci <andrear@balena.io>


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
