### PR TITLE
API/overview: Replace the application.device_type property with is_for__device_type since it's not in the v6 model

### DIFF
--- a/pages/reference/api/overview.md
+++ b/pages/reference/api/overview.md
@@ -49,11 +49,10 @@ Depending on the number of fleets you have access to, this could return much mor
 
 `$select` specifies which fields to return for each resource. By default, every field comes back as part of the response, but most use cases require only one or two of these pieces of information.
 
-The following API call uses `$select` to only return the name and device type for each application:
+The following API call uses `$select` to only return the name and the device type id for each application:
 
 ```shell
-curl -X GET
-"{{ $links.apiBase }}/v6/application?\$select=app_name,device_type" \
+curl -X GET "{{ $links.apiBase }}/v6/application?\$select=app_name,is_for__device_type" \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer <AUTH_TOKEN>"
 ```

--- a/pages/reference/api/overview.md
+++ b/pages/reference/api/overview.md
@@ -102,6 +102,15 @@ curl -X GET \
 -H "Authorization: Bearer <AUTH_TOKEN>"
 ```
 
+Similarly we can extend our earlier API call that retrieves all applications to also include their device type slug by using a `$expand`:
+```shell
+curl -X GET \
+"{{ $links.apiBase }}/v6/application?\$select=app_name\$expand=is_for__device_type(\$select=id,slug)" \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer <AUTH_TOKEN>"
+```
+
+
 It's also possible to filter on a field that belongs to a linked resource. To find all devices belonging to an application by that application's name, you would construct your query like this:
 
 ```shell


### PR DESCRIPTION
Change-type: patch
See: https://balena.fibery.io/Work/Task/Update-the-doc-examples-to-use-the-v7-model-2208