### PR TITLE
patch: Redirect deleted Getting Started guides

### DIFF
--- a/config/redirects.txt
+++ b/config/redirects.txt
@@ -236,6 +236,7 @@
 /learn/more/examples/seed-projects/ /learn/more/examples/labs-projects
 
 
+
 # Important: keep dynamic redirect below the static redirects
 # https://developers.cloudflare.com/pages/platform/redirects/
 # Dynamic redirects
@@ -248,6 +249,13 @@
 /reference/OS/overview/:version /reference/OS/overview/
 /reference/OS/network/:version/ /reference/OS/network/
 /reference/OS/network/:version /reference/OS/network/
+
+## Removed Getting Started guides
+
+/learn/getting-started/skx2/:language/ /learn/getting-started/raspberrypi3/:language/
+/learn/getting-started/skx2/:language /learn/getting-started/raspberrypi3/:language/
+/learn/getting-started/ts4900/:language/ /learn/getting-started/raspberrypi3/:language/
+/learn/getting-started/ts4900/:language /learn/getting-started/raspberrypi3/:language/
 
 ###############################################
 # Legacy Server Style Redirects


### PR DESCRIPTION
Deleted getting started guides had to be redirected. 

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
