### PR TITLE
patch: Add Subresource Integrity to scripts being fetched

### DIFF
--- a/templates/_base-images-ref.html
+++ b/templates/_base-images-ref.html
@@ -1,4 +1,4 @@
-<script src="//cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.15/lodash.min.js" type="text/javascript"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.15/lodash.min.js" integrity="sha512-3oappXMVVac3Ge3OndW0WqpGTWx9jjRJA8SXin8RxmPfc8rg87b31FGy14WHG/ZMRISo9pBjezW9y00RYAEONA==" crossorigin="anonymous"></script>
 <script type="text/javascript">
 
   (function () {

--- a/templates/_config.html
+++ b/templates/_config.html
@@ -1,4 +1,4 @@
-<script src="//cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.15/lodash.min.js" type="text/javascript"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.15/lodash.min.js" integrity="sha512-3oappXMVVac3Ge3OndW0WqpGTWx9jjRJA8SXin8RxmPfc8rg87b31FGy14WHG/ZMRISo9pBjezW9y00RYAEONA==" crossorigin="anonymous"></script>
 <script type="text/javascript">
   (function () {
     window.jQuery

--- a/templates/_copy_code_block.html
+++ b/templates/_copy_code_block.html
@@ -1,4 +1,4 @@
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.8/clipboard.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.11/clipboard.min.js" integrity="sha512-7O5pXpc0oCRrxk8RUfDYFgn0nO1t+jLuIOQdOMRp4APB7uZ4vSjspzp5y6YDtDs4VzUSTbWzBFZ/LKJhnyFOKw==" crossorigin="anonymous"></script>
 <script type="text/javascript">
   window.addEventListener('load', function () {
     // Creating the clipboard button 

--- a/templates/_devices.html
+++ b/templates/_devices.html
@@ -1,4 +1,4 @@
-<script src="//cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.15/lodash.min.js" type="text/javascript"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.15/lodash.min.js" integrity="sha512-3oappXMVVac3Ge3OndW0WqpGTWx9jjRJA8SXin8RxmPfc8rg87b31FGy14WHG/ZMRISo9pBjezW9y00RYAEONA==" crossorigin="anonymous"></script>
 <script type="text/javascript">
 
   (function () {

--- a/templates/_esr_devices.html
+++ b/templates/_esr_devices.html
@@ -1,4 +1,4 @@
-<script src="//cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.15/lodash.min.js" type="text/javascript"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.15/lodash.min.js" integrity="sha512-3oappXMVVac3Ge3OndW0WqpGTWx9jjRJA8SXin8RxmPfc8rg87b31FGy14WHG/ZMRISo9pBjezW9y00RYAEONA==" crossorigin="anonymous"></script>
 <script type="text/javascript">
 
   (function () {

--- a/templates/_machines-architectures.html
+++ b/templates/_machines-architectures.html
@@ -1,4 +1,4 @@
-<script src="//cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.15/lodash.min.js" type="text/javascript"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.15/lodash.min.js" integrity="sha512-3oappXMVVac3Ge3OndW0WqpGTWx9jjRJA8SXin8RxmPfc8rg87b31FGy14WHG/ZMRISo9pBjezW9y00RYAEONA==" crossorigin="anonymous"></script>
 <script type="text/javascript">
   (function () {
     window.jQuery


### PR DESCRIPTION
Adding Subresource integrity to script tags in the docs. 

Hash generated from: https://www.srihash.org/
Report: https://github.com/balena-io/docs/security/code-scanning/1
Solves: https://github.com/balena-io/docs/issues/2909

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
