### PR TITLE
actions.md: Clarify that the deactivation fee is not covered by the plan's allowance

### DIFF
--- a/pages/learn/manage/actions.md
+++ b/pages/learn/manage/actions.md
@@ -96,7 +96,7 @@ Turning on local mode is useful when you are prototyping your services, as it al
 
 ### Deactivate Device
 
-This setting will [deactivate the device][inactive-devices] and charge a one-time deactivation fee (equivalent to the cost of a single undiscounted device-month). To deactivate, the device must be offline and be attached to a valid billing account.
+This setting will [deactivate the device][inactive-devices] and charge a one-time deactivation fee (equivalent to the cost of a single undiscounted device-month) that is not covered by your plan's allowance. To deactivate, the device must be offline and be attached to a valid billing account.
 
 Once the device is deactivated, the device won't be counted towards your device total. It will remain inactive until it comes back online.
 


### PR DESCRIPTION
Change-type: patch
See: https://balena.fibery.io/Inputs/Pattern/user-expected-device-deactivation-fee-to-be-covered-by-their-plan's-allowance-4579
See: https://balena.zulipchat.com/#narrow/stream/346009-aspect.2Fcustomer-success/topic/tpsistemas.20querying.20about.20a.20bill.20over.20deactivated.20devices/near/408236452

---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
