### PR TITLE
patch: Remove $os_version key from docs

### DIFF
--- a/config/navigation.txt
+++ b/config/navigation.txt
@@ -107,14 +107,14 @@ Reference
     [/reference/hardware/wifi-dongles]
 
   Host OS
-    Overview[/reference/OS/overview/$os_version]
+    Overview[/reference/OS/overview]
     Host OS updates
       [/reference/OS/updates/self-service]
       [/reference/OS/updates/update-process]
       [/reference/OS/updates/migrate-to-2.0]
       [/reference/OS/updates/rollbacks]
     Extended support release process[/reference/OS/extended-support-release]  
-    Network[/reference/OS/network/$os_version]
+    Network[/reference/OS/network]
     [/reference/OS/configuration]
     [/reference/OS/time]
     [/reference/OS/advanced]

--- a/pages/reference/OS/network.md
+++ b/pages/reference/OS/network.md
@@ -1,5 +1,5 @@
 ---
-title: Network Setup on {{ $os_version.name }}
+title: Network Setup on balenaOS 2.x
 
 ---
 


### PR DESCRIPTION
The os_version keys were deleted in the previous PR. These were still referenced in the documentation and not removed. I have removed them now. The error we were seeing on build time. 

```
Expanding dynamic doc reference/supervisor/configuration-list.md
Parsing navigation...
/home/vipulgupta2048/work/docs/node_modules/@balena/doxx/doxx.js:16
    throw err
    ^

Error: Unknown key $os_version
    at /home/vipulgupta2048/work/docs/node_modules/metalsmith-dynamic/build/dictionaries.js:67:13
    at Dicts.getDict (/home/vipulgupta2048/work/docs/node_modules/metalsmith-dynamic/build/dictionaries.js:68:7)
    at Dicts.getValues (/home/vipulgupta2048/work/docs/node_modules/metalsmith-dynamic/build/dictionaries.js:72:23)
    at setRefRec (/home/vipulgupta2048/work/docs/node_modules/@balena/doxx/build/metalsmith-plugins.js:78:22)
    at setRef (/home/vipulgupta2048/work/docs/node_modules/@balena/doxx/build/metalsmith-plugins.js:108:18)
    at visitNode (/home/vipulgupta2048/work/docs/node_modules/@balena/doxx/build/metalsmith-plugins.js:116:20)
    at self (/home/vipulgupta2048/work/docs/node_modules/@balena/doxx-utils/build/index.js:23:7)
    at self (/home/vipulgupta2048/work/docs/node_modules/@balena/doxx-utils/build/index.js:30:24)
    at self (/home/vipulgupta2048/work/docs/node_modules/@balena/doxx-utils/build/index.js:30:24)
    at Ware.<anonymous> (/home/vipulgupta2048/work/docs/node_modules/@balena/doxx/build/metalsmith-plugins.js:148:9)
    at Ware.<anonymous> (/home/vipulgupta2048/work/docs/node_modules/wrap-fn/index.js:45:19)
    at next (/home/vipulgupta2048/work/docs/node_modules/ware/lib/index.js:85:20)
    at /home/vipulgupta2048/work/docs/node_modules/wrap-fn/index.js:121:18
    at Ware.<anonymous> (/home/vipulgupta2048/work/docs/node_modules/@balena/doxx-utils/build/index.js:14:16)
    at Ware.<anonymous> (/home/vipulgupta2048/work/docs/node_modules/wrap-fn/index.js:45:19)
    at next (/home/vipulgupta2048/work/docs/node_modules/ware/lib/index.js:85:20)
    at /home/vipulgupta2048/work/docs/node_modules/wrap-fn/index.js:121:18
    at Ware.<anonymous> (/home/vipulgupta2048/work/docs/node_modules/metalsmith-dynamic/build/index.js:133:14)
    at Ware.<anonymous> (/home/vipulgupta2048/work/docs/node_modules/wrap-fn/index.js:45:19)
    at next (/home/vipulgupta2048/work/docs/node_modules/ware/lib/index.js:85:20)
    at /home/vipulgupta2048/work/docs/node_modules/wrap-fn/index.js:121:18
    at Ware.<anonymous> (/home/vipulgupta2048/work/docs/node_modules/@balena/doxx-utils/build/index.js:14:16)
    at Ware.<anonymous> (/home/vipulgupta2048/work/docs/node_modules/wrap-fn/index.js:45:19)
    at next (/home/vipulgupta2048/work/docs/node_modules/ware/lib/index.js:85:20)
    at /home/vipulgupta2048/work/docs/node_modules/wrap-fn/index.js:121:18
    at Ware.<anonymous> (/home/vipulgupta2048/work/docs/node_modules/@balena/doxx-utils/build/index.js:14:16)
    at Ware.<anonymous> (/home/vipulgupta2048/work/docs/node_modules/wrap-fn/index.js:45:19)
    at next (/home/vipulgupta2048/work/docs/node_modules/ware/lib/index.js:85:20)
    at Ware.run (/home/vipulgupta2048/work/docs/node_modules/ware/lib/index.js:88:3)
    at Metalsmith.<anonymous> (/home/vipulgupta2048/work/docs/node_modules/thunkify/index.js:43:12)
    at next (/home/vipulgupta2048/work/docs/node_modules/co/index.js:90:21)
    at Metalsmith.<anonymous> (/home/vipulgupta2048/work/docs/node_modules/co/index.js:45:5)
    at Metalsmith.next (/home/vipulgupta2048/work/docs/node_modules/co/index.js:90:21)
    at Metalsmith.<anonymous> (/home/vipulgupta2048/work/docs/node_modules/co/index.js:93:18)
    at Immediate.<anonymous> (/home/vipulgupta2048/work/docs/node_modules/co/index.js:52:14)
    at processImmediate (internal/timers.js:461:21)
```

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
