### PR TITLE
Remove vpn_address from resource.json as it is not useful

### DIFF
--- a/config/dictionaries/resource.json
+++ b/config/dictionaries/resource.json
@@ -234,7 +234,6 @@
       "last_vpn_event",
       "ip_address",
       "mac_address",
-      "vpn_address",
       "public_address",
       "os_version",
       "os_variant",


### PR DESCRIPTION
This only made any sense within the context of the device or the vpn
server and there are much better ways of handling it for the past 6+
years

Change-type: patch


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
