### PR TITLE
Fix infinite page reload when querystring != null

### DIFF
--- a/templates/_track.html
+++ b/templates/_track.html
@@ -15,7 +15,7 @@
 <script type="text/javascript">
   var urlParamsHandler = new analyticsClient.AnalyticsUrlParams();
   var newQuery = urlParamsHandler.consumeUrlParameters(window.location.search);
-  if (newQuery != null) {
+  if (newQuery != null && `?${newQuery` != window.location.search) {
     window.location.search = newQuery;
   }
 


### PR DESCRIPTION
Fix https://github.com/balena-io/docs/issues/1935
Prevent reload if queryString didn't changed


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
