### PR TITLE
patch: Add docs for download endpoint

### DIFF
--- a/config/dictionaries/resource.json
+++ b/config/dictionaries/resource.json
@@ -555,21 +555,21 @@
     "examples": [
       {
         "id": "download-private-balenaos",
-        "summary": "Download unmanaged releases of balenaOS for private device types",
-        "description": "Unmanaged releases of balenaOS for private device types are not released publically. If you have access to a private device type, then images can be downloaded by providing an API key. Add an `--output` flag to provide a path for the image to be downloaded in the curl command below.",
+        "summary": "Download private or ESR balenaOS images",
+        "description": "In order to download an ESR or private balenaOS image, you need to provide your [bearer token](https://www.balena.io/docs/learn/manage/account/#api-keys). The `deviceType` and `version` parameters are required. Add an `--output` flag to provide a path for the image to be downloaded.",
         "method": "GET",
         "endpoint": "/download",
-        "content-type": "application/zip",
+        "content-type": "application/octet-stream",
         "filters": "?deviceType=<DEVICE NAME>&version=<BALENAOS VERSION>&fileType=.zip'"
       },
       {
         "id": "download-balenaos",
-        "summary": "Download unmanaged releases of balenaOS for public device types",
-        "description": "Same as above but the auth header is optional to use. These releases are available on [balena.io/os](balena.io/os)",
+        "summary": "Download public balenaOS images",
+        "description": "Same as above but the auth header is optional to use. The `deviceType` and `version` parameters are required. These releases also  available for download on [balena.io/os](balena.io/os) and the dashboard.",
         "method": "GET",
         "endpoint": "/download",
-        "content-type": "application/zip",
-        "filters": "?deviceType=<DEVICE NAME>&version=<BALENAOS VERSION>&fileType=.zip'"
+        "content-type": "application/octet-stream",
+        "filters": "?deviceType=<DEVICE NAME>&version=<BALENAOS VERSION>&fileType=.gz'"
       }
     ]
   },

--- a/config/dictionaries/resource.json
+++ b/config/dictionaries/resource.json
@@ -549,6 +549,31 @@
     ]
   },
   {
+    "id": "download",
+    "name": "Download balenaOS",
+    "fields": [],
+    "examples": [
+      {
+        "id": "download-private-balenaos",
+        "summary": "Download unmanaged releases of balenaOS for private device types",
+        "description": "Unmanaged releases of balenaOS for private device types are not released publically. If you have access to a private device type, then images can be downloaded by providing an API key. Add an `--output` flag to provide a path for the image to be downloaded in the curl command below.",
+        "method": "GET",
+        "endpoint": "/download",
+        "content-type": "application/zip",
+        "filters": "?deviceType=<DEVICE NAME>&version=<BALENAOS VERSION>&fileType=.zip'"
+      },
+      {
+        "id": "download-balenaos",
+        "summary": "Download unmanaged releases of balenaOS for public device types",
+        "description": "Same as above but the auth header is optional to use. These releases are available on [balena.io/os](balena.io/os)",
+        "method": "GET",
+        "endpoint": "/download",
+        "content-type": "application/zip",
+        "filters": "?deviceType=<DEVICE NAME>&version=<BALENAOS VERSION>&fileType=.zip'"
+      }
+    ]
+  },
+  {
     "id": "fleet_config_variable",
     "name": "Fleet config variable",
     "fields": [

--- a/templates/api.html
+++ b/templates/api.html
@@ -20,7 +20,7 @@
 				{% endif %}
 				<pre><code>curl -X {{ example.method }} \
 "{{ $links.apiBase }}{{ example.endpoint }}{{ example.filters }}" \
--H "Content-Type: application/json" \
+-H {% if example.content-type %} "Content-Type: {{example.content-type}}" {% else %} "Content-Type: application/json" {% endif %} \
 -H "Authorization: Bearer &lt;AUTH_TOKEN&gt;" {% if example.data %}\
 --data '{{ example.data }}'{% endif %}</code></pre>
 			{% endfor %}


### PR DESCRIPTION
Added 2 examples explaining how balenaOS can be downloaded using the /download endpoint for both public and private device types. This is how it looks. 

![Screenshot from 2022-10-31 15-28-58](https://user-images.githubusercontent.com/22801822/198983864-50d1299f-a7d4-4186-8a50-b30110e6c482.png)


Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
