### PR TITLE
Update config.txt to reflect changes in config.txt parsing with Supervisor v16+

### DIFF
--- a/pages/reference/OS/advanced.md
+++ b/pages/reference/OS/advanced.md
@@ -95,6 +95,16 @@ dtoverlay=i2c-rtc,ds1307
 dtoverlay=lirc-rpi
 ```
 
+As of Supervisor v16+, the above will translate to:
+
+```
+dtoverlay=i2c-rtc
+dtparam=dc1307
+dtoverlay=lirc-rpi
+```
+
+This modifies each parameter to be on its own line in order to avoid the 80 character line limit imposed by config.txt. It is the recommended method of setting one or more overlays with their own parameters.
+
 This parsing will only be done if the value is a valid string, so if it doesn't begin with a quote `"`, the value will be parsed as a single string and not split into several lines. For instance `BALENA_HOST_CONFIG_dtoverlay = i2c-rtc,ds1307` will translate to:
 
 ```


### PR DESCRIPTION
Supervisor v16+ adds each dtparam for a dtoverlay on its own line to comply with the 80-char line limit for config.txt.

Change-type: patch