### PR TITLE
Revert "patch: bump lycheeverse/lychee-action from 1.1.1 to 1.2.0"

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v1.2.0
+        uses: lycheeverse/lychee-action@v1.1.1
         with:
           args: >
             --config ./lychee.toml


### PR DESCRIPTION
Lychee's Github action 1.2.0 fails to parse markdown files, hence reverting back. 

Related: 
https://github.com/lycheeverse/lychee/issues/436
https://github.com/lycheeverse/lychee-action/issues/67

Reverts balena-io/docs#2156

