### PR TITLE
patch: Redirect deprecated docs

### DIFF
--- a/config/redirects.txt
+++ b/config/redirects.txt
@@ -111,3 +111,7 @@
 ^\/reference\/resinOS\/?(.*) -> /reference/OS/$1
 ^\/reference\/OS\/meta-balena\/?(.*) -> /reference/OS/custom-device-support/$1$2
 ^\/reference\/base-images\/resin-base-images\/?(\?.+)?(#.+)?$ -> /reference/base-images/base-images/$1$2
+^\/reference\/OS\/overview\/1.x\/?(.*) -> /reference/OS/overview/$1$2
+^\/reference\/OS\/overview\/2.x\/?(.*) -> /reference/OS/overview/$1$2
+^\/reference\/OS\/network\/1.x\/?(.*) -> /reference/OS/network/$1$2
+^\/reference\/OS\/network\/2.x\/?(.*) -> /reference/OS/network/$1$2

--- a/pages/reference/OS/network.md
+++ b/pages/reference/OS/network.md
@@ -1,5 +1,5 @@
 ---
-title: Network Setup on balenaOS 2.x
+title: Network Setup on balenaOS
 
 ---
 


### PR DESCRIPTION
~Redirect 1.x balenaOS docs to 2.x~

Update: Will be redirecting both 1.x and 2.x balenaOS docs to just the page, not keep it version specific. This is because we deprecated all balenaOS 1.x docs and the only major version that remains is 2.x. Hence it make sense to drop the version specific docs entirely. Examples:

1. https://www.balena.io/docs/reference/OS/overview/2.x/ --> https://www.balena.io/docs/reference/OS/overview/
2. https://www.balena.io/docs/reference/OS/network/1.x/ --> https://www.balena.io/docs/reference/OS/network/


Context: https://www.flowdock.com/app/rulemotion/resin-devops/threads/hQm7r4VFlyTyeKS2PE6yXRNrcUo
Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*

