### PR TITLE
patch: Deprecate Dynamic Docs config option

### DIFF
--- a/config/doxx.coffee
+++ b/config/doxx.coffee
@@ -14,9 +14,8 @@ module.exports = {
   templatesDir: config.templatesDir
   partialsDir: config.partialsDir
   metaExtra: (fileName) ->
-    fileMatch = fileName.match(config.dynamicDocs)
     externalFileMatch = fileName.match(config.externalDocs)
-    improveDocsLink: if fileMatch then "#{config.editPageLink}/#{config.partialsDir}/#{fileMatch[1]}" else "#{config.editPageLink}/#{config.docsSourceDir}/#{fileName}"
+    improveDocsLink: "#{config.editPageLink}/#{config.docsSourceDir}/#{fileName}"
     externalImproveDocsLink: if externalFileMatch then links.externalDocs[externalFileMatch[1]]
     $links: links
     $names: names

--- a/config/index.coffee
+++ b/config/index.coffee
@@ -2,10 +2,8 @@ DOCS_SOURCE_DIR = 'pages'
 TEMPLATES_DIR = 'templates'
 PARTIALS_DIR = 'shared'
 
-DYNAMIC_DOCS = /.*(getting-started|cloud-iot-provisioning).*/
-
 # These files are pulled in externally and so cannot be edited in the base repo
-EXTERNAL_DOCS = /.*(python-sdk|node-sdk|balena-cli|supervisor-api|rollbacks|update-locking|diagnostics|cli-masterclass|advanced-cli|host-os-masterclass|services-masterclass|fleet-management|device-debugging|docker-masterclass|customer-board-support|resources).*/
+EXTERNAL_DOCS = /.*(python-sdk|node-sdk|balena-cli|supervisor-api|rollbacks|update-locking|diagnostics|cli-masterclass|advanced-cli|host-os-masterclass|services-masterclass|fleet-management|device-debugging|docker-masterclass|customer-board-support|resources|cloud-iot-provisioning|getting-started).*/
 
 FB_APP_ID = '221218511385682'
 
@@ -44,7 +42,6 @@ module.exports =
   docsDestDir: 'contents'
   templatesDir: TEMPLATES_DIR
   partialsDir: PARTIALS_DIR
-  dynamicDocs: DYNAMIC_DOCS
   externalDocs: EXTERNAL_DOCS
   editPageLink: 'https://github.com/balena-io/docs/edit/master'
   links: require('./links')

--- a/config/links.coffee
+++ b/config/links.coffee
@@ -52,3 +52,5 @@ module.exports =
     "rollbacks": "https://github.com/balena-os/meta-balena/edit/master/docs/rollbacks.md"
     "customer-board-support": "https://github.com/balena-os/meta-balena/edit/master/contributing-device-support.md"
     "resources": "https://github.com/balena-io/docs/edit/master/pages/reference/api/resources.md"
+    "cloud-iot-provisioning": "https://github.com/balena-io/docs/edit/master/pages/learn/develop/cloud-iot-provisioning.md"
+    "getting-started": "https://github.com/balena-io/docs/edit/master/pages/learn/getting-started.md"


### PR DESCRIPTION
Had a thought about this. Our overall goal is remove as many static paritals as we could for our dynamic docs. The newest edition to Dyanmic docs is the Cloud Provisioning docs that doesn't use partials at all. Hence, I am putting together this patch to deprecate the dynamic docs proprety completely. This benefits two-folds

1. No more confusion on where the "Improve this doc" link will point to 
2. With no partials to point to, we can point to the main blueprint doc as the improve this doc link

Additionally fixes issues with "Improve this Doc" links for Cloud Provisioning docs since they don't have any partials. Their improve link was going 404

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
