### PR TITLE
patch: Check links on staging deployments

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -26,3 +26,49 @@ jobs:
     with:
       cloudflare_website: "balenacloud-docs"
       docusaurus_website: false
+
+  link-checker:
+    name: Check links in pull request
+    runs-on: ubuntu-latest
+    needs: flowzone
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # fetch external files && building the docs
+      - name: Build the docs
+        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65
+        with:
+          node-version: 18
+      - run: npm run deploy-docs
+
+      - name: Restore lychee cache
+        id: restore-cache
+        if: |
+          github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+        uses: actions/cache/restore@v3
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+
+      # Run link checker on the generated HTML
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@2b973e86fc7b1f6b36a93795fe2c9c6ae1118621 # for v1.10.0
+        env:
+          DEPLOYMENT_URL: ${{ needs.flowzone.outputs.cloudflare_deployment_url || 'https://docs.balena.io' }}
+        with:
+          args: >
+            -qq
+            --base ${{ env.DEPLOYMENT_URL }}
+            --config ./lychee.toml
+            "build/**/*" "tools/fetch-external.sh"
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Save lychee cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: .lycheecache
+          key: ${{ steps.restore-cache.outputs.cache-primary-key }}

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,16 +1,11 @@
 name: link checker
 
 on:
-  repository_dispatch:
   # Run action manually when needed
   workflow_dispatch:
   # Check links once a week on Monday
   schedule:
     - cron: "00 00 * * 1"
-  # Runs on each PR for the master branch
-  pull_request:
-    branches:
-      - "master"
 
 jobs:
   Checking-Links:
@@ -27,38 +22,21 @@ jobs:
           node-version: 18
       - run: npm run deploy-docs
 
-      - name: Restore lychee cache
-        id: restore-cache
-        uses: actions/cache/restore@v3
-        with:
-          path: .lycheecache
-          key: cache-lychee-${{ github.sha }}
-          restore-keys: cache-lychee-
-
       # Run link checker on the generated HTML
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@2b973e86fc7b1f6b36a93795fe2c9c6ae1118621 # for v1.10.0
         with:
           args: >
+            --base https://docs.balena.io
             --config ./lychee.toml
             "build/**/*" "tools/fetch-external.sh"
           token: ${{ secrets.GITHUB_TOKEN }}
-          
 
       - name: Create Issue From File
-        if: |
-          github.event_name != 'pull_request' && 
-          env.lychee_exit_code != 0
+        if: env.lychee_exit_code != 0
         uses: peter-evans/create-issue-from-file@v4
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md
           labels: automated issue
-
-      - name: Save lychee cache
-        uses: actions/cache/save@v3
-        if: always()
-        with:
-          path: .lycheecache
-          key: ${{ steps.restore-cache.outputs.cache-primary-key }}

--- a/lychee.toml
+++ b/lychee.toml
@@ -2,10 +2,10 @@
 
 # Verbose program output
 # Accepts log level: "error", "warn", "info", "debug", "trace"
-verbose = "info"
+verbose = "error"
 
 # Show progress
-progress = true
+progress = false
 
 # Path to summary output file.
 # output = "report.md"
@@ -66,7 +66,7 @@ headers = []
 # remap = [ "https://example.com http://example.invalid" ]
 
 # Base URL or website root directory to check relative URLs.
-base = "https://docs.balena.io"
+# base = "https://docs.balena.io"
 
 # HTTP basic auth support. This will be the username and password passed to the
 # authorization HTTP header. See


### PR DESCRIPTION
Use Lychee to check the following links 

1. During a pull request, Flowzone will publish the staging version of the site to CF, use the CF url to check links (with cache)
2. During a scheduled run, use the production url, docs.balena.io to check any links broken (without cache) 

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
