### PR TITLE
Clarify default value for device hostname

### DIFF
--- a/pages/reference/OS/overview.md
+++ b/pages/reference/OS/overview.md
@@ -42,7 +42,7 @@ To persist logs on the device, enable persistent logging via the [configuration]
 
 ### Hostname
 
-{{ $names.os.lower }} allows the setting of a custom [hostname][config-json-hostname] via `config.json`, by setting `"hostname": "my-new-hostname"`. Your device will then broadcast (via Avahi) on the network as `my-new-hostname.local`. If you don't set a custom hostname, the device will default to `<short-UUID>.local`. You can also set a custom hostname via the [Supervisor API][supervisor-api] on device.
+{{ $names.os.lower }} allows the setting of a custom [hostname][config-json-hostname] via `config.json`, by setting `"hostname": "my-new-hostname"`. Your device will then broadcast (via Avahi) on the network as `my-new-hostname.local`. If you don't set a custom hostname, the device hostname will default to `<short-UUID>`. You can also set a custom hostname via the [Supervisor API][supervisor-api] on device.
 
 ### Logo
 


### PR DESCRIPTION
I wasn't clear if the [sentence](https://docs.balena.io/reference/OS/overview/#hostname) says "\<short-UUID\>.local" is the default Avahi network domain name broadcast or the default device hostname. Since the paragraph is focused on hostname, define the default hostname, not the broadcast name.

For [reference](https://github.com/balena-os/meta-balena/blob/master/meta-balena-common/recipes-support/balena-hostname/balena-hostname/balena-hostname), see how hostname is set at boot time.