### PR TITLE
Add fetch-external script to link checker

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -21,17 +21,25 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 14
-      - run: npm ci && npm run build
+      - run: npm run deploy-docs
+
+      # Enable Lychee cache
+      - name: Restore lychee cache
+        uses: actions/cache@v3
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
 
       # Run link checker on the generated HTML
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v1.5.1
+        uses: lycheeverse/lychee-action@4dcb8bee2a0a4531cba1a1f392c54e8375d6dd81
         with:
           args: >
             --config ./lychee.toml
             --github-token ${{ secrets.GITHUB_TOKEN }}
-            "contents/**/*" 
+            "build/**/*" "tools/fetch-external.sh"
 
       - name: Create Issue From File
         if: github.event_name != 'pull_request'

--- a/lychee.toml
+++ b/lychee.toml
@@ -15,6 +15,9 @@ progress = true
 # multiple runs.
 cache = true
 
+# Discard all cached requests older than this duration.
+max_cache_age = "2d"
+
 #############################  Runtime  #############################
 
 # Number of threads to utilize.
@@ -74,6 +77,9 @@ headers = []
 exclude = [
     "https://github.com/balena-io-library/base-images",
     "https://community.openvpn.net/openvpn",
+    "https://cloudlink.balena-cloud.com/",
+    "https://vpn.balena-cloud.com/ping",
+    "https://chrome.google.com/webstore/*",
     "https://github.com/myorg/myapp",
     "https://index.docker.io/v2/",
     "https://api.balena-(cloud|staging).com/",
@@ -91,7 +97,8 @@ exclude = [
     "https://fonts.gstatic.com/*",
     "https://bob:secret@proxy.company.com:12345",
     "https://github.com/balena-io/balena-cli/releases/download/*",
-    "file://*"
+    "file://*",
+    "https://github.com/balena-io/docs/edit/master/pages/reference/supervisor/configuration-list/*"
     ]
 
 # Exclude URLs contained in a file from checking


### PR DESCRIPTION
Adds in an extra degree of checking if external resource URL's are not failing. 

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
