### PR TITLE
patch: Update network-manager links from developer-old.gnome.org

### DIFF
--- a/pages/reference/OS/network.md
+++ b/pages/reference/OS/network.md
@@ -569,12 +569,12 @@ To re-enable IPv6 follow the same commands but with `set ipv6.method enable`.
 
 <!-- links -->
 
-[nm-setting-ref]:https://developer-old.gnome.org/NetworkManager/stable/ref-settings.html
-[nm-ipv4-setting-ref]:https://developer-old.gnome.org/NetworkManager/stable/settings-ipv4.html
+[nm-setting-ref]:https://www.networkmanager.dev/docs/api/latest/ref-settings.html
+[nm-ipv4-setting-ref]:https://www.networkmanager.dev/docs/api/latest/settings-ipv4.html
 [eduroam-ref]:https://www.eduroam.org
-[nm-gsm-setting-ref]:https://developer-old.gnome.org/NetworkManager/stable/settings-gsm.html
+[nm-gsm-setting-ref]:https://networkmanager.dev/docs/api/latest/settings-gsm.html
 [connman-link]: https://en.wikipedia.org/wiki/ConnMan
-[networkmanager-link]:https://developer-old.gnome.org/NetworkManager/
+[networkmanager-link]:https://www.networkmanager.dev
 [modemmanager-link]:https://www.freedesktop.org/wiki/Software/ModemManager/
 [wifi-connect]:{{ $links.githubOS }}/wifi-connect
 [dbus-link]:https://www.freedesktop.org/wiki/Software/dbus/
@@ -583,7 +583,7 @@ To re-enable IPv6 follow the same commands but with `set ipv6.method enable`.
 [redsocks-conf-example]:https://github.com/darkk/redsocks/blob/master/redsocks.conf.example
 [python-base-images]:/reference/base-images/base-images/
 [python-build-images]:/reference/base-images/base-images/#run-vs-build
-[nm-connectivity]:https://developer-old.gnome.org/NetworkManager/stable/NetworkManager.conf.html
+[nm-connectivity]:https://networkmanager.dev/docs/api/latest/NetworkManager.conf.html
 [wifi-dongles]:/reference/hardware/wifi-dongles
 [meta-balena-connectivity]:{{ $links.githubOS }}/meta-balena#connectivity
 


### PR DESCRIPTION
The old network-manager has been deprecated and the links needs to be replaced.

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
