### PR TITLE
API/Resources: Add docs listing the balenaOS versions of a device type

### DIFF
--- a/config/dictionaries/resource.json
+++ b/config/dictionaries/resource.json
@@ -671,6 +671,29 @@
     ]
   },
   {
+    "id": "balenaos_versions",
+    "name": "List balenaOS versions",
+    "fields": [],
+    "examples": [
+      {
+        "id": "list-balenaos-versions-for-device-type",
+        "summary": "List the supported balenaOS versions for a device type",
+        "description": "To request a list of the supported balenaOS versions for a particular device type, the `DEVICE TYPE SLUG` parameter is required. Even though this query only selects the `raw_version` field, you can additionally specify any of the fields found in the release resource. The Authorization header is optional.",
+        "method": "GET",
+        "endpoint": "/v6/release",
+        "filters": "?\\$select=raw_version&\\$filter=(is_final%20eq%20true)%20and%20(is_invalidated%20eq%20false)%20and%20(status%20eq%20'success')%20and%20(semver_major%20gt%200)%20and%20(belongs_to__application/any(bta:(bta/is_host%20eq%20true)%20and%20(bta/is_for__device_type/any(dt:dt/slug%20eq%20'<DEVICE TYPE SLUG>'))))&\\$orderby=semver_major%20desc,semver_minor%20desc,semver_patch%20desc,revision%20desc"
+      },
+      {
+        "id": "list-balenaos-versions-for-private-device-type",
+        "summary": "List the supported balenaOS versions for a private device type",
+        "description": "Same as above, but in order to access private device types, you must provide an authentication token.",
+        "method": "GET",
+        "endpoint": "/v6/release",
+        "filters": "?\\$select=raw_version&\\$filter=(is_final%20eq%20true)%20and%20(is_invalidated%20eq%20false)%20and%20(status%20eq%20'success')%20and%20(semver_major%20gt%200)%20and%20(belongs_to__application/any(bta:(bta/is_host%20eq%20true)%20and%20(bta/is_for__device_type/any(dt:dt/slug%20eq%20'<DEVICE TYPE SLUG>'))))&\\$orderby=semver_major%20desc,semver_minor%20desc,semver_patch%20desc,revision%20desc"
+      }
+    ]
+  },
+  {
     "id": "download",
     "name": "Download balenaOS",
     "fields": [],


### PR DESCRIPTION
Since these do not use the release_tags for picking the versions, I've put this as draft and merge it after https://github.com/balena-io/balena-api/pull/4821 gets released, which bacfills the semver fields of all releases from their release_tags, so that users don't get  confused by the v0.0.0 versions.

Depends-on: https://github.com/balena-io/balena-api/pull/4821
Change-type: minor
See: https://balena.zulipchat.com/#narrow/stream/345889-balena-io.2Fos/topic/Determine.20list.20of.20supported.20OS.28hostapp.29.20for.20a.20device-type/near/421801181


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
