### PR TITLE
Automate configuration list through balena API

### DIFF
--- a/config/navigation.txt
+++ b/config/navigation.txt
@@ -126,7 +126,7 @@ Reference
     # Handled in redirects.txt
     Configuration List[/reference/supervisor/configuration-list/]
       # with $device being dynamic
-      Configuration List for {{ $device.name }}[/reference/supervisor/configuration-list/$device/]
+      Configuration list for {{ $device.name }}[/reference/supervisor/configuration-list/$device/]
 
       
   Base images

--- a/config/navigation.txt
+++ b/config/navigation.txt
@@ -123,7 +123,12 @@ Reference
     [/reference/supervisor/bandwidth-reduction]
     [/reference/supervisor/docker-compose]
     [/reference/supervisor/supervisor-upgrades]
+    # Handled in redirects.txt
+    Configuration List[/reference/supervisor/configuration-list/]
+      # with $device being dynamic
+      Configuration List for {{ $device.name }}[/reference/supervisor/configuration-list/$device/]
 
+      
   Base images
     [/reference/base-images/base-images]
     [/reference/base-images/base-images-ref]

--- a/config/redirects.txt
+++ b/config/redirects.txt
@@ -30,6 +30,7 @@
 
 # Default redirects
 ^\/learn\/getting-started\/?(\?.+)?(#.+)?$ -> /learn/getting-started/raspberrypi3/nodejs/$1$2
+^\/reference\/supervisor\/configuration-list\/?(\?.+)?(#.+)?$ -> /reference/supervisor/configuration-list/raspberrypi3/$1$2
 ^\/learn\/develop\/?(\?.+)?(#.+)?$ -> /learn/develop/local-mode/$1$2
 ^\/learn\/deploy\/?(\?.+)?(#.+)?$ -> /learn/deploy/deployment/$1$2
 ^\/learn\/deploy\/build-optimisation\/?(\?.+)?(#.+)?$ -> /learn/deploy/build-optimization/$1$2

--- a/pages/learn/manage/configuration.md
+++ b/pages/learn/manage/configuration.md
@@ -85,4 +85,6 @@ __Note:__ In addition to the dashboard, this configuration can be also be set us
 [cli]:/reference/cli/reference/balena-cli/#envs
 [local-mode]:/learn/develop/local-mode
 [update-locking]:/learn/deploy/release-strategy/update-locking
-[boot-config-guide]:/reference/OS/advanced/#modifying-configtxt-using-configuration-variables
+[boot-config-guide]:/reference/OS/advanced
+[service-variables]:/learn/manage/variables
+[configuration-reference]:/reference/supervisor/configuration-variables

--- a/pages/learn/manage/configuration.md
+++ b/pages/learn/manage/configuration.md
@@ -12,29 +12,13 @@ __Note:__ Configuration defined in the dashboard will not apply to devices in [l
 
 ## Variable list
 
-This list contains variables that can be used with {{ $names.company.lower }} devices, some of which will automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the dashboard, most of these variables can still be used with older supervisor versions, so be sure to check the *Valid from* column:
+Aside from [variables][variables], you can also configure device behavior with Supervisor or device type specific variables.
 
-Name | Default | Description | Valid from
---- | --- | --- | ---
-BALENA_OVERRIDE_LOCK | 0 | When set to 1 overrides any existing [update lock][update-locking] on the device. Allows updating devices in the case that the release locked updates but is stuck in an invalid state. | v1.0.0
-BALENA_SUPERVISOR_CONNECTIVITY_CHECK | true | Enable / Disable VPN connectivity check | v1.3.0
-BALENA_SUPERVISOR_LOCAL_MODE | false | Enable / Disable [local mode][local-mode] | v4.0.0
-BALENA_SUPERVISOR_LOG_CONTROL | true | Enable / Disable logs being sent to the {{ $names.company.lower }} API | v1.3.0
-BALENA_SUPERVISOR_POLL_INTERVAL | 900000 | Define the {{ $names.company.lower }} API poll interval in milliseconds. This value can increase if the device needs to backoff due to server errors. The minimum value for this variable is defined by the balenaCloud backend, and may vary. | v1.3.0
-BALENA_SUPERVISOR_VPN_CONTROL | true | Enable / Disable VPN | v1.3.0
-BALENA_SUPERVISOR_INSTANT_UPDATE_TRIGGER | true | Enable / Disable instant triggering of updates when a new release is deployed. If set to false, the device will ignore the notification that is triggered when the device's target state has changed. In this case, the device will rely on polling to apply updates. Note: You can spread out updates on devices if you disable instant updates and specify a different poll interval for each device in your fleet. This avoids overloading local networks if they are all at one location. | v9.13.0
-
-In addition to these values, there may be some device-type specific configuration variables that can be set. For example, these are a few of the values that apply to Raspberry Pi devices, corresponding to the contents of the [Raspberry Pi `config.txt` file](https://www.raspberrypi.com/documentation/computers/config_txt.html):
-
-{{> "general/config-variables-pi" }}
-
-You can find more information on updating `config.txt` through the configuration tab in our [Advanced Boot Configuration Guide][boot-config-guide].
+For a complete list of valid configuration variables that can be configured, check the [configuration list][configuration-list].
 
 ## Fleet configuration management
 
-Configuration defined at the fleet level controls the behavior of any devices running in that fleet unless it is overridden with device configuration of the same name.
-
-If you want to change the default value for any of the pre-populated configuration, make sure you are in the *Configuration* tab on the fleet, then click *activate* for the variable you wish to define:
+Configuration defined at the fleet level controls the behavior of any devices running in that fleet unless it is overridden with device configuration of the same name. If you want to change the default value for any of the pre-populated configuration, make sure you are in the *Configuration* tab on the fleet, then click *activate* for the variable you wish to define:
 
 <img alt="Activate fleet level configuration" src="/img/configuration/activate_default_config.png" width="100%">
 
@@ -56,13 +40,13 @@ The device level configuration list includes the pre-populated default values. V
 
 <img alt="Device configuration" src="/img/configuration/device_config_variables.png" width="100%">
 
-Clicking the edit icon will pop up a small dialog for editing the value:
+Clicking the small edit (pencil) icon will pop up a small dialog for editing the value:
 
 <img alt="Edit device configuration" src="/img/configuration/edit_device_config.png" width="80%">
 
 To remove the device level configuration, and reset it to its default value, click the delete (trash can) icon.
 
-### Adding custom configuration
+## Adding custom configuration
 
 The custom configuration section can be used to modify configuration options beyond the ones pre-populated for your device using the balenaCloud dashboard. Examples include, [modifying config.txt using configuration variables][boot-config-guide] for Raspberry Pi devices.
 
@@ -85,6 +69,7 @@ __Note:__ In addition to the dashboard, this configuration can be also be set us
 [cli]:/reference/cli/reference/balena-cli/#envs
 [local-mode]:/learn/develop/local-mode
 [update-locking]:/learn/deploy/release-strategy/update-locking
-[boot-config-guide]:/reference/OS/advanced
+[boot-config-guide]:/reference/OS/advanced#modifying-configtxt-using-configuration-variables
 [service-variables]:/learn/manage/variables
-[configuration-reference]:/reference/supervisor/configuration-variables
+[configuration-list]:/reference/supervisor/configuration-list
+[variables]:/learn/manage/variables

--- a/pages/reference/OS/advanced.md
+++ b/pages/reference/OS/advanced.md
@@ -9,7 +9,7 @@ __Warning:__ This page contains details of advanced configuration options that e
 
 ## Raspberry Pi
 
-The Raspberry Pi exposes device configuration options via a text file on the [boot partition][boot-partition] named [`config.txt`][config-txt-docs]. You can change boot options in this file, either by manually editing it before the device's first boot or editing the default [configuration][configuration] values.
+The Raspberry Pi exposes device configuration options via a text file on the [boot partition][boot-partition] named [`config.txt`][config-txt-docs]. You can change boot options in this file, either by manually editing it before the device's first boot or editing the default [configuration][configuration-list] values using the device [Configuration][configuration] tab in the balenaCloud dashboard. 
 
 The boot partition is mounted on the device at `/mnt/boot`, so the file is located at `/mnt/boot/config.txt` on the device. To view the contents of `config.txt` on a provisioned device, use the following commands:
 

--- a/pages/reference/OS/advanced.md
+++ b/pages/reference/OS/advanced.md
@@ -9,11 +9,9 @@ __Warning:__ This page contains details of advanced configuration options that e
 
 ## Raspberry Pi
 
-The Raspberry Pi exposes device [configuration options][config-txt] via a text file on the [boot partition][boot-partition] named [`config.txt`][config-txt]. You can change boot options in this file, either by manually editing it before the device's first boot or editing the device [configuration variables][config-vars]. By default, the following values are set for Raspberry Pi devices:
+The Raspberry Pi exposes device configuration options via a text file on the [boot partition][boot-partition] named [`config.txt`][config-txt-docs]. You can change boot options in this file, either by manually editing it before the device's first boot or editing the default [configuration][configuration] values.
 
-{{> "general/config-variables-pi" }}
-
-The boot partition is mounted on the device at `/mnt/boot`, and so on the device, the file is located at `/mnt/boot/config.txt`. For example, to view the contents of `config.txt` on a provisioned device use the following commands:
+The boot partition is mounted on the device at `/mnt/boot`, so the file is located at `/mnt/boot/config.txt` on the device. To view the contents of `config.txt` on a provisioned device, use the following commands:
 
 ```shell
 $ balena ssh <uuid>

--- a/pages/reference/OS/advanced.md
+++ b/pages/reference/OS/advanced.md
@@ -9,7 +9,7 @@ __Warning:__ This page contains details of advanced configuration options that e
 
 ## Raspberry Pi
 
-The Raspberry Pi exposes device configuration options via a text file on the [boot partition][boot-partition] named [`config.txt`][config-txt-docs]. You can change boot options in this file, either by manually editing it before the device's first boot or editing the default [configuration][configuration-list] values using the device [Configuration][configuration] tab in the balenaCloud dashboard. 
+The Raspberry Pi exposes device configuration options via a text file on the [boot partition][boot-partition] named [`config.txt`][config-txt]. You can change boot options in this file, either by manually editing it before the device's first boot or editing the default [configuration][configuration-list] values using the device [Configuration][configuration] tab in the balenaCloud dashboard. 
 
 The boot partition is mounted on the device at `/mnt/boot`, so the file is located at `/mnt/boot/config.txt` on the device. To view the contents of `config.txt` on a provisioned device, use the following commands:
 
@@ -110,6 +110,7 @@ __Note:__ This setting disables the Raspberry Pi rainbow splash screen but does 
 [boot-partition]:/reference/OS/overview/2.x/#image-partition-layout
 [config-txt]:https://www.raspberrypi.com/documentation/computers/config_txt.html
 [configuration]:/learn/manage/configuration
+[configuration-list]:/reference/supervisor/configuration-list
 [configuration-fleet]:/learn/manage/configuration/#fleet-configuration-management
 [configuration-device]:/learn/manage/configuration/#device-configuration-management
 [custom-configuration]:/learn/manage/configuration/#adding-custom-configuration

--- a/pages/reference/supervisor/configuration-list.md
+++ b/pages/reference/supervisor/configuration-list.md
@@ -1,0 +1,21 @@
+---
+title: Configuration List for {{ $device.name }}
+
+layout: config.html
+extras: config-js
+
+dynamic:
+  variables: [ $device ]
+  ref: $original_ref/$device
+  $switch_text: Configuration for $device
+---
+
+# {{ title }}
+
+This list contains configuration variables that can be used with {{ $names.company.lower }} devices, some of which will automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the dashboard, most of these variables can still be used with older supervisor versions, so be sure to check the *Valid from* column.
+
+In addition to these values, there may be some device-type specific configuration variables that can be set. For example, these are a few of the values that apply to Raspberry Pi devices, corresponding to the contents of the [Raspberry Pi `config.txt` file](https://www.raspberrypi.org/documentation/configuration/config-txt/README.md)
+
+You can find more information on updating `config.txt` through configuration variables in our [Advanced Boot Configuration Guide][boot-config-guide].
+
+[boot-config-guide]:/reference/OS/advanced/#modifying-configtxt-remotely

--- a/pages/reference/supervisor/configuration-list.md
+++ b/pages/reference/supervisor/configuration-list.md
@@ -9,13 +9,3 @@ dynamic:
   ref: $original_ref/$device
   $switch_text: Configuration for $device
 ---
-
-# {{ title }}
-
-This list contains configuration variables that can be used with {{ $names.company.lower }} devices, some of which will automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the dashboard, most of these variables can still be used with older supervisor versions, so be sure to check the *Valid from* column.
-
-In addition to these values, there may be some device-type specific configuration variables that can be set. For example, these are a few of the values that apply to Raspberry Pi devices, corresponding to the contents of the [Raspberry Pi `config.txt` file](https://www.raspberrypi.org/documentation/configuration/config-txt/README.md)
-
-You can find more information on updating `config.txt` through configuration variables in our [Advanced Boot Configuration Guide][boot-config-guide].
-
-[boot-config-guide]:/reference/OS/advanced/#modifying-configtxt-remotely

--- a/shared/general/config-variables-pi.md
+++ b/shared/general/config-variables-pi.md
@@ -1,5 +1,0 @@
-Name | Default | Description
---- | --- | ---
-BALENA_HOST_CONFIG_disable_splash | 1 | Enable / Disable the Raspberry Pi rainbow splash screen
-BALENA_HOST_CONFIG_dtparam | "i2c_arm=on","spi=on","audio=on" | Define DT parameters
-BALENA_HOST_CONFIG_gpu_mem | 16 | Define device GPU memory in megabytes

--- a/templates/_base-images-ref.html
+++ b/templates/_base-images-ref.html
@@ -51,6 +51,7 @@
         return window.jQuery("#base-images-ref").append(table);
       })
       .fail(function (error) {
+        console.error(error);
         return window
           .jQuery("#base-images-ref")
           .append(

--- a/templates/_config.html
+++ b/templates/_config.html
@@ -12,16 +12,19 @@
           let property = properties[key]
           table +=
             `<tr>
-              <td>
-                ${property.hasOwnProperty("description") ? property.description : "No description available"}
-                ${property.examples != null && property.examples.length > 0 ? '<br /> Example:' + property.examples[0] : ''}
-              </td>
               <td>${key}</td>
               <td>
                 ${Array.isArray(property.enum) ? property.enum.join(', ') : property.type}
               </td>
               <td>
+                ${property.hasOwnProperty("will_reboot") ? "Yes" : "No"}
+              </td>
+              <td>
                 ${property.hasOwnProperty("default") ? property.default : ""}
+              </td>
+              <td>
+                ${property.hasOwnProperty("description") ? property.description : "No description available"}
+                ${property.examples != null && property.examples.length > 0 ? '<br /> Example:' + property.examples[0] : ''}
               </td>
             </tr>`
         })

--- a/templates/_config.html
+++ b/templates/_config.html
@@ -14,8 +14,11 @@
             table += 
               `<tr>
               <td>${key}</td>
-              <td>${property.hasOwnProperty("enum") ? "boolean" : property.type }</td>
-              <td>${property.hasOwnProperty("description") ? property.description : "No description available"}</td>
+              <td>${Array.isArray(property. enum) ? property. enum.join(', ') : property.type}</td>
+              <td>
+                  ${property.hasOwnProperty("description") ? property.description : "No description available"}
+                  ${property.examples != null && property.examples.length > 0 ? '<br /> Example:' + property.examples[0] : ''}
+              </td>
               <td>${property.hasOwnProperty("default") ? property.default : "No default value" }</td>
               </tr>`
           })

--- a/templates/_config.html
+++ b/templates/_config.html
@@ -14,17 +14,17 @@
             `<tr>
               <td>${key}</td>
               <td>
-                ${Array.isArray(property.enum) ? property.enum.join(', ') : property.type}
+                ${property.hasOwnProperty("description") ? property.description : "No description available"}
+                ${property.examples != null && property.examples.length > 0 ? '<br /> Example:' + property.examples[0] : ''}
               </td>
               <td>
                 ${property.hasOwnProperty("will_reboot") ? "Yes" : "No"}
               </td>
               <td>
-                ${property.hasOwnProperty("default") ? property.default : ""}
+                ${Array.isArray(property.enum) ? property.enum.join(', ') : property.type}
               </td>
               <td>
-                ${property.hasOwnProperty("description") ? property.description : "No description available"}
-                ${property.examples != null && property.examples.length > 0 ? '<br /> Example:' + property.examples[0] : ''}
+                ${property.hasOwnProperty("default") ? property.default : ""}
               </td>
             </tr>`
         })

--- a/templates/_config.html
+++ b/templates/_config.html
@@ -1,6 +1,5 @@
 <script src="//cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.15/lodash.min.js" type="text/javascript"></script>
 <script type="text/javascript">
-
   (function () {
     window.jQuery
       .ajax({
@@ -9,24 +8,29 @@
       .done(function (deviceTypeVars) {
         let table = ""
         var properties = deviceTypeVars.configVarSchema.properties
-            Object.keys(properties).forEach(function (key) {
-              let property = properties[key]
-            table += 
-              `<tr>
-              <td>${key}</td>
-              <td>${Array.isArray(property. enum) ? property. enum.join(', ') : property.type}</td>
+        Object.keys(properties).forEach(function (key) {
+          let property = properties[key]
+          table +=
+            `<tr>
               <td>
-                  ${property.hasOwnProperty("description") ? property.description : "No description available"}
-                  ${property.examples != null && property.examples.length > 0 ? '<br /> Example:' + property.examples[0] : ''}
+                ${property.hasOwnProperty("description") ? property.description : "No description available"}
+                ${property.examples != null && property.examples.length > 0 ? '<br /> Example:' + property.examples[0] : ''}
               </td>
-              <td>${property.hasOwnProperty("default") ? property.default : "No default value" }</td>
-              </tr>`
-          })
-          return window.jQuery("#support_devices_table").append(table);
+              <td>${key}</td>
+              <td>
+                ${Array.isArray(property.enum) ? property.enum.join(', ') : property.type}
+              </td>
+              <td>
+                ${property.hasOwnProperty("default") ? property.default : ""}
+              </td>
+            </tr>`
+        })
+        return window.jQuery("#config_table").append(table);
       })
       .fail(function (error) {
+        console.error(error)
         return window
-          .jQuery("#support_devices_table")
+          .jQuery("#config_table")
           .append(
             '<tr><td colspan="4">Something went wrong.</td></tr>'
           );

--- a/templates/_config.html
+++ b/templates/_config.html
@@ -1,0 +1,32 @@
+<script src="//cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.15/lodash.min.js" type="text/javascript"></script>
+<script type="text/javascript">
+
+  (function () {
+    window.jQuery
+      .ajax({
+        url: `https://api.balena-cloud.com/config/vars?deviceType={{ $device.id }}`
+      })
+      .done(function (deviceTypeVars) {
+        let table = ""
+        var properties = deviceTypeVars.configVarSchema.properties
+            Object.keys(properties).forEach(function (key) {
+              let property = properties[key]
+            table += 
+              `<tr>
+              <td>${key}</td>
+              <td>${property.hasOwnProperty("enum") ? "boolean" : property.type }</td>
+              <td>${property.hasOwnProperty("description") ? property.description : "No description available"}</td>
+              <td>${property.hasOwnProperty("default") ? property.default : "No default value" }</td>
+              </tr>`
+          })
+          return window.jQuery("#support_devices_table").append(table);
+      })
+      .fail(function (error) {
+        return window
+          .jQuery("#support_devices_table")
+          .append(
+            '<tr><td colspan="4">Something went wrong.</td></tr>'
+          );
+      });
+  }.call(this))
+</script>

--- a/templates/_devices.html
+++ b/templates/_devices.html
@@ -68,6 +68,7 @@
         return window.jQuery("#support_devices_table").append(table);
       })
       .fail(function (error) {
+        console.error(error)
         return window
           .jQuery("#support_devices_table")
           .append(

--- a/templates/_machines-architectures.html
+++ b/templates/_machines-architectures.html
@@ -29,6 +29,7 @@
         return window.jQuery("#machines_architectures").append(table);
       })
       .fail(function (error) {
+        console.error(error);
         return window
           .jQuery("#machines_architectures")
           .append(

--- a/templates/config.html
+++ b/templates/config.html
@@ -19,16 +19,17 @@
 <table>
   <thead>
     <tr>
-      <th>Name</th>
       <th>Variable Name</th>
-      <th>Value</th>
+      <th>Type</th>
+      <th>Will reboot</th>
       <th>Default</th>
+      <th>Description</th>
     </tr>
   </thead>
   <tbody id="config_table"></tbody>
 </table>
-{% endblock %}
 
 <p>
   You can find more information on updating config.txt through configuration variables in our <a href="/reference/OS/advanced/#modifying-configtxt-using-configuration-variables">Advanced Boot Configuration Guide</a>. In addition to the dashboard, this configuration can be also be set using the API or any of its clients, including the <a href="/reference/sdk/node-sdk">SDK</a> and <a href="/reference/cli/reference/balena-cli/#envs">CLI</a>.
 </p>
+{% endblock %}

--- a/templates/config.html
+++ b/templates/config.html
@@ -1,8 +1,8 @@
 {% extends "default.html" %}
 
 {% block dynamicSwitchCustom %}
-  <p class="dynamic-switch__append">
-  </p>
+<p class="dynamic-switch__append">
+</p>
 {% endblock %}
 
 {% block "contents" %}
@@ -10,26 +10,35 @@
   Configuration List for {{ $device.name }}
 </h1>
 <p>
-  The list contains configuration and their respective variables that can be used with {{ $names.company.lower }} devices. Some of which will automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check the *Supported by* context for each configuration.
+  The list contains configuration and their respective variables that can be used with {{ $names.company.lower }}
+  devices. Some of which will automatically appear for devices with supervisor v7.0.0 and greater. While they may not
+  automatically populate in the Configuration dashboard, most of these variables can still be used with older supervisor
+  versions, so be sure to check the *Supported by* context for each configuration.
 </p>
 <p>
-  In addition to these values, there may be device-type specific configuration variables that can be set. For example, these are a few of the values that apply to Raspberry Pi devices, corresponding to the contents of the <a href="https://www.raspberrypi.com/documentation/computers/config_txt.html">Raspberry Pi config.txt file</a>
+  In addition to these values, there may be device-type specific configuration variables that can be set. For example,
+  these are a few of the values that apply to Raspberry Pi devices, corresponding to the contents of the <a
+    href="https://www.raspberrypi.com/documentation/computers/config_txt.html">Raspberry Pi config.txt file</a>.
 </p>
 
 <table>
   <thead>
     <tr>
       <th>Variable Name</th>
-      <th>Type</th>
-      <th>Will reboot</th>
-      <th>Default</th>
       <th>Description</th>
+      <th>Will reboot</th>
+      <th>Type</th>
+      <th>Default</th>
     </tr>
   </thead>
   <tbody id="config_table"></tbody>
 </table>
 
 <p>
-  You can find more information on updating config.txt through configuration variables in our <a href="/reference/OS/advanced/#modifying-configtxt-using-configuration-variables">Advanced Boot Configuration Guide</a>. In addition to the dashboard, this configuration can be also be set using the API or any of its clients, including the <a href="/reference/sdk/node-sdk">SDK</a> and <a href="/reference/cli/reference/balena-cli/#envs">CLI</a>.
+  You can find more information on updating config.txt through configuration variables in our <a
+    href="/reference/OS/advanced/#modifying-configtxt-using-configuration-variables">Advanced Boot Configuration
+    Guide</a>. In addition to the dashboard, this configuration can be also be set using the API or any of its clients,
+  including the <a href="/reference/sdk/node-sdk">SDK</a> and <a
+    href="/reference/cli/reference/balena-cli/#envs">CLI</a>.
 </p>
 {% endblock %}

--- a/templates/config.html
+++ b/templates/config.html
@@ -6,19 +6,29 @@
 {% endblock %}
 
 {% block "contents" %}
-
 <h1>
   Configuration List for {{ $device.name }}
 </h1>
+<p>
+  The list contains configuration and their respective variables that can be used with {{ $names.company.lower }} devices. Some of which will automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check the *Supported by* context for each configuration.
+</p>
+<p>
+  In addition to these values, there may be device-type specific configuration variables that can be set. For example, these are a few of the values that apply to Raspberry Pi devices, corresponding to the contents of the <a href="https://www.raspberrypi.com/documentation/computers/config_txt.html">Raspberry Pi config.txt file</a>
+</p>
+
 <table>
   <thead>
     <tr>
-      <th>Configuration</th>
+      <th>Name</th>
+      <th>Variable Name</th>
       <th>Value</th>
-      <th>Description</th>
       <th>Default</th>
     </tr>
   </thead>
-  <tbody id="support_devices_table"></tbody>
+  <tbody id="config_table"></tbody>
 </table>
 {% endblock %}
+
+<p>
+  You can find more information on updating config.txt through configuration variables in our <a href="/reference/OS/advanced/#modifying-configtxt-using-configuration-variables">Advanced Boot Configuration Guide</a>. In addition to the dashboard, this configuration can be also be set using the API or any of its clients, including the <a href="/reference/sdk/node-sdk">SDK</a> and <a href="/reference/cli/reference/balena-cli/#envs">CLI</a>.
+</p>

--- a/templates/config.html
+++ b/templates/config.html
@@ -1,0 +1,24 @@
+{% extends "default.html" %}
+
+{% block dynamicSwitchCustom %}
+  <p class="dynamic-switch__append">
+  </p>
+{% endblock %}
+
+{% block "contents" %}
+
+<h1>
+  Configuration List for {{ $device.name }}
+</h1>
+<table>
+  <thead>
+    <tr>
+      <th>Configuration</th>
+      <th>Value</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody id="support_devices_table"></tbody>
+</table>
+{% endblock %}

--- a/templates/default.html
+++ b/templates/default.html
@@ -80,6 +80,9 @@
     {% if extras == "devices-js" %}
       {% include "_devices.html" %}
     {% endif %}
+    {% if extras == "config-js" %}
+      {% include "_config.html" %}
+    {% endif %}
     {% if extras == "base-images-ref-js" %}
       {% include "_base-images-ref.html" %}
     {% endif %}


### PR DESCRIPTION
- Add a new page for the configuration list with a dropdown menu for device types
- Parsing API response to generate a table with some description
- Add page to the /reference/supervisor section
- Redirected to raspberrypi3's configuration list as the default device type

## Demo 

![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/22801822/146465182-d02f5c25-c987-4acd-9d4c-9d5a4fa3f548.gif)


TODO 

- [x] Need to merge #2144 first to bolt down the configuration variables naming issue
- [ ] The redirect is acting up a little where when it redirects but also restores the state of the sidebar for some reason. Need to fix this. 
- [x] We really need to implement this first: https://jel.ly.fish/e06ebc86-6c96-43cb-9775-415a60156b1e so the API response is standardized in the short term - https://github.com/balena-io/open-balena-api/pull/896