### PR TITLE
overview: 2.x: Remove mentions to OS variants

### DIFF
--- a/shared/overview/2.x.md
+++ b/shared/overview/2.x.md
@@ -12,39 +12,40 @@ The first version of {{ $names.os.lower }} was developed as part of the {{ $name
 
 We look forward to working with the community to grow and mature {{ $names.os.lower }} into an operating system with even broader device support, a broader operating envelope, and as always, taking advantage of the most modern developments in security and reliability.
 
-## Variants of {{ $names.os.lower }}
+### Development vs. Production mode
 
-Each version of {{ $names.os.lower }} is available in development and production variants, both built from the same source, but with slightly differing feature sets.
+{{ $names.os.lower }} can be downloaded in production or development mode. This can be later changed via [developmentMode][config-json-developmentmode].
 
-|   Version Name   | Variant Type |                                                                                                            Description                                                                                                             |
-|:----------------:|:------------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
-| 2.46.1+rev3-prod |  production  |                                                          This is the production version of {{ $names.os.lower }} and should be used for any production fleet deployments.                                                          |
-| 2.46.1+rev3-dev  | development  | This is the development version of {{ $names.os.lower }} and should be used when you are developing a new application and want to use the fast [local mode][local-mode] workflow. This variant should never be used in production. |
+Development mode is recommended while getting started with {{ $names.os.lower }} and building an application using the fast [local mode][local-mode] workflow. Development mode enables a number of useful features while developing, namely:
 
-### Development vs. Production images
-
-__Warning:__ Development images have an exposed Docker socket and enable passwordless root SSH access and should never be used in production.
-
-The development images are recommended while getting started with {{ $names.os.lower }} and building an application. The development images enable a number of useful features while developing, namely:
-
-* Passwordless [SSH access][ssh-host] into {{ $names.os.lower }} on port `22222` as the root user.
+* Passwordless [SSH access][ssh-host] into {{ $names.os.lower }} on port `22222` as the root user, unless custom [ssh keys][config-json-ssh] are provided in which case key-based authentication is used.
 * Docker socket exposed on port `2375`, which allows `{{ $names.company.lower }} push` / `build` / `deploy`, that enables remote Docker builds on the target device (see [Deploy to your Fleet][deploy-to-fleet]).
 * Getty console attached to tty1 and serial.
 * Capable of entering [local mode][local-mode] for rapid development of application containers locally.
 
-__Note:__ Raspberry Pi devices don’t have Getty attached to serial.
+__Note:__ Raspberry Pi devices don’t have Getty attached to serial by default, but they can be configured to enable serial in the {{ $names.cloud.lower }} Dashboard via [configuration variables][supervisor-configuration-list].
 
-Production images disable passwordless root access, and an SSH key must be [added][config-json-ssh] to `config.json` to access a production image using a direct SSH connection. You may still access a production image by tunneling SSH through the {{ $names.company.lower }} VPN via the CLI (using `balena ssh <uuid>`) or the {{ $names.cloud.lower }} [web terminal][ssh-host]. To use SSH via the VPN, you need to have an SSH key configured on your development machine and [added][ssh-key-add] to the {{ $names.cloud.lower }} dashboard.
+__Warning:__ Development mode has an exposed Docker socket and enable passwordless root SSH access and should never be used in production.
 
-In both development and production versions of {{ $names.os.lower }}, logs are written to an 8 MB journald RAM buffer in order to avoid wear on the flash storage used by most of the supported boards.
+Production mode disables passwordless root access, and an SSH key must be [added][config-json-ssh] to `config.json` to access a production image using a direct SSH connection. You may still access a production image by tunneling SSH through the {{ $names.company.lower }} VPN via the CLI (using `balena ssh <uuid>`) or the {{ $names.cloud.lower }} [web terminal][ssh-host]. To use SSH via the VPN, you need to have an SSH key configured on your development machine and [added][ssh-key-add] to the {{ $names.cloud.lower }} dashboard.
+
+### Logging
+
+In {{ $names.os.lower }}, logs are written to an 8 MB journald RAM buffer in order to avoid wear on the flash storage used by most of the supported boards.
 
 To persist logs on the device, enable persistent logging via the [configuration][fleet-configuration] tab in the {{ $names.cloud.lower }} dashboard, or prior to device provisioning setting the `"persistentLogging": true` [key][config-json-logging] in `config.json`. The logs can be accessed via the host OS at `/var/log/journal`. For versions of {{ $names.os.lower }} < 2.45.0, persistent logs are limited to 8 MB and stored in the state partition of the device. {{ $names.os.upper }} versions >= 2.45.0 store a maximum of 32 MB of persistent logs in the data partition of the device.
 
-Both development and production versions of {{ $names.os.lower }} allow the setting of a custom [hostname][config-json-hostname] via `config.json`, by setting `"hostname": "my-new-hostname"`. Your device will then broadcast (via Avahi) on the network as `my-new-hostname.local`. If you don't set a custom hostname, the device will default to `<short-UUID>.local`. You can also set a custom hostname via the [Supervisor API][supervisor-api] on device.
+### Hostname
 
-On production images, nothing is written to tty1, on boot you should only see the {{ $names.company.lower }} logo, and this will persist until your application code takes over the framebuffer. If you would like to replace the {{ $names.company.lower }} logo with your own custom splash logo, then you will need to replace the `splash/balena-logo.png` file that you will find in the [first partition][partition] of the image (boot partition or `resin-boot`) with your own logo.
+{{ $names.os.lower }} allows the setting of a custom [hostname][config-json-hostname] via `config.json`, by setting `"hostname": "my-new-hostname"`. Your device will then broadcast (via Avahi) on the network as `my-new-hostname.local`. If you don't set a custom hostname, the device will default to `<short-UUID>.local`. You can also set a custom hostname via the [Supervisor API][supervisor-api] on device.
+
+### Logo
+
+On production mode, nothing is written to tty1, on boot you should only see the {{ $names.company.lower }} logo, and this will persist until your application code takes over the framebuffer. If you would like to replace the {{ $names.company.lower }} logo with your own custom splash logo, then you will need to replace the `splash/balena-logo.png` file that you will find in the [first partition][partition] of the image (boot partition or `resin-boot`) with your own logo.
 
 __Note:__ As it currently stands, plymouth expects the image to be named `balena-logo.png`. This file was called `resin-logo.png` on older releases.
+
+### Provisioning keys
 
 When a {{ $names.os.lower }} image is downloaded from the {{ $names.cloud.lower }} dashboard, it contains a provisioning key that allows devices flashed with the image to be added to a specific fleet, and a device API key generated. As such, you should handle such images downloaded from {{ $names.cloud.lower }} with care as anyone with access to the image can add a device to your fleet. You can find out more about the access restrictions of a device API key [here][security].
 
@@ -78,7 +79,7 @@ The {{ $names.lower.company }} Supervisor is a lightweight container that runs o
 
 ### Avahi
 
-In order to improve the [development experience][local-mode] of {{ $names.os.lower }}, there is an [Avahi][avahi] daemon that starts advertising the device as `{{ $names.company.lower }}.local` or `<hostname>.local` on boot if the image is a development image.
+In order to improve the [development experience][local-mode] of {{ $names.os.lower }}, there is an [Avahi][avahi] daemon that starts advertising the device on boot as `<short-UUID>.local` or `<hostname>.local` if the hostname is set.
 
 ### Dnsmasq
 
@@ -192,3 +193,5 @@ __Note:__ Instructions for adding custom board support may be found [here][custo
 [yocto-build]:{{ $links.osSiteUrl }}/docs/custom-build/#Bake-your-own-Image
 [yocto-poky]:https://www.yoctoproject.org/software-item/poky/
 [yocto-releases]:https://wiki.yoctoproject.org/wiki/Releases
+[config-json-developmentmode]:/reference/OS/configuration/#developmentmode
+[supervisor-configuration-list]:/reference/supervisor/configuration-list


### PR DESCRIPTION
BalenaOS is now a unified image that can be configured for production
or development mode. Update the documentation to reflect this.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
