### PR TITLE
patch: Add deactivation fee to device deactivate feature

### DIFF
--- a/.cspell/balena-words.txt
+++ b/.cspell/balena-words.txt
@@ -27,3 +27,4 @@ sshproxy
 versionbot
 Versionist
 volume-pricing
+undiscounted

--- a/pages/learn/manage/actions.md
+++ b/pages/learn/manage/actions.md
@@ -96,7 +96,9 @@ Turning on local mode is useful when you are prototyping your services, as it al
 
 ### Deactivate Device
 
-This setting will [deactivate the device][inactive-devices] and charge a one-time deactivation fee. To deactivate, the device must be offline and be attached to a valid billing account.
+This setting will [deactivate the device][inactive-devices] and charge a one-time deactivation fee (equivalent to the cost of a single undiscounted device-month). To deactivate, the device must be offline and be attached to a valid billing account.
+
+Once the device is deactivated, the device won't be counted towards your device total. It will remain inactive until it comes back online.
 
 ### Grant Support Access
 


### PR DESCRIPTION
The device deactivation fee has been documented under the FAQ section on our billing page but there wasn't any mention of it in the docs. This PR fixes that. 

Context: https://balena.zulipchat.com/#narrow/stream/350505-aspect.2Fmarketing/topic/Docs.20-.20Deactivation.20Fee

---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
