### PR TITLE
Fix SAML docs use `auth` prefix on SAML urls

### DIFF
--- a/pages/learn/accounts/idp-setup/google-workspace-saml-setup.md
+++ b/pages/learn/accounts/idp-setup/google-workspace-saml-setup.md
@@ -29,7 +29,7 @@ This guide will walk you through the steps to create a SAML Identity Provider (I
     * ACS URL: Fill in the Assertion Consumer Service (ACS) URL with:
 
     ```
-    https://api.balena-cloud.com/saml/acme/callback
+    https://api.balena-cloud.com/auth/saml/acme/callback
     ```
 
     Replace `acme` with the name you will give your IdP in balenaCloud.
@@ -37,7 +37,7 @@ This guide will walk you through the steps to create a SAML Identity Provider (I
     * Entity ID: Fill in the Entity ID with:
 
     ```
-    https://api.balena-cloud.com/saml/acme
+    https://api.balena-cloud.com/auth/saml/acme
     ```
 
     Again, replace `acme` with the name you will give your IdP.


### PR DESCRIPTION
Change-type: patch


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
