### PR TITLE
patch: Fail build script when doxx command errors out

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,3 +1,13 @@
-dirname=$(dirname $0)
-cd "$dirname/.."
-./node_modules/.bin/doxx "$(pwd)/config/doxx"
+#!/usr/bin/env bash
+
+# exit on error, unassigned vars, or pipe fails
+set -euo pipefail
+
+# get the absolute path to the script in case it is called from elsewhere
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# run cd in a subshell so we don't end up in another directory on failure
+(
+    cd "$SCRIPT_DIR/.."
+    node --unhandled-rejections=strict ./node_modules/.bin/doxx "$(pwd)/config/doxx"
+)


### PR DESCRIPTION
The doxx command in the build script used to error out with an exit code 0. This PR fixes that behavior with converting the unhandled-rejections in node to strict which makes sure `unhandledpromiserejection` errors always exit the program with exit code 1. Also, added `set -e` along with other bash environment variables to improve script's behavior overall. 

This primarily makes sure our CI/CD builds won't be successfull if the docs build is failing. Hopefully preventing us from merging broken documentation changes. 


Context: https://www.flowdock.com/app/rulemotion/resin-devops/threads/lRgvlRyPy6MLl4c5dsgI-vVbnEw
Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
