### PR TITLE
patch: Fix link to projects

### DIFF
--- a/pages/learn/getting-started.md
+++ b/pages/learn/getting-started.md
@@ -211,7 +211,7 @@ Your release will then be downloaded and started by all the devices you have con
 [local-mode]:/learn/develop/local-mode
 [multicontainer]:/learn/develop/multicontainer
 [npminstall]:{{ $links.githubCli }}/blob/master/INSTALL.md#npm-installation
-[projects]:{{ $links.blogSiteUrl }}/tag/project/
+[projects]:{{ $links.blogSiteUrl }}/tags/project/
 [releases]:{{ $links.githubCli }}/releases
 [variables]:/learn/manage/variables/
 [terminal]:/learn/manage/ssh-access


### PR DESCRIPTION
Noticed projects URL in "Next steps" section returns a 404. Looks like correct one is just a single character change.