### PR TITLE
patch: fix querystring infinite reload

### DIFF
--- a/templates/_track.html
+++ b/templates/_track.html
@@ -15,7 +15,7 @@
 <script type="text/javascript">
   var urlParamsHandler = new analyticsClient.AnalyticsUrlParams();
   var newQuery = urlParamsHandler.consumeUrlParameters(window.location.search);
-  if (newQuery != null) {
+  if (newQuery != null && `?${newQuery}` !== window.location.search) {
     window.location.search = newQuery;
   }
 


### PR DESCRIPTION
Fix for "When querystring is present the page was reloading infinitely".

https://github.com/balena-io/docs/issues/1935
