### PR TITLE
Remove references to defunct Google Cloud IoT service

### DIFF
--- a/config/dictionaries/cloud.json
+++ b/config/dictionaries/cloud.json
@@ -24,18 +24,6 @@
     "cloudFunctionName": "Azure"
   },
   {
-    "id": "gcp",
-    "name": "Google Cloud",
-    "shortName": "GCP",
-    "platformName": "GCP",
-    "platformUrl": "https://cloud.google.com/solutions/iot",
-    "iotCoreName": "IoT Core",
-    "iotCoreUrl": "https://cloud.google.com/iot-core",
-    "credentialType": "public key pair",
-    "provisionRepoName": "gcp-iot-provision",
-    "cloudFunctionName": "Cloud"
-  },
-  {
     "id": "cb-gcp",
     "name": "ClearBlade-GCP",
     "shortName": "ClearBlade",

--- a/config/redirects.txt
+++ b/config/redirects.txt
@@ -110,10 +110,12 @@
 /learn/develop/integrations/aws /learn/develop/cloud-iot-provisioning/aws/
 /learn/develop/integrations/azure-iot-hub/ /learn/develop/cloud-iot-provisioning/azure/
 /learn/develop/integrations/azure-iot-hub /learn/develop/cloud-iot-provisioning/azure/
-/learn/develop/integrations/google-iot/ /learn/develop/cloud-iot-provisioning/gcp/
-/learn/develop/integrations/google-iot /learn/develop/cloud-iot-provisioning/gcp/
+/learn/develop/integrations/google-iot/ /learn/develop/cloud-iot-provisioning/
+/learn/develop/integrations/google-iot /learn/develop/cloud-iot-provisioning/
 /learn/develop/integrations/bluemix/ /learn/develop/cloud-iot-provisioning/
 /learn/develop/integrations/bluemix /learn/develop/cloud-iot-provisioning/
+/learn/develop/cloud-iot-provisioning/gcp/ /learn/develop/cloud-iot-provisioning/
+/learn/develop/cloud-iot-provisioning/gcp /learn/develop/cloud-iot-provisioning/
 
 # Restructure
 /introduction/ /learn/welcome/introduction/
@@ -325,8 +327,9 @@
 ^\/learn\/develop\/integrations\/?(\?.+)?(#.+)?$ -> /learn/develop/cloud-iot-provisioning/$1$2
 ^\/learn\/develop\/integrations\/aws\/?(\?.+)?(#.+)?$ -> /learn/develop/cloud-iot-provisioning/aws/$1$2
 ^\/learn\/develop\/integrations\/azure-iot-hub\/?(\?.+)?(#.+)?$ -> /learn/develop/cloud-iot-provisioning/azure/$1$2
-^\/learn\/develop\/integrations\/google-iot\/?(\?.+)?(#.+)?$ -> /learn/develop/cloud-iot-provisioning/gcp/$1$2
+^\/learn\/develop\/integrations\/google-iot\/?(\?.+)?(#.+)?$ -> /learn/develop/cloud-iot-provisioning/$1$2
 ^\/learn\/develop\/integrations\/bluemix\/?(\?.+)?(#.+)?$ -> /learn/develop/cloud-iot-provisioning/$1$2
+^\/learn\/develop\/cloud-iot-provisioning\/gcp\/?(\?.+)?(#.+)?$ -> /learn/develop/cloud-iot-provisioning/$1$2
 
 # Restructure
 ^\/introduction\/?(\?.+)?(#.+)?$ -> /learn/welcome/introduction/$1$2

--- a/pages/learn/develop/cloud-iot-provisioning.md
+++ b/pages/learn/develop/cloud-iot-provisioning.md
@@ -7,16 +7,12 @@ dynamic:
 
 # Cloud IoT Provisioning with {{ $cloud.name }}
 
-{{#is $cloud.shortName "GCP"}}
-  __Note:__ Google has issued a [deprecation notice](https://cloud.google.com/iot/docs/release-notes#August_16_2022) for the Cloud IoT service due to shutdown in August 2023. Balena's provisioning support for GCP IoT Core will not receive further updates. See [ClearBlade-GCP](/learn/develop/cloud-iot-provisioning/cb-gcp/) for a replacement service.
-{{/is}}
-
-The [{{ $cloud.name }} {{#is $cloud.shortName "GCP"}}(GCP){{/is}} IoT]({{ $cloud.platformUrl }}) platform provides a valuable suite of services to collect, store, and distribute IoT data and actions. Its [{{ $cloud.iotCoreName }}]({{ $cloud.iotCoreUrl }}) service is the portal for registration and messaging with Internet-connected things. We want to make it easy for balena devices to register and interact with {{ $cloud.iotCoreName }}.
+The [{{ $cloud.name }} IoT]({{ $cloud.platformUrl }}) platform provides a valuable suite of services to collect, store, and distribute IoT data and actions. Its [{{ $cloud.iotCoreName }}]({{ $cloud.iotCoreUrl }}) service is the portal for registration and messaging with Internet-connected things. We want to make it easy for balena devices to register and interact with {{ $cloud.iotCoreName }}.
 
 Our IoT provisioning tools automate device registration to {{ $cloud.shortName }} {{ $cloud.iotCoreName }}, and leverage balenaCloud and environment variables to store and access the registration credentials. This guide shows you how provisioning works and gets you started with the tools in the [{{ $cloud.provisionRepoName }}](https://github.com/balena-io-examples/{{ $cloud.provisionRepoName}}) repository.
 
 {{#is $cloud.shortName "ClearBlade"}}
-  As its name suggests, {{ $cloud.name }} is a hybrid platform. {{ $cloud.shortName }} provides the IoT Core service, while Google Cloud (GCP) provides the underlying host platform for other services like the cloud function described below. {{ $cloud.shortName }} {{ $cloud.iotCoreName }} is a replacement for Google's [deprecated](https://cloud.google.com/iot/docs/release-notes#August_16_2022) IoT Core service due to shutdown in August 2023. See our [blog post](https://blog.balena.io/replace-google-iot-core-with-clearblade/) on migrating to {{ $cloud.shortName }}.
+  As its name suggests, {{ $cloud.name }} is a hybrid platform. {{ $cloud.shortName }} provides the IoT Core service, while Google Cloud (GCP) provides the underlying host platform for other services like the cloud function described below.
 {{/is}}
 
 ## How It Works


### PR DESCRIPTION
Google's Cloud IoT service was terminated in mid-August 2023. This update removes references to it from the Cloud IoT provisioning section.