### PR TITLE
extended-support-release: use dynamic list of supported devices

### DIFF
--- a/pages/reference/OS/extended-support-release.md
+++ b/pages/reference/OS/extended-support-release.md
@@ -1,6 +1,7 @@
 ---
 title: Extended Support Release Process
 excerpt: An overview of the {{ $names.company.lower }} extended support release process
+extras: esr-devices-js
 ---
 # Extended Support Release (ESR) process
 
@@ -38,18 +39,21 @@ __Note:__ Once updated to an ESR version, it is not possible to update from an E
 
 ## Supported devices
 
-ESR host OS versions are currently available for the following devices with additional device support planned:
+All device types are eligible for ESR, however they require a dedicated build and release pipeline so support needs to be requested via our [support channels]({{ $links.mainSiteUrl }}/support).
 
-* Raspberry Pi (v1 / Zero / Zero W)
-* Raspberry Pi 3
-* Raspberry Pi 3 (64 bit OS)
-* Raspberry Pi 4
-* RockPi 4B
-* Beaglebone Black
-* Balena Fin (CM3)
-* Intel NUC
-* Nvidia Jetson TX2
-* ROCK Pi 4B
+ESR host OS versions are currently available for the following devices:
+
+<table>
+  <thead>
+    <tr>
+      <th></th>
+      <th>Device Name</th>
+      <th>Machine Name</th>
+      <th>Architecture</th>
+    </tr>
+  </thead>
+  <tbody id="support_esr_devices_table"></tbody>
+</table>
 
 [self-service-updates]:/reference/OS/updates/self-service/#running-an-update
 [billing]:{{ $links.mainSiteUrl }}/pricing/

--- a/templates/_esr_devices.html
+++ b/templates/_esr_devices.html
@@ -1,0 +1,91 @@
+<script src="//cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.15/lodash.min.js" type="text/javascript"></script>
+<script type="text/javascript">
+
+  (function () {
+    var archAliasMap = {
+      rpi: 'armv6hf',
+    };
+    // The following pine client query was used to generate the OData url below.
+    // TODO: Start using the sdk in the docs and use the call directly.
+    // await sdk.pine.get({
+    //   resource: 'device_type',
+    //   options: {
+    //       $select: ['name', 'slug', 'logo'],
+    //       $expand: {
+    //           is_of__cpu_architecture: {
+    //               $select: 'slug'
+    //           }
+    //       },
+    //       $filter: {
+    //           is_default_for__application: {
+    //               $any: {
+    //                   $alias: 'idfa',
+    //                   $expr: {
+    //                       idfa: {
+    //                           is_host: true,
+    //                           is_archived: false,
+    //                           owns__release: {
+    //                               $any: {
+    //                                   $alias: 'r',
+    //                                   $expr: {
+    //                                       status: 'success',
+    //                                       is_final: true,
+    //                                       is_invalidated: false,
+    //                                   }
+    //                               }
+    //                           }
+    //                       },
+    //                       $and: {
+    //                           idfa: {
+    //                               app_name: {
+    //                                   $contains: '-esr',
+    //                               }
+    //                           }
+    //                       }
+    //                   },
+    //               },
+    //           },
+    //       },
+    //       $orderby: {
+    //           name: 'asc',
+    //       }
+    //   }
+    // })
+    window.jQuery
+      .ajax({
+        url: "https://api.balena-cloud.com/v6/device_type?$select=name,slug,logo&$expand=is_of__cpu_architecture($select=slug)&$filter=is_default_for__application/any(idfa:((idfa/is_host%20eq%20true)%20and%20(idfa/is_archived%20eq%20false)%20and%20(idfa/owns__release/any(r:(status%20eq%20%27success%27)%20and%20(is_final%20eq%20true)%20and%20(is_invalidated%20eq%20false))))%20and(contains(idfa/app_name,%27-esr%27)))&$orderby=name%20asc"
+      })
+      .done(function (deviceTypesResponse) {
+        var table = _(deviceTypesResponse.d)
+          .reduce(function (acc, deviceType) {
+            var archSlug = deviceType.is_of__cpu_architecture[0].slug;
+            if (archAliasMap[archSlug]) {
+              archSlug = archAliasMap[archSlug];
+            }
+            var tableCell =
+              "<tr> <td>" +
+              "<img class='device_icon' src=" + deviceType.logo + " />" +
+              "</td> <td>" +
+              deviceType.name +
+              "</td> <td>" +
+              deviceType.slug +
+              "</td> <td>" +
+              archSlug +
+              "</td> </tr>";
+            return acc + tableCell;
+          }, "");
+
+        return window.jQuery("#support_esr_devices_table").append(table);
+      })
+      .fail(function (error) {
+        console.error(error)
+        return window
+          .jQuery("#support_esr_devices_table")
+          .append(
+            '<tr><td colspan="4">Something went wrong.</td></tr>'
+          );
+      });
+
+  }.call(this));
+
+</script>

--- a/templates/default.html
+++ b/templates/default.html
@@ -86,6 +86,9 @@
     {% if extras == "devices-js" %}
       {% include "_devices.html" %}
     {% endif %}
+    {% if extras == "esr-devices-js" %}
+      {% include "_esr_devices.html" %}
+    {% endif %}
     {% if extras == "config-js" %}
       {% include "_config.html" %}
     {% endif %}


### PR DESCRIPTION
Replace the static listing of supported ESR devices with a dynamic list that fetches from the API.

Change-type: patch


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
