### PR TITLE
patch: Add support for manaul workflow runs

### DIFF
--- a/.github/workflows/deploy-to-heroku.yml
+++ b/.github/workflows/deploy-to-heroku.yml
@@ -1,6 +1,7 @@
 name: Deploy to Heroku
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master


### PR DESCRIPTION
Mysteriously our scheduled GitHub action workflow to update the website has stopped running. I checked the logs and recent commits to find potenial errors. It stopped running on the scheduled time for 5 days. Checking answers on the web, I found folks suggesting way to unclog the run queue to get the scheduled action running again along with a way to trigger it manually to get it running. 

1. https://stackoverflow.com/questions/59560214/github-action-works-on-push-but-not-scheduled
2. Scheduled workflows are unreliable https://upptime.js.org/blog/2021/01/22/github-actions-schedule-not-working/
3. Adding a manual trigger seems a nice way to unblock when we are in a fix: https://devopsjournal.io/blog/2022/08/12/workflows-not-starting

Will give this a shot and see if it fixes it. 

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
