### PR TITLE
Add Github action to automatically deploy to Heroku.

### DIFF
--- a/.github/workflows/deploy-to-heroku.yml
+++ b/.github/workflows/deploy-to-heroku.yml
@@ -1,0 +1,16 @@
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: balena-docs
+    steps:
+      - uses: actions/checkout@v2
+      - uses: akhileshns/heroku-deploy@v3.12.12 # This is the action
+        with:
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: ${{secrets.HEROKU_APP_NAME}}"YOUR APP's NAME" #Must be unique in Heroku
+          heroku_email: ${{secrets.HEROKU_DEPLOYMENT_EMAIL}}


### PR DESCRIPTION
Automatic deployments using Heroku-Github Oauth integration
is currently broken.

Change-type: patch
Signed-off-by: Carlo Miguel F. Cruz <carloc@balena.io>


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
