### PR TITLE
develop/hardware: Add Jetson AGX Orin to the list of devices

### DIFF
--- a/pages/learn/develop/hardware/i2c-and-spi.md
+++ b/pages/learn/develop/hardware/i2c-and-spi.md
@@ -313,7 +313,7 @@ Similarly, rs485 can be selected in the environment file as well. The device sho
 ## Jetson Devices
 
 ### Custom device trees
-Loading of custom device trees in balenaOS is supported by the Jetson Nano and Jetson TX2 family of devices. The list of devices that support this function includes:
+Loading of custom device trees in balenaOS is supported by the Jetson Nano, Jetson TX2 and Jetson Orin family of devices. The list of devices that support this function includes:
 - Floyd  Nano
 - Jetson Nano SD-CARD
 - Jetson Nano eMMC
@@ -326,13 +326,14 @@ Loading of custom device trees in balenaOS is supported by the Jetson Nano and J
 - Orbitty TX2
 - Photon  TX2 NX
 - Spacely TX2
+- Jetson AGX Orin Devkit
 
-Loading of custom device trees is not supported for the Jetson Xavier family of devices in balenaOS. U-Boot provides the complete set of functionality necessary for loading custom device-trees in balenaOS for the Jetson Nano and TX2 devices, and this bootloader is not supported by the Jetson Xavier BSP.
+Loading of custom device trees is not supported for the Jetson Xavier family of devices in balenaOS. U-Boot provides the complete set of functionality necessary for loading custom device-trees in balenaOS for the Jetson Nano and TX2 devices, and this bootloader is not supported by the Jetson AGX Xavier and Jetson Xavier NX BSP. The Jetson AGX Orin family of devices uses a new Tegra UEFI bootloader which allows balenaOS to load custom device-trees.
 
-To test a custom device tree on a Jetson Nano or TX2 device, place your custom compiled device tree in the host operating system of your device, in the following path: /mnt/sysroot/active/current/boot/
+To test a custom device tree on a Jetson Nano, TX2 or Jetson AGX Orin device, place your custom compiled device tree in the host operating system of your device, in the following path: /mnt/sysroot/active/current/boot/
 After that, navigate to the `Device Configuration` tab in the balenaCloud dashboard, activate the following configuration with the description `Define the file name of the DTB to be used`, and specify the file name of the custom device tree. The value of this configuration should contain the file name only. After the change is applied, the device will automatically reboot and load the new device tree.
 
-After the custom device tree has been validated, it can be included in newer balenaOS images. Open a pull request in the [balena Jetson device](https://github.com/balena-os/balena-jetson) repository following this [example commit](https://github.com/balena-os/balena-jetson/commit/3dbf9c96e5986c2138f318d1ee9f0d5c1a2fc3c8). Once your PR is approved and merged, a new balenaOS image that includes your custom device tree will become available shortly.
+After the custom device tree has been validated, it can be included in newer balenaOS images. For Jetson TX2 and Nano, open a pull request in the [balena Jetson device](https://github.com/balena-os/balena-jetson) repository following this [example commit](https://github.com/balena-os/balena-jetson/commit/3dbf9c96e5986c2138f318d1ee9f0d5c1a2fc3c8). For the Jetson AGX Orin, the PR should be opened in the [balena Jetson Orin](https://github.com/balena-os/balena-jetson-orin) repository. Once your PR is approved and merged, a new balenaOS image that includes your custom device tree will become available shortly.
 
 [i2c-link]:http://en.wikipedia.org/wiki/I%C2%B2C
 [spi-link]:http://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus


### PR DESCRIPTION
... that support custom device-tree loading.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
