### PR TITLE
Be more explicit about risks of using advanced configuration variables

### DIFF
--- a/pages/reference/OS/advanced.md
+++ b/pages/reference/OS/advanced.md
@@ -5,7 +5,7 @@ excerpts: Configuration options to expose more device functionality to {{ $names
 
 # Advanced boot settings
 
-__Warning:__ This page contains details of advanced configuration options that expose more functionality, but any mistakes may potentially leave a device inaccessible.
+__Warning:__ This page contains details of advanced configuration options that expose more functionality, but any mistakes may potentially leave a device inaccessible. Be sure to try your changes in a controlled environment before applying them to production devices.
 
 ## Raspberry Pi
 

--- a/templates/config.html
+++ b/templates/config.html
@@ -20,6 +20,10 @@
   these are a few of the values that apply to Raspberry Pi devices, corresponding to the contents of the <a
     href="https://www.raspberrypi.com/documentation/computers/config_txt.html">Raspberry Pi config.txt file</a>.
 </p>
+<p>
+  <strong>Warning:</strong> Wrong configuration may potentially leave a device inaccessible. Be sure to try your changes
+  in a controlled environment before applying them to production devices.
+</p>
 
 <table>
   <thead>


### PR DESCRIPTION
This came from a particular set of changes to config.txt file
on a Raspberry Pi making the device not boot but the problem is general
enough to apply to all devices. There are many ways of misconfiguring
the variables to make the system not bootable, certainly more that we
would be able to list in the docs, therefore the suggestion is to try
in a controlled environment before rolling to production.

---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
