### PR TITLE
patch: Clarify deltas default behavior

### DIFF
--- a/pages/learn/deploy/delta.md
+++ b/pages/learn/deploy/delta.md
@@ -15,7 +15,7 @@ These binary deltas save on the amount of data needed to be downloaded, reduce t
 
 ## Enabling delta updates
 
-For any devices running {{ $names.os.lower }} >= 2.47.1, the delta update behavior is enabled by default. For devices running {{ $names.os.lower }} < 2.47.1, updating to >= 2.47.1 via a [self-service update][self-service-update] will enable delta updates for the device.
+The delta updates feature is now available in all devices running {{ $names.os.lower }} >= 2.47.1. For devices running {{ $names.os.lower }} < 2.47.1, updating to >= 2.47.1 via a [self-service update][self-service-update] will enable delta updates for your device.
 
 ## Delta behavior
 


### PR DESCRIPTION
Clarified deltas default enabled behavior can't be disabled on devices above balenaOS 2.47.1

﻿Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>

---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
