### PR TITLE
docs/troubleshooting: Update RPI 3B+ hw revisions info

### DIFF
--- a/shared/troubleshooting/raspberrypi3-64.md
+++ b/shared/troubleshooting/raspberrypi3-64.md
@@ -4,6 +4,11 @@ To determine the cause of this issue, check your ACT LED for known [error notifi
 
 One other thing to confirm is that you are not trying to boot a Raspberry Pi 2 with an OS download designed for the Raspberry Pi B+. This will not work. The Raspberry Pi 2 requires an OS download specific to its architecture.
 
+#### Hardware revision
+
+The inability to boot your Raspberry Pi 3 may be related to the hardware revision used. RaspberryPi 3B+ Rev9 is supported by firmware versions from September 2021 onwards. Thus, balenaOS releases
+at v2.101.7 or newer are expected to work with this hardware revision because they use an updated firmware.
+
 ### Connectivity
 
 If a {{ $names.company.upper }} ASCII logo appears with a prompt to check your dashboard, then you are likely experiencing connectivity issues. Check ethernet cables are connected properly and that provided WiFi credentials are correct and try again, also let us known that the LED notification didn't show for you.

--- a/shared/troubleshooting/raspberrypi3.md
+++ b/shared/troubleshooting/raspberrypi3.md
@@ -4,6 +4,11 @@ To determine the cause of this issue, check your ACT LED for known [error notifi
 
 One other thing to confirm is that you are not trying to boot a Raspberry Pi 2 with an OS download designed for the Raspberry Pi B+. This will not work. The Raspberry Pi 2 requires an OS download specific to its architecture.
 
+#### Hardware revision
+
+The inability to boot your Raspberry Pi 3 may be related to the hardware revision used. RaspberryPi 3B+ Rev9 is supported by firmware versions from September 2021 onwards. Thus, balenaOS releases
+at v2.95.3+rev1 or newer are expected to work with this hardware revision because they use an updated firmware.
+
 ### Connectivity
 
 If a {{ $names.company.upper }} ASCII logo appears with a prompt to check your dashboard, then you are likely experiencing connectivity issues. Check ethernet cables are connected properly and that provided WiFi credentials are correct and try again, also let us known that the LED notification didn't show for you.
@@ -41,5 +46,7 @@ If you have a screen attached to your Raspberry Pi and notice that there is a sm
 If you are having issues with your RPI3 connecting to your wifi, make sure
 to check that the 2.4 GHz channel on your wifi router is set to something less than 11, since
 the firmware on the Raspberry Pi doesn't support channel 12 and 13.
+
+
 
 [error]:#error-notifications


### PR DESCRIPTION
Change-type: patch

[v2.89.19](https://github.com/balena-os/balena-raspberrypi/commit/8b6f572f94fc01ac20709a2d03358f386734c36f) updated the rpi bootfiles to 2022.01.20 in https://github.com/balena-os/balena-raspberrypi/commit/eab45104bc657d5ab5a0c4c539f3d1569945d7f2

Therefore, the RasberryPi 3B+ R9 should be usable according to the [PCN](https://pip.raspberrypi.com/categories/797-pcn/documents/RP-003337-PC/Pi3B-Revision-9-PCN.pdf), with BalenaOS releases newer than [v2.89.19](https://github.com/balena-os/balena-raspberrypi/commits/master?after=49dd0694d19fd0010002f5df85c2535703555962+419&branch=master&qualified_name=refs%2Fheads%2Fmaster)

---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
