### PR TITLE
Add the `overall_status` field for `device`

### DIFF
--- a/config/dictionaries/resource.json
+++ b/config/dictionaries/resource.json
@@ -228,6 +228,7 @@
       "note",
       "local_id",
       "status",
+      "overall_status",
       "is_online",
       "last_connectivity_event",
       "is_connected_to_vpn",

--- a/config/dictionaries/resource.json
+++ b/config/dictionaries/resource.json
@@ -300,6 +300,14 @@
         "filters": "?\\$filter=uuid%20eq%20'<UUID>'"
       },
       {
+        "id": "device-overall-status",
+        "summary": "Get the device overall_status field",
+        "description": "The overall_status field is returned only when explicitly requested with $select.",
+        "method": "GET",
+        "endpoint": "/v6/device(<ID>)",
+        "filters": "?\\$select=overall_status"
+      },
+      {
         "id": "rename-device",
         "summary": "Rename device",
         "description": "",


### PR DESCRIPTION
As [discussed internally](https://balena.zulipchat.com/#narrow/stream/345882-_help/topic/device.2Eoverall_status/near/362024508), the `overall_status` field was missing for the `device` resource.

First time touching the API resources part of the docs. [Looks correct](https://38e5a981.balenacloud-docs.pages.dev/reference/api/resources/device/), but let me know if I did something wrong here!