### PR TITLE
patch: Update create-issue-from-file action to v5

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -7,6 +7,12 @@ on:
   schedule:
     - cron: "00 00 * * 1"
 
+permissions:
+  contents: read
+  issues: write
+  actions: read
+  pull-requests: read
+
 jobs:
   Checking-Links:
     runs-on: ubuntu-latest
@@ -37,8 +43,11 @@ jobs:
 
       - name: Create Issue From File
         if: env.lychee_exit_code != 0
-        uses: peter-evans/create-issue-from-file@v4
+        uses: peter-evans/create-issue-from-file@v5
         with:
           title: Link Checker Report
+          token: ${{ secrets.GITHUB_TOKEN }}
           content-filepath: ./lychee/out.md
-          labels: automated issue
+          labels: |
+            report
+            automated issue


### PR DESCRIPTION
v4 of this action has been failing for the past few weeks with the error: `Resource not accessible by integration`

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
