### PR TITLE
patch: Fix directory name in GitHub Action

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -31,7 +31,7 @@ jobs:
           args: >
             --config ./lychee.toml
             --github-token ${{ secrets.GITHUB_TOKEN }}
-            "content/**" 
+            "contents/**" 
 
       - name: Create Issue From File
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
The Github action wasn't working or creating issues since the directory name was wrong.

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
