### PR TITLE
Stop pulling diagnosis sub docs

### DIFF
--- a/config/navigation.txt
+++ b/config/navigation.txt
@@ -148,4 +148,4 @@ Reference
     Python SDK[/reference/sdk/python-sdk]
     Deprecation Policy[/reference/sdk/deprecation-policy]
 
-  Device Diagnostics[/reference/diagnostics]
+  Diagnostics[/reference/diagnostics]

--- a/tools/build-masterclass.sh
+++ b/tools/build-masterclass.sh
@@ -23,12 +23,6 @@ cd pages/learn/manage && $SCRIPT_DIR/extract-markdown.sh "Accessing your device"
 
 cd pages/learn/manage && $SCRIPT_DIR/extract-markdown.sh "Granting Support Access to a Support Agent" <support-access.md >support-access-device.md && mv support-access-device.md $masterclass_path/debugging/ &
 
-cd pages/reference/ && $SCRIPT_DIR/extract-markdown.sh "Getting Started" <diagnostics.md >initial-diagnosis.md && mv initial-diagnosis.md $masterclass_path/debugging/ &
-
-cd pages/reference/ && $SCRIPT_DIR/extract-markdown.sh "Device Diagnostics" <device-diagnostics.md >device-diagnostics-partial.md && mv device-diagnostics-partial.md $masterclass_path/debugging/ &
-
-cd pages/reference/ && $SCRIPT_DIR/extract-markdown.sh "Supervisor State" <supervisor-state.md >supervisor-diagnostics.md && mv supervisor-diagnostics.md $masterclass_path/debugging/ &
-
 cd pages/faq/troubleshooting/ && $SCRIPT_DIR/extract-markdown.sh "Accessing a Device using a Gateway Device" <debugging-device-gateway.md >device-gateway-partial.md && mv device-gateway-partial.md $masterclass_path/debugging/ &
 
 cd pages/learn/manage && $SCRIPT_DIR/extract-markdown.sh "Device Logs" <device-logs.md >device-logs-partial.md && mv device-logs-partial.md $masterclass_path/debugging/ &

--- a/tools/fetch-external.sh
+++ b/tools/fetch-external.sh
@@ -21,8 +21,6 @@ curl --fail --show-error -o pages/reference/balena-cli.md -L https://github.com/
 curl --fail --show-error -o shared/masterclass/debugging/engine.md -L https://github.com/balena-os/balena-engine/raw/master/balena-docs/engine-debugging.md &
 
 # diagnostics
-curl --fail --show-error -o pages/reference/supervisor-state.md -L https://github.com/balena-io-modules/device-diagnostics/raw/master/supervisor-state.md &
-curl --fail --show-error -o pages/reference/device-diagnostics.md -L https://github.com/balena-io-modules/device-diagnostics/raw/master/device-diagnostics.md &
 curl --fail --show-error -o pages/reference/diagnostics.md -L https://github.com/balena-io-modules/device-diagnostics/raw/master/diagnostics.md &
 
 # Supervisor


### PR DESCRIPTION
Makes necessary changes to account for seperate docs for supervisor-state and device diagnostics not existing

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
