### PR TITLE
Reduce repetitive paths for base-images docs

### DIFF
--- a/config/navigation.txt
+++ b/config/navigation.txt
@@ -141,7 +141,7 @@ Reference
 
 
   Base images
-    [/reference/base-images/base-images]
+    [/reference/base-images/balena-base-images]
     [/reference/base-images/base-images-ref]
     [/reference/base-images/devicetypes]
 

--- a/config/redirects.txt
+++ b/config/redirects.txt
@@ -82,8 +82,8 @@
 /using/dockerfile /learn/develop/dockerfile/
 /runtime/migrate-to-2.0/ /reference/OS/updates/migrate-to-2.0/
 /runtime/migrate-to-2.0 /reference/OS/updates/migrate-to-2.0/
-/configuration/resin-base-images/ /reference/base-images/resin-base-images/
-/configuration/resin-base-images /reference/base-images/resin-base-images/
+/configuration/resin-base-images/ /reference/base-images/balena-base-images/
+/configuration/resin-base-images /reference/base-images/balena-base-images/
 /deployment/wifi/ /reference/OS/network/2.x/
 /deployment/wifi /reference/OS/network/2.x/
 /runtime/terminal/ /learn/manage/ssh-access/
@@ -198,8 +198,8 @@
 /tools/sdk /reference/sdk/node-sdk/
 /tools/python-sdk/ /reference/sdk/python-sdk/
 /tools/python-sdk /reference/sdk/python-sdk/
-/runtime/resin-base-images/ /reference/base-images/base-images/
-/runtime/resin-base-images /reference/base-images/base-images/
+/runtime/resin-base-images/ /reference/base-images/balena-base-images/
+/runtime/resin-base-images /reference/base-images/balena-base-images/
 /configuration/custom-docker-base-images/ /reference/base-images/customer-docker-base-images/
 /configuration/custom-docker-base-images /reference/base-images/customer-docker-base-images/
 /deployment/docker-templates/ /learn/develop/dockerfile/
@@ -218,8 +218,8 @@
 /reference/OS/meta-balena /reference/OS/customer-board-support/
 /reference/OS/custom-device-support/ /reference/OS/customer-board-support/
 /reference/OS/custom-device-support /reference/OS/customer-board-support/
-/reference/base-images/resin-base-images/ /reference/base-images/base-images/
-/reference/base-images/resin-base-images /reference/base-images/base-images/
+/reference/base-images/resin-base-images/ /reference/base-images/balena-base-images/
+/reference/base-images/resin-base-images /reference/base-images/balena-base-images/
 /reference/api/resources/application/ /reference/api/resources/fleet/
 /reference/api/resources/application /reference/api/resources/fleet/
 /learn/manage/app-types/ /learn/accounts/fleet-types/
@@ -259,6 +259,10 @@
 /faq/troubleshooting/debugging-device-gateway /faq/debugging-device-gateway/
 /faq/troubleshooting/debugging-storage-media/ /faq/debugging-storage-media/
 /faq/troubleshooting/debugging-storage-media /faq/debugging-storage-media/
+
+# base images restructure
+/reference/base-images/base-images/ /reference/base-images/balena-base-images/
+/reference/base-images/base-images /reference/base-images/balena-base-images/
 
 # Important: keep dynamic redirect below the static redirects
 # https://developers.cloudflare.com/pages/platform/redirects/

--- a/pages/faq/questions.md
+++ b/pages/faq/questions.md
@@ -170,7 +170,7 @@ The Intel NUC images are images purposely built to match the Intel NUC hardware.
 [forums]:{{ $names.forums_domain }}/c/troubleshooting
 
 [device-types]: /reference/base-images/devicetypes
-[base-image]: /reference/base-images/base-images
+[base-image]: /reference/base-images/balena-base-images
 [dockerfile]: /learn/develop/dockerfile
 [multicontainer]: /learn/develop/multicontainer
 [app-types]: /learn/manage/app-types

--- a/pages/learn/deploy/build-optimization.md
+++ b/pages/learn/deploy/build-optimization.md
@@ -132,5 +132,5 @@ path-include /usr/share/locale/en*
 [docker-best-practices]:https://docs.docker.com/articles/dockerfile_best-practices/
 [services-masterclass]:/learn/more/masterclasses/services-masterclass/#6-multi-stage-builds
 [scratch]:https://hub.docker.com/_/scratch
