### PR TITLE
patch: Replace shebang in scripts with env interpreter

### DIFF
--- a/tools/extract-markdown.sh
+++ b/tools/extract-markdown.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HEADER=$1
 

--- a/tools/fetch-external.sh
+++ b/tools/fetch-external.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script pulls in external documentation that should be edited in the corresponding upstream repo
 
 # Use node-jq if jq is not pre-installed in the environment nor set in path

--- a/tools/prepare.sh
+++ b/tools/prepare.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 dirname=$(dirname $0)
 cd $dirname/..
 

--- a/tools/test-spelling.sh
+++ b/tools/test-spelling.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 consolidatedOutput=""
 exitCode=0
 while read -r file


### PR DESCRIPTION
`#!/usr/bin/env` searches PATH for bash, and bash is not always
in /bin, particularly on non-Linux systems.

Signed-off-by: Kyle Harding <kyle@balena.io>


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
