### PR TITLE
patch: Reduce title text to 70 characters

### DIFF
--- a/pages/learn/deploy/release-strategy/update-strategies.md
+++ b/pages/learn/deploy/release-strategy/update-strategies.md
@@ -22,7 +22,7 @@ Setting the `io.balena.update.strategy` label to a valid value selects the updat
 
 which are explained below. The `io.balena.update.handover-timeout` label is only used in the  `hand-over` strategy, and its use is explained in the [strategy's description](#hand-over).
 
-__Note:__ Prior to Balena Supervisor v7.23.0 the strategy was controlled by two configuration variables, `RESIN_SUPERVISOR_UPDATE_STRATEGY` and `RESIN_SUPERVISOR_HANDOVER_TIMEOUT`, which had the same effect as the labels do today. 
+__Note:__ Prior to balena Supervisor v7.23.0 the strategy was controlled by two configuration variables, `RESIN_SUPERVISOR_UPDATE_STRATEGY` and `RESIN_SUPERVISOR_HANDOVER_TIMEOUT`, which had the same effect as the labels do today. 
 This mechanism for controlling the strategy is considered _deprecated_ and may be removed in the future.
 
 All update strategies below honor the [fleet update locks][update-locks] which you can use prevent updates temporarily.

--- a/pages/learn/getting-started.md
+++ b/pages/learn/getting-started.md
@@ -1,5 +1,5 @@
 ---
-title: Get Started with {{ $names.cloud.lower }} using {{ $device.name }} and {{ $language.name }}
+title: "Getting started: {{ $device.name }} and {{ $language.name }}"
 
 layout: getting-started.html
 

--- a/pages/learn/more/glossary.md
+++ b/pages/learn/more/glossary.md
@@ -363,7 +363,7 @@ Amazon Redshift is a cloud data warehouse used to process large amounts of data,
 A snapshot of code collected into one or more [Docker images](#docker-image).
 
 ### Resin
-The former name for Balena, changed late 2018.
+The former name for balena, changed late 2018.
 
 ### Rulemotion
 The former name for Resin.

--- a/pages/reference/supervisor/configuration-list.md
+++ b/pages/reference/supervisor/configuration-list.md
@@ -1,5 +1,5 @@
 ---
-title: Configuration List for {{ $device.name }}
+title: Configuration List for {{ $device.name }} | balena
 
 layout: config.html
 extras: config-js

--- a/shared/getting-started/whatYouNeed/fincm3.md
+++ b/shared/getting-started/whatYouNeed/fincm3.md
@@ -1,6 +1,6 @@
 <img style="float: right;padding-left: 10px;" src="/img/fincm3/fincm3.webp" width="30%">
 
-* A [Balena Fin][fin-link]. See our [supported devices list][supportedDevicesList] for other boards.
+* A [balena Fin][fin-link]. See our [supported devices list][supportedDevicesList] for other boards.
 * A 5.5/2.1mm Barrel Jack Power supply rated at 6 - 24 Vdc. It is also possible to power the fin via the phoenix connector next to the barrel jack, be sure to **never** apply power to both connectors simultaneously!
 * A micro USB cable.
 * **[Optional]** An ethernet cable.

--- a/shared/troubleshooting/jetson-nano-2gb-devkit.md
+++ b/shared/troubleshooting/jetson-nano-2gb-devkit.md
@@ -1,4 +1,4 @@
-### Unable to boot balenaOS image downloaded from Balena cloud
+### Unable to boot balenaOS image downloaded from balenaCloud
 
 Starting with L4T 32.5, all bootloaders and firmware on the Jetson Nano family of boards have been moved from the sd-card/eMMC to the device's QSPI flash memory. L4T 32.5 and newer bootloaders are not compatible with previous L4T releases.
 

--- a/shared/troubleshooting/jetson-nano-emmc.md
+++ b/shared/troubleshooting/jetson-nano-emmc.md
@@ -1,4 +1,4 @@
-### Unable to boot balenaOS image downloaded from Balena cloud
+### Unable to boot balenaOS image downloaded from balenaCloud
 
 Starting with L4T 32.5, all bootloaders and firmware on the Jetson Nano family of boards have been moved from the sd-card/eMMC to the device's QSPI flash memory. L4T 32.5 and newer bootloaders are not compatible with previous L4T releases.
 

--- a/shared/troubleshooting/jetson-nano.md
+++ b/shared/troubleshooting/jetson-nano.md
@@ -1,4 +1,4 @@
-### Unable to boot balenaOS image downloaded from Balena cloud
+### Unable to boot balenaOS image downloaded from balenaCloud
 
 Starting with L4T 32.5, all bootloaders and firmware on the Jetson Nano family of boards have been moved from the sd-card/eMMC to the device's QSPI flash memory. L4T 32.5 and newer bootloaders are not compatible with previous L4T releases.
 

--- a/shared/troubleshooting/jetson-tx2-nx-devkit.md
+++ b/shared/troubleshooting/jetson-tx2-nx-devkit.md
@@ -2,7 +2,7 @@
 ### Are L4T 28.4 and 28.5 releases supported in balenaOS?
 
 The L4T versions 28.4 and 28.5 did not follow the usual incremental release process, instead these version were released in July 2020 and July 2021 respectively, after the first iterations of L4T 32.X were released.
-Since balenaOS uses the [OE4T/meta-tegra][meta-tegra] yocto repository and only updates to incremetal versions of L4T, balenaOS images based on 28.4 and and 28.5 which were released after L4T 32.1 are not available in the Balena cloud.
+Since balenaOS uses the [OE4T/meta-tegra][meta-tegra] yocto repository and only updates to incremetal versions of L4T, balenaOS images based on 28.4 and and 28.5 which were released after L4T 32.1 are not available in the balenaCloud.
 
 ### Can a balenaOS update from an older L4T 28.X based release to a newer L4T 32.X be interrupted? Can I boot back into the old OS?
 

--- a/shared/troubleshooting/jetson-tx2.md
+++ b/shared/troubleshooting/jetson-tx2.md
@@ -10,7 +10,7 @@ To resolve, either:
 ### Are L4T 28.4 and 28.5 releases supported in balenaOS?
 
 The L4T versions 28.4 and 28.5 did not follow the usual incremental release process, instead these version were released in July 2020 and July 2021 respectively, after the first iterations of L4T 32.X were released.
-Since balenaOS uses the [OE4T/meta-tegra][meta-tegra] yocto repository and only updates to incremetal versions of L4T, balenaOS images based on 28.4 and and 28.5 which were released after L4T 32.1 are not available in the Balena cloud.
+Since balenaOS uses the [OE4T/meta-tegra][meta-tegra] yocto repository and only updates to incremetal versions of L4T, balenaOS images based on 28.4 and and 28.5 which were released after L4T 32.1 are not available in the balenaCloud.
 
 ### Can a balenaOS update from an older L4T 28.X based release to a newer L4T 32.X be interrupted? Can I boot back into the old OS?
 

--- a/templates/default.html
+++ b/templates/default.html
@@ -3,7 +3,7 @@
 
   <head>
     <meta charset="utf-8">
-    <title>{{ title }} - {{ $names.company.upper }} Documentation</title>
+    <title>{{ title }} | {{ $names.company.lower }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="shortcut icon" type="image/x-icon" href="/favicon.png" />
 
@@ -11,7 +11,7 @@
       <meta property="fb:app_id" content="{{ fbAppId }}" />
     {% endif %}
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="{{ title }} - {{ $names.company.upper }} Documentation" />
+    <meta property="og:title" content="{{ title }} | {{ $names.company.lower }}" />
     {% if excerpt %}
       <meta property="og:description" content="{{ excerpt }}" />
     {% endif %}


### PR DESCRIPTION
Pages which have page titles over Google's estimated pixel length limit for titles in search results. Google snippet length is actually based upon pixels limits, rather than a character length. The SEO Spider tries to match the latest pixel truncation points in the SERPs, but it is an approximation and Google adjusts them frequently.

Pages which have h1s over the configured length. There is no hard limit for characters in an h1, however they should be clear and concise for users and long headings might be less helpful

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
