### PR TITLE
network/2.x: Add instructions to disable IPv6 if required

### DIFF
--- a/shared/network/2.x.md
+++ b/shared/network/2.x.md
@@ -11,6 +11,7 @@
 * [Network Requirements](#network-requirements)
 * [Connecting Behind a Proxy](#connecting-behind-a-proxy)
 * [Checking connectivity](#checking-connectivity)
+* [Disable IPv6](#disable-ipv6)
 
 ## Introduction
 
@@ -507,6 +508,32 @@ We've published an example [here](https://github.com/balenalabs/proxy-tunnel) de
 You can configure a connectivity check using NetworkManager's builtin [feature][nm-connectivity]. In order to configure
 custom endpoints, the URL, expected response, and check interval can be set in `config.json` (more information available
 [here][meta-balena-connectivity]). By default, NetworkManager is configured to use {{ $names.cloud.lower }} to perform the check.
+
+## Disable IPv6
+
+In cases where a local network issue is preventing IPv6 traffic from being routed, you can fully disable IPv6 in {{ $names.os.lower }} 2.0 with the following commands.
+
+__Warning:__ Making changes to the networking of a device is extremely dangerous and can lead to a device being unrecoverable, so exercise caution with any of the following.
+
+```
+root@087fd7c:/# nmcli c show
+NAME                UUID                                  TYPE      DEVICE
+Wired connection    087fd7cd-9a6b-423c-8b64-c30cbf6a7126  ethernet  eno1
+...
+
+root@087fd7c:~# nmcli c edit 087fd7cd-9a6b-423c-8b64-c30cbf6a7126
+
+nmcli> set ipv6.method disable
+
+nmcli> save persistent
+Connection 'Wired connection' (087fd7cd-9a6b-423c-8b64-c30cbf6a7126) successfully updated.
+
+nmcli> quit
+
+root@087fd7c:~# nmcli c up 087fd7cd-9a6b-423c-8b64-c30cbf6a7126
+```
+
+To re-enable IPv6 follow the same commands but with `set ipv6.method enable`.
 
 <!-- links -->
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>

Based on discussion in brainstorm topic (internal only):
https://jel.ly.fish/brainstorm-topic-c3f8670a-8981-42ae-bcbf-1f57e959122d

Copied from this pattern (internal only):
https://jel.ly.fish/scratchpad-entry-0b610300-4182-4627-83b6-90ae82e9661c