-[run-vs-build]:/reference/base-images/base-images/#run-vs-build
-[install-packages]:/reference/base-images/base-images/#installing-packages
+[run-vs-build]:/reference/base-images/balena-base-images/#run-vs-build
+[install-packages]:/reference/base-images/balena-base-images/#installing-packages

--- a/pages/learn/develop/dockerfile.md
+++ b/pages/learn/develop/dockerfile.md
@@ -198,7 +198,7 @@ The {{ $names.company.lower }} Supervisor requires that the directory `/tmp/bale
 [builders]:/learn/deploy/deployment
 [local-build]:/reference/cli/#build-source
 [multicontainer]:/learn/develop/multicontainer
-[base-images]:/reference/base-images/base-images
+[base-images]:/reference/base-images/balena-base-images
 [supported-devices]:/reference/base-images/devicetypes/
 
 [init-system-link]:https://en.wikipedia.org/wiki/Init

--- a/pages/learn/develop/hardware.md
+++ b/pages/learn/develop/hardware.md
@@ -32,5 +32,5 @@ For more details on interacting with external hardware, check out these guides:
 [gpio]:/learn/develop/hardware/gpio
 [i2c-spi]:/learn/develop/hardware/i2c-and-spi
 [usb]:/learn/develop/hardware/usb
-[base-image-wiki-link]:/reference/base-images/base-images/
+[base-image-wiki-link]:/reference/base-images/balena-base-images/
 [udev-link]:https://www.freedesktop.org/software/systemd/man/udev.html

--- a/pages/learn/develop/runtime.md
+++ b/pages/learn/develop/runtime.md
@@ -306,7 +306,7 @@ If your filesystem is not supported you can contact us through our [forums](http
 
 **Preparing the container**
 
-In order to be able to detect external media dynamically you will need to run the container in privileged mode and enable `udevd` on it. This can be easily done if you are using [balena base images](https://www.balena.io/docs/reference/base-images/base-images/#working-with-dynamically-plugged-devices) by:
+In order to be able to detect external media dynamically you will need to run the container in privileged mode and enable `udevd` on it. This can be easily done if you are using [balena base images](https://www.balena.io/docs/reference/base-images/balena-base-images/#working-with-dynamically-plugged-devices) by:
 
 - Adding `privileged: true` to your container's service definition on the `docker-compose.yml` file.
 - Adding `ENV UDEV=on` to your container's `Dockerfile`.

--- a/pages/reference/OS/network.md
+++ b/pages/reference/OS/network.md
@@ -581,8 +581,8 @@ To re-enable IPv6 follow the same commands but with `set ipv6.method enable`.
 [network-manager-examples]:https://wiki.gnome.org/Projects/NetworkManager/Developers#Show_me_more_examples.21 "NetworkManager: Show me more examples!"
 [redsocks]:https://github.com/darkk/redsocks
 [redsocks-conf-example]:https://github.com/darkk/redsocks/blob/master/redsocks.conf.example
-[python-base-images]:/reference/base-images/base-images/
-[python-build-images]:/reference/base-images/base-images/#run-vs-build
+[python-base-images]:/reference/base-images/balena-base-images/
+[python-build-images]:/reference/base-images/balena-base-images/#run-vs-build
 [nm-connectivity]:https://networkmanager.dev/docs/api/latest/NetworkManager.conf.html
 [wifi-dongles]:/reference/hardware/wifi-dongles
 [meta-balena-connectivity]:{{ $links.githubOS }}/meta-balena#connectivity

--- a/pages/reference/base-images/balena-base-images.md
+++ b/pages/reference/base-images/balena-base-images.md
@@ -1,7 +1,6 @@
 ---
 title: Balena base images
-excerpt: Docker images maintained by balena
-
+excerpt: Docker images published and maintained by balena
 
 ---
 


### PR DESCRIPTION
Same reasoning and project as #3062

- **patch: Rename base-images.md to balena-base-images.md**
- **Fix links for balena-base-images page**
- **Add redirects & navigation entry**
