### PR TITLE
patch: Deploy daily to Cloudflare using custom action

### DIFF
--- a/.github/workflows/deploy-to-cloudflare-pages.yml
+++ b/.github/workflows/deploy-to-cloudflare-pages.yml
@@ -1,0 +1,29 @@
+name: Daily deploy to CF Pages
+
+on:
+  # Deploy once every day
+  schedule:
+    - cron: "0 0 * * *"
+
+
+jobs:
+  deploy-cloudflare-pages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
+        with:
+          node-version: 18
+      
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Build docs
+        uses: npm run deploy-docs --if-present
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@4c10c1822abba527d820b29e6333e7f5dac2cabd # 2.0.0
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          accountId: ${{ secrets.CF_ACCOUNT_ID }}
+          command: pages publish --branch master --project-name=balenacloud-docs build/ >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1,9 +1,6 @@
 name: Flowzone
 
 on:
-  # Meant to deploy docs to Cloudflare Pages once each day
-  schedule:
-    - cron: "0 0 * * *"
   pull_request:
     types: [opened, synchronize, closed]
     branches:


### PR DESCRIPTION
Scheduling Flowzone didn't and won't work out since: https://balena.zulipchat.com/#narrow/stream/348930-balena-io.2Fflowzone/topic/.E2.9C.94.20Flowzone.20on.20schedule.20jobs
Hence, this PR reverts #2551 and adds a custom action to deploy to CF pages daily.

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
