### PR TITLE
patch: Fix Doc improvement links for balenaOS Overview & Network page

### DIFF
--- a/config/index.coffee
+++ b/config/index.coffee
@@ -2,7 +2,7 @@ DOCS_SOURCE_DIR = 'pages'
 TEMPLATES_DIR = 'templates'
 PARTIALS_DIR = 'shared'
 
-DYNAMIC_DOCS = /.*(getting-started|overview|network).*/
+DYNAMIC_DOCS = /.*(getting-started).*/
 
 # These files are pulled in externally and so cannot be edited in the base repo
 EXTERNAL_DOCS = /.*(python-sdk|node-sdk|balena-cli|supervisor-api|update-locking|diagnostics|google-iot|azure-iot-hub|cli-masterclass|advanced-cli|host-os-masterclass|services-masterclass|fleet-management|device-debugging|docker-masterclass).*/


### PR DESCRIPTION
With #2280, I didn't take into account deleting these items from the list of dynamic pages. Both these pages are no longer dynamic, and hence can be removed from here. This field is used to generate "Improve this Doc" links for the docs.

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
