### PR TITLE
patch: Add token input to lychee action

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -37,13 +37,12 @@ jobs:
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@22134d37a1fff6c2974df9c92a7c7e1e86a08f9c # for v1.9.0
-        
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
           args: >
             --config ./lychee.toml
             "build/**/*" "tools/fetch-external.sh"
+          token: ${{secrets.GITHUB_TOKEN}}
+          
 
       - name: Create Issue From File
         if: |


### PR DESCRIPTION
Saw a large uptick in failed GitHub Actions, hence adding in the token to make sure it all works. 


Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
