### PR TITLE
patch: Update NPM dependencies

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -31,6 +31,7 @@ jobs:
     name: Check links in pull request
     runs-on: ubuntu-latest
     needs: flowzone
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -54,16 +55,17 @@ jobs:
           key: cache-lychee-${{ github.sha }}
           restore-keys: cache-lychee-
 
+      - name: Set Deployment URL
+        run: echo "DEPLOYMENT_URL=${{ needs.flowzone.outputs.cloudflare_deployment_url || 'https://docs.balena.io' }}" >> $GITHUB_ENV
+
       # Run link checker on the generated HTML
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@2b973e86fc7b1f6b36a93795fe2c9c6ae1118621 # for v1.10.0
-        env:
-          DEPLOYMENT_URL: ${{ needs.flowzone.outputs.cloudflare_deployment_url || 'https://docs.balena.io' }}
         with:
           args: >
             -qq
-            --base ${{ env.DEPLOYMENT_URL }}
+            --base $DEPLOYMENT_URL
             --config ./lychee.toml
             "build/**/*" "tools/fetch-external.sh"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@balena/doxx": "^1.0.3",
-        "balena-sdk": "^20.6.8",
+        "balena-sdk": "^20.8.3",
         "bootstrap": "^3.4.1",
         "bootstrap-select": "^1.13.18",
         "coffeescript": "^2.7.0",
-        "express": "^4.21.1",
+        "express": "^4.21.2",
         "express-http-to-https": "1.1.4",
         "headroom.js": "0.12.0",
         "highlight.js": "10.7.3",
@@ -23,7 +23,7 @@
         "lodash": "^4.17.21"
       },
       "devDependencies": {
-        "cspell": "^8.16.0",
+        "cspell": "^8.17.1",
         "css-loader": "5.2.7",
         "file-loader": "6.2.0",
         "line-by-line": "^0.1.6",
@@ -35,7 +35,7 @@
         "watch": "^1.0.2",
         "webpack": "5.96.1",
         "webpack-cli": "^5.1.4",
-        "wrangler": "^3.88.0"
+        "wrangler": "^3.99.0"
       },
       "engines": {
         "node": "^18.0.0"
@@ -126,29 +126,50 @@
         "npm": ">=8.1.0"
       }
     },
+    "node_modules/@balena/abstract-sql-compiler/node_modules/@balena/sbvr-types": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@balena/sbvr-types/-/sbvr-types-7.1.3.tgz",
+      "integrity": "sha512-kizk+ClfYJVJidMx69BiFSFqtDE97R4JXRYrn1Ff/vK+ycN7Mj3HVObFk5DvckresiBI9S2mvZsysW+RVNmJsg==",
+      "engines": {
+        "node": ">=16.13.0",
+        "npm": ">=8.1.0"
+      },
+      "optionalDependencies": {
+        "bcrypt": "^5.1.1",
+        "bcryptjs": "^2.4.3",
+        "sha.js": "^2.4.11"
+      }
+    },
     "node_modules/@balena/abstract-sql-to-typescript": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@balena/abstract-sql-to-typescript/-/abstract-sql-to-typescript-3.2.3.tgz",
-      "integrity": "sha512-trdxELxlIwDSULF0sD/LW6t/X/D77LC53CjCaLGBsfbqYJUErnvkI420SBShf4zNXnE7K2qULdu9OiwQilKjjg==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@balena/abstract-sql-to-typescript/-/abstract-sql-to-typescript-4.0.6.tgz",
+      "integrity": "sha512-OPfXbrM08VB7Uywr3QtlaJLIelsW55mgb9hYTgjlwW+mA3ZgvxBtr9DbKcAGujB2xNxwHBXCqwafP4X3CzGJ+Q==",
       "dependencies": {
         "@balena/abstract-sql-compiler": "^9.2.0",
-        "@balena/odata-to-abstract-sql": "^6.2.7",
-        "@balena/sbvr-types": "^7.1.3",
-        "@types/node": "^20.14.8",
+        "@balena/odata-to-abstract-sql": "^6.3.0",
+        "@types/node": "^20.16.5",
         "common-tags": "^1.8.2"
       },
       "engines": {
         "node": ">=16.13.0",
         "npm": ">=8.1.0"
+      },
+      "peerDependencies": {
+        "@balena/sbvr-types": "^7.1.0, ^8.0.0, ^9.0.0"
       }
     },
     "node_modules/@balena/abstract-sql-to-typescript/node_modules/@types/node": {
-      "version": "20.14.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
-      "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
+      "version": "20.17.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.11.tgz",
+      "integrity": "sha512-Ept5glCK35R8yeyIeYlRIZtX6SLRyqMhOFTgj5SOkMpLTdw3SEHI9fHx60xaUZ+V1aJxQJODE+7/j5ocZydYTg==",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.19.2"
       }
+    },
+    "node_modules/@balena/abstract-sql-to-typescript/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
     "node_modules/@balena/doxx": {
       "version": "1.0.3",
@@ -208,26 +229,26 @@
       }
     },
     "node_modules/@balena/odata-parser": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@balena/odata-parser/-/odata-parser-3.0.8.tgz",
-      "integrity": "sha512-EhC7uYZUTIeoBPSAHRfL2tz4H2pfe9vO9U4jf/84NVnh6GKApA8Gfo4QQWwL/SHuz+KJI0LkhjU9yNqKCPE0kg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@balena/odata-parser/-/odata-parser-3.1.2.tgz",
+      "integrity": "sha512-RBLqz1u945NgQ+Ds2YS1VXnk1ViFHoNIuRyROHGDmmp6LrczBq8fSZAs+cxb7URZptOryLBhQKwf3m23xUa11Q==",
       "engines": {
         "node": ">=16.13.0",
         "npm": ">=8.1.0"
       }
     },
     "node_modules/@balena/odata-to-abstract-sql": {
-      "version": "6.2.7",
-      "resolved": "https://registry.npmjs.org/@balena/odata-to-abstract-sql/-/odata-to-abstract-sql-6.2.7.tgz",
-      "integrity": "sha512-SfIxIAw5/60qux3xBT/pS29GZpKzMmAu0oZpdfnni/duhPQmKBs/peGqqF2rPcHp1rODiqRzNFDcJ7KkPq9Wrg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@balena/odata-to-abstract-sql/-/odata-to-abstract-sql-6.4.0.tgz",
+      "integrity": "sha512-GMC8AP0HAS1Di5jM+JEjVEque4cQxLK77MQLVXgGI8dJK/UGwUDt/ThwOeqPTUKBHjUGPhiQgY6WedCHyM3zqw==",
       "dependencies": {
-        "@balena/abstract-sql-compiler": "^9.1.4",
-        "@balena/odata-parser": "^3.0.3",
-        "@types/lodash": "^4.14.202",
+        "@balena/abstract-sql-compiler": "^9.2.0",
+        "@balena/odata-parser": "^3.1.0",
+        "@types/lodash": "^4.17.10",
         "@types/memoizee": "^0.4.11",
         "@types/string-hash": "^1.1.3",
         "lodash": "^4.17.21",
-        "memoizee": "^0.4.15",
+        "memoizee": "^0.4.17",
         "string-hash": "^1.1.3"
       },
       "engines": {
@@ -236,9 +257,10 @@
       }
     },
     "node_modules/@balena/sbvr-types": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@balena/sbvr-types/-/sbvr-types-7.1.3.tgz",
-      "integrity": "sha512-kizk+ClfYJVJidMx69BiFSFqtDE97R4JXRYrn1Ff/vK+ycN7Mj3HVObFk5DvckresiBI9S2mvZsysW+RVNmJsg==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@balena/sbvr-types/-/sbvr-types-9.1.0.tgz",
+      "integrity": "sha512-oOnRFpCLlvCpHm5z91/m3qUOWrpvosVYHL8NiOUGakB2JwMZsAAf6tCq8Q0QEJJRbG/v1HBHLo+aJDvj52Mn5g==",
+      "peer": true,
       "engines": {
         "node": ">=16.13.0",
         "npm": ">=8.1.0"
@@ -262,9 +284,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20241106.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20241106.1.tgz",
-      "integrity": "sha512-zxvaToi1m0qzAScrxFt7UvFVqU8DxrCO2CinM1yQkv5no7pA1HolpIrwZ0xOhR3ny64Is2s/J6BrRjpO5dM9Zw==",
+      "version": "1.20241218.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20241218.0.tgz",
+      "integrity": "sha512-8rveQoxtUvlmORKqTWgjv2ycM8uqWox0u9evn3zd2iWKdou5sncFwH517ZRLI3rq9P31ZLmCQBZ0gloFsTeY6w==",
       "cpu": [
         "x64"
       ],
@@ -278,9 +300,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20241106.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20241106.1.tgz",
-      "integrity": "sha512-j3dg/42D/bPgfNP3cRUBxF+4waCKO/5YKwXNj+lnVOwHxDu+ne5pFw9TIkKYcWTcwn0ZUkbNZNM5rhJqRn4xbg==",
+      "version": "1.20241218.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20241218.0.tgz",
+      "integrity": "sha512-be59Ad9nmM9lCkhHqmTs/uZ3JVZt8NJ9Z0PY+B0xnc5z6WwmV2lj0RVLtq7xJhQsQJA189zt5rXqDP6J+2mu7Q==",
       "cpu": [
         "arm64"
       ],
@@ -294,9 +316,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20241106.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20241106.1.tgz",
-      "integrity": "sha512-Ih+Ye8E1DMBXcKrJktGfGztFqHKaX1CeByqshmTbODnWKHt6O65ax3oTecUwyC0+abuyraOpAtdhHNpFMhUkmw==",
+      "version": "1.20241218.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20241218.0.tgz",
+      "integrity": "sha512-MzpSBcfZXRxrYWxQ4pVDYDrUbkQuM62ssl4ZtHH8J35OAeGsWFAYji6MkS2SpVwVcvacPwJXIF4JSzp4xKImKw==",
       "cpu": [
         "x64"
       ],
@@ -310,9 +332,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20241106.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20241106.1.tgz",
-      "integrity": "sha512-mdQFPk4+14Yywn7n1xIzI+6olWM8Ybz10R7H3h+rk0XulMumCWUCy1CzIDauOx6GyIcSgKIibYMssVHZR30ObA==",
+      "version": "1.20241218.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20241218.0.tgz",
+      "integrity": "sha512-RIuJjPxpNqvwIs52vQsXeRMttvhIjgg9NLjjFa3jK8Ijnj8c3ZDru9Wqi48lJP07yDFIRr4uDMMqh/y29YQi2A==",
       "cpu": [
         "arm64"
       ],
@@ -326,9 +348,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20241106.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20241106.1.tgz",
-      "integrity": "sha512-4rtcss31E/Rb/PeFocZfr+B9i1MdrkhsTBWizh8siNR4KMmkslU2xs2wPaH1z8+ErxkOsHrKRa5EPLh5rIiFeg==",
+      "version": "1.20241218.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20241218.0.tgz",
+      "integrity": "sha512-tO1VjlvK3F6Yb2d1jgEy/QBYl//9Pyv3K0j+lq8Eu7qdfm0IgKwSRgDWLept84/qmNsQfausZ4JdNGxTf9xsxQ==",
       "cpu": [
         "x64"
       ],
@@ -341,31 +363,18 @@
         "node": ">=16"
       }
     },
-    "node_modules/@cloudflare/workers-shared": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-shared/-/workers-shared-0.7.1.tgz",
-      "integrity": "sha512-46cP5FCrl3TrvHeoHLb5SRuiDMKH5kc9Yvo36SAfzt8dqJI/qJRoY1GP3ioHn/gP7v2QIoUOTAzIl7Ml7MnfrA==",
-      "dev": true,
-      "dependencies": {
-        "mime": "^3.0.0",
-        "zod": "^3.22.3"
-      },
-      "engines": {
-        "node": ">=16.7.0"
-      }
-    },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.16.0.tgz",
-      "integrity": "sha512-R0Eqq5kTZnmZ0elih5uY3TWjMqqAeMl7ciU7maUs+m1FNjCEdJXtJ9wrQxNgjmXi0tX8cvahZRO3O558tEz/KA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.17.1.tgz",
+      "integrity": "sha512-HmkXS5uX4bk/XxsRS4Q+zRvhgRa81ddGiR2/Xfag9MIi5L5UnEJ4g21EpmIlXkMxYrTu2fp69SZFss5NfcFF9Q==",
       "dev": true,
       "dependencies": {
         "@cspell/dict-ada": "^4.0.5",
         "@cspell/dict-al": "^1.0.3",
         "@cspell/dict-aws": "^4.0.7",
         "@cspell/dict-bash": "^4.1.8",
-        "@cspell/dict-companies": "^3.1.7",
-        "@cspell/dict-cpp": "^6.0.1",
+        "@cspell/dict-companies": "^3.1.8",
+        "@cspell/dict-cpp": "^6.0.2",
         "@cspell/dict-cryptocurrencies": "^5.0.3",
         "@cspell/dict-csharp": "^4.0.5",
         "@cspell/dict-css": "^4.0.16",
@@ -374,17 +383,17 @@
         "@cspell/dict-docker": "^1.1.11",
         "@cspell/dict-dotnet": "^5.0.8",
         "@cspell/dict-elixir": "^4.0.6",
-        "@cspell/dict-en_us": "^4.3.26",
+        "@cspell/dict-en_us": "^4.3.28",
         "@cspell/dict-en-common-misspellings": "^2.0.7",
         "@cspell/dict-en-gb": "1.1.33",
-        "@cspell/dict-filetypes": "^3.0.8",
+        "@cspell/dict-filetypes": "^3.0.9",
         "@cspell/dict-flutter": "^1.0.3",
         "@cspell/dict-fonts": "^4.0.3",
         "@cspell/dict-fsharp": "^1.0.4",
         "@cspell/dict-fullstack": "^3.2.3",
-        "@cspell/dict-gaming-terms": "^1.0.8",
+        "@cspell/dict-gaming-terms": "^1.0.9",
         "@cspell/dict-git": "^3.0.3",
-        "@cspell/dict-golang": "^6.0.16",
+        "@cspell/dict-golang": "^6.0.17",
         "@cspell/dict-google": "^1.0.4",
         "@cspell/dict-haskell": "^4.0.4",
         "@cspell/dict-html": "^4.0.10",
@@ -399,16 +408,16 @@
         "@cspell/dict-markdown": "^2.0.7",
         "@cspell/dict-monkeyc": "^1.0.9",
         "@cspell/dict-node": "^5.0.5",
-        "@cspell/dict-npm": "^5.1.11",
+        "@cspell/dict-npm": "^5.1.17",
         "@cspell/dict-php": "^4.0.13",
         "@cspell/dict-powershell": "^5.0.13",
         "@cspell/dict-public-licenses": "^2.0.11",
-        "@cspell/dict-python": "^4.2.12",
+        "@cspell/dict-python": "^4.2.13",
         "@cspell/dict-r": "^2.0.4",
         "@cspell/dict-ruby": "^5.0.7",
-        "@cspell/dict-rust": "^4.0.9",
+        "@cspell/dict-rust": "^4.0.10",
         "@cspell/dict-scala": "^5.0.6",
-        "@cspell/dict-software-terms": "^4.1.13",
+        "@cspell/dict-software-terms": "^4.1.19",
         "@cspell/dict-sql": "^2.1.8",
         "@cspell/dict-svelte": "^1.0.5",
         "@cspell/dict-swift": "^2.0.4",
@@ -421,30 +430,30 @@
       }
     },
     "node_modules/@cspell/cspell-json-reporter": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.16.0.tgz",
-      "integrity": "sha512-KLjPK94gA3JNuWy70LeenJ6EL3SFk2ejERKYJ6SVV/cVOKIvVd2qe42yX3/A/DkF2xzuZ2LD4z0sfoqQL1BaqA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.17.1.tgz",
+      "integrity": "sha512-EV9Xkh42Xw3aORvDZfxusICX91DDbqQpYdGKBdPGuhgxWOUYYZKpLXsHCmDkhruMPo2m5gDh++/OqjLRPZofKQ==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-types": "8.16.0"
+        "@cspell/cspell-types": "8.17.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.16.0.tgz",
-      "integrity": "sha512-WoCgrv/mrtwCY4lhc6vEcqN3AQ7lT6K0NW5ShoSo116U2tRaW0unApIYH4Va8u7T9g3wyspFEceQRR1xD9qb9w==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.17.1.tgz",
+      "integrity": "sha512-uhC99Ox+OH3COSgShv4fpVHiotR70dNvAOSkzRvKVRzV6IGyFnxHjmyVVPEV0dsqzVLxltwYTqFhwI+UOwm45A==",
       "dev": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-resolver": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.16.0.tgz",
-      "integrity": "sha512-b+99bph43ptkXlQHgPXSkN/jK6LQHy2zL1Fm9up7+x6Yr64bxAzWzoeqJAPtnrPvFuOrFN0jZasZzKBw8CvrrQ==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.17.1.tgz",
+      "integrity": "sha512-XEK2ymTdQNgsV3ny60VkKzWskbICl4zNXh/DbxsoRXHqIRg43MXFpTNkEJ7j873EqdX7BU4opQQ+5D4stWWuhQ==",
       "dev": true,
       "dependencies": {
         "global-directory": "^4.0.1"
@@ -454,123 +463,123 @@
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.16.0.tgz",
-      "integrity": "sha512-+fn763JKA4EYCOv+1VShFq015UMEBAFRDr+rlCnesgLE0fv9TSFVLsjOfh9/g6GuGQLCRLUqKztwwuueeErstQ==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.17.1.tgz",
+      "integrity": "sha512-2sFWQtMEWZ4tdz7bw0bAx4NaV1t0ynGfjpuKWdQppsJFKNb+ZPZZ6Ah1dC13AdRRMZaG194kDRFwzNvRaCgWkQ==",
       "dev": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.16.0.tgz",
-      "integrity": "sha512-bGrIK7p4NVsK+QX/CYWmjax+FkzfSIZaIaoiBESGV5gmwgXDVRMJ3IP6tQVAmTtckOYHCmtT5CZgI8zXWr8dHQ==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.17.1.tgz",
+      "integrity": "sha512-NJbov7Jp57fh8addoxesjb8atg/APQfssCH5Q9uZuHBN06wEJDgs7fhfE48bU+RBViC9gltblsYZzZZQKzHYKg==",
       "dev": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/dict-ada": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-ada/-/dict-ada-4.0.5.tgz",
-      "integrity": "sha512-6/RtZ/a+lhFVmrx/B7bfP7rzC4yjEYe8o74EybXcvu4Oue6J4Ey2WSYj96iuodloj1LWrkNCQyX5h4Pmcj0Iag==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ada/-/dict-ada-4.0.6.tgz",
+      "integrity": "sha512-1DpA3LeidQS5Wec5ZnrIRtuv/ijUcfcUq8G5hj/3QZT4vTTRXtIaQnfsq7t3XYsRlisYHkVmm2CgsJ/8hKChLw==",
       "dev": true
     },
     "node_modules/@cspell/dict-al": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-al/-/dict-al-1.0.3.tgz",
-      "integrity": "sha512-V1HClwlfU/qwSq2Kt+MkqRAsonNu3mxjSCDyGRecdLGIHmh7yeEeaxqRiO/VZ4KP+eVSiSIlbwrb5YNFfxYZbw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-al/-/dict-al-1.0.4.tgz",
+      "integrity": "sha512-W4ppuwhZN6A1genmj9Q4NC8UKy7TrRb7UjvMsuPDen+V8anePTys9a0DpKp3z0S6nlrcZgqYNe9Hw/9k76mkAQ==",
       "dev": true
     },
     "node_modules/@cspell/dict-aws": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.7.tgz",
-      "integrity": "sha512-PoaPpa2NXtSkhGIMIKhsJUXB6UbtTt6Ao3x9JdU9kn7fRZkwD4RjHDGqulucIOz7KeEX/dNRafap6oK9xHe4RA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.8.tgz",
+      "integrity": "sha512-9gYdKw34dorYbwh+ycUDNQQHfkUTBRKQNriSUXB0L/SA/k1bbFuD7qQxUmSmmH+Q0AjDCJ41OntF7l/Ok1H3ig==",
       "dev": true
     },
     "node_modules/@cspell/dict-bash": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-bash/-/dict-bash-4.1.8.tgz",
-      "integrity": "sha512-I2CM2pTNthQwW069lKcrVxchJGMVQBzru2ygsHCwgidXRnJL/NTjAPOFTxN58Jc1bf7THWghfEDyKX/oyfc0yg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-bash/-/dict-bash-4.1.9.tgz",
+      "integrity": "sha512-Gl7tE1dFgtZHUZTpzAA4/HyKE9QXJ1dyDrru98J4LdhTPaoyXW+b8hfr4y7n21zzEqE2zAW4fi3o85IY28uPTQ==",
       "dev": true
     },
     "node_modules/@cspell/dict-companies": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.1.7.tgz",
-      "integrity": "sha512-ncVs/efuAkP1/tLDhWbXukBjgZ5xOUfe03neHMWsE8zvXXc5+Lw6TX5jaJXZLOoES/f4j4AhRE20jsPCF5pm+A==",
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.1.12.tgz",
+      "integrity": "sha512-99FxBNdLOQc3nVQ663Xh7JqDLbIy/AdqOecQ5bk3HpmXpSkoDvTT7XCUU5nQZvmFBrrQlXFKlRRYjLfTEOUDdA==",
       "dev": true
     },
     "node_modules/@cspell/dict-cpp": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-6.0.2.tgz",
-      "integrity": "sha512-yw5eejWvY4bAnc6LUA44m4WsFwlmgPt2uMSnO7QViGMBDuoeopMma4z9XYvs4lSjTi8fIJs/A1YDfM9AVzb8eg==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-6.0.3.tgz",
+      "integrity": "sha512-OFrVXdxCeGKnon36Pe3yFjBuY4kzzEwWFf3vDz+cJTodZDkjFkBifQeTtt5YfimgF8cfAJZXkBCsxjipAgmAiw==",
       "dev": true
     },
     "node_modules/@cspell/dict-cryptocurrencies": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-cryptocurrencies/-/dict-cryptocurrencies-5.0.3.tgz",
-      "integrity": "sha512-bl5q+Mk+T3xOZ12+FG37dB30GDxStza49Rmoax95n37MTLksk9wBo1ICOlPJ6PnDUSyeuv4SIVKgRKMKkJJglA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cryptocurrencies/-/dict-cryptocurrencies-5.0.4.tgz",
+      "integrity": "sha512-6iFu7Abu+4Mgqq08YhTKHfH59mpMpGTwdzDB2Y8bbgiwnGFCeoiSkVkgLn1Kel2++hYcZ8vsAW/MJS9oXxuMag==",
       "dev": true
     },
     "node_modules/@cspell/dict-csharp": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-csharp/-/dict-csharp-4.0.5.tgz",
-      "integrity": "sha512-c/sFnNgtRwRJxtC3JHKkyOm+U3/sUrltFeNwml9VsxKBHVmvlg4tk4ar58PdpW9/zTlGUkWi2i85//DN1EsUCA==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-csharp/-/dict-csharp-4.0.6.tgz",
+      "integrity": "sha512-w/+YsqOknjQXmIlWDRmkW+BHBPJZ/XDrfJhZRQnp0wzpPOGml7W0q1iae65P2AFRtTdPKYmvSz7AL5ZRkCnSIw==",
       "dev": true
     },
     "node_modules/@cspell/dict-css": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.0.16.tgz",
-      "integrity": "sha512-70qu7L9z/JR6QLyJPk38fNTKitlIHnfunx0wjpWQUQ8/jGADIhMCrz6hInBjqPNdtGpYm8d1dNFyF8taEkOgrQ==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.0.17.tgz",
+      "integrity": "sha512-2EisRLHk6X/PdicybwlajLGKF5aJf4xnX2uuG5lexuYKt05xV/J/OiBADmi8q9obhxf1nesrMQbqAt+6CsHo/w==",
       "dev": true
     },
     "node_modules/@cspell/dict-dart": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-dart/-/dict-dart-2.2.4.tgz",
-      "integrity": "sha512-of/cVuUIZZK/+iqefGln8G3bVpfyN6ZtH+LyLkHMoR5tEj+2vtilGNk9ngwyR8L4lEqbKuzSkOxgfVjsXf5PsQ==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dart/-/dict-dart-2.2.5.tgz",
+      "integrity": "sha512-j/J99MH4NV2Klok0XMqnHxGl2lkewBcYjGYWdBKvVSbLXyA4oOaL+vCZR8Nmwf+lHInJFN8nkMU2k7TnC0MgUw==",
       "dev": true
     },
     "node_modules/@cspell/dict-data-science": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-2.0.5.tgz",
-      "integrity": "sha512-nNSILXmhSJox9/QoXICPQgm8q5PbiSQP4afpbkBqPi/u/b3K9MbNH5HvOOa6230gxcGdbZ9Argl2hY/U8siBlg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-2.0.6.tgz",
+      "integrity": "sha512-gOYKZOg358yhnnQfr1/f232REmjeIymXUHJdrLEMPirluv2rzMWvEBBazqRVQ++jMUNg9IduVI0v096ZWMDekA==",
       "dev": true
     },
     "node_modules/@cspell/dict-django": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-django/-/dict-django-4.1.3.tgz",
-      "integrity": "sha512-yBspeL3roJlO0a1vKKNaWABURuHdHZ9b1L8d3AukX0AsBy9snSggc8xCavPmSzNfeMDXbH+1lgQiYBd3IW03fg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-django/-/dict-django-4.1.4.tgz",
+      "integrity": "sha512-fX38eUoPvytZ/2GA+g4bbdUtCMGNFSLbdJJPKX2vbewIQGfgSFJKY56vvcHJKAvw7FopjvgyS/98Ta9WN1gckg==",
       "dev": true
     },
     "node_modules/@cspell/dict-docker": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.11.tgz",
-      "integrity": "sha512-s0Yhb16/R+UT1y727ekbR/itWQF3Qz275DR1ahOa66wYtPjHUXmhM3B/LT3aPaX+hD6AWmK23v57SuyfYHUjsw==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.12.tgz",
+      "integrity": "sha512-6d25ZPBnYZaT9D9An/x6g/4mk542R8bR3ipnby3QFCxnfdd6xaWiTcwDPsCgwN2aQZIQ1jX/fil9KmBEqIK/qA==",
       "dev": true
     },
     "node_modules/@cspell/dict-dotnet": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.8.tgz",
-      "integrity": "sha512-MD8CmMgMEdJAIPl2Py3iqrx3B708MbCIXAuOeZ0Mzzb8YmLmiisY7QEYSZPg08D7xuwARycP0Ki+bb0GAkFSqg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.9.tgz",
+      "integrity": "sha512-JGD6RJW5sHtO5lfiJl11a5DpPN6eKSz5M1YBa1I76j4dDOIqgZB6rQexlDlK1DH9B06X4GdDQwdBfnpAB0r2uQ==",
       "dev": true
     },
     "node_modules/@cspell/dict-elixir": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-elixir/-/dict-elixir-4.0.6.tgz",
-      "integrity": "sha512-TfqSTxMHZ2jhiqnXlVKM0bUADtCvwKQv2XZL/DI0rx3doG8mEMS8SGPOmiyyGkHpR/pGOq18AFH3BEm4lViHIw==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-elixir/-/dict-elixir-4.0.7.tgz",
+      "integrity": "sha512-MAUqlMw73mgtSdxvbAvyRlvc3bYnrDqXQrx5K9SwW8F7fRYf9V4vWYFULh+UWwwkqkhX9w03ZqFYRTdkFku6uA==",
       "dev": true
     },
     "node_modules/@cspell/dict-en_us": {
-      "version": "4.3.27",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.27.tgz",
-      "integrity": "sha512-7JYHahRWpi0VykWFTSM03KL/0fs6YtYfpOaTAg4N/d0wB2GfwVG/FJ/SBCjD4LBc6Rx9dzdo95Hs4BB8GPQbOA==",
+      "version": "4.3.28",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.28.tgz",
+      "integrity": "sha512-BN1PME7cOl7DXRQJ92pEd1f0Xk5sqjcDfThDGkKcsgwbSOY7KnTc/czBW6Pr3WXIchIm6cT12KEfjNqx7U7Rrw==",
       "dev": true
     },
     "node_modules/@cspell/dict-en-common-misspellings": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.0.7.tgz",
-      "integrity": "sha512-qNFo3G4wyabcwnM+hDrMYKN9vNVg/k9QkhqSlSst6pULjdvPyPs1mqz1689xO/v9t8e6sR4IKc3CgUXDMTYOpA==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.0.8.tgz",
+      "integrity": "sha512-l1u/pDjwrPyWwBd1hCkZhdsK8yLbLFPD2xWz+1tFFI7WaV9ckDZoF3woRc/0wFGRy53yrfSAVuwhoYOQnHe/fA==",
       "dev": true
     },
     "node_modules/@cspell/dict-en-gb": {
@@ -580,27 +589,27 @@
       "dev": true
     },
     "node_modules/@cspell/dict-filetypes": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.8.tgz",
-      "integrity": "sha512-D3N8sm/iptzfVwsib/jvpX+K/++rM8SRpLDFUaM4jxm8EyGmSIYRbKZvdIv5BkAWmMlTWoRqlLn7Yb1b11jKJg==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.10.tgz",
+      "integrity": "sha512-JEN3627joBVtpa1yfkdN9vz1Z129PoKGHBKjXCEziJvf2Zt1LeULWYYYg/O6pzRR4yzRa5YbXDTuyrN7vX7DFg==",
       "dev": true
     },
     "node_modules/@cspell/dict-flutter": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-flutter/-/dict-flutter-1.0.3.tgz",
-      "integrity": "sha512-52C9aUEU22ptpgYh6gQyIdA4MP6NPwzbEqndfgPh3Sra191/kgs7CVqXiO1qbtZa9gnYHUoVApkoxRE7mrXHfg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-flutter/-/dict-flutter-1.0.4.tgz",
+      "integrity": "sha512-XlWLCUsI9m2rKJ5TqYcDucajzQOqa7Hy8dhHaRQEyWic6oYvikpA1KtXsi8JD6JaiqfhejZZ6vNsQm1//6iSAg==",
       "dev": true
     },
     "node_modules/@cspell/dict-fonts": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-fonts/-/dict-fonts-4.0.3.tgz",
-      "integrity": "sha512-sPd17kV5qgYXLteuHFPn5mbp/oCHKgitNfsZLFC3W2fWEgZlhg4hK+UGig3KzrYhhvQ8wBnmZrAQm0TFKCKzsA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fonts/-/dict-fonts-4.0.4.tgz",
+      "integrity": "sha512-cHFho4hjojBcHl6qxidl9CvUb492IuSk7xIf2G2wJzcHwGaCFa2o3gRcxmIg1j62guetAeDDFELizDaJlVRIOg==",
       "dev": true
     },
     "node_modules/@cspell/dict-fsharp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-fsharp/-/dict-fsharp-1.0.4.tgz",
-      "integrity": "sha512-G5wk0o1qyHUNi9nVgdE1h5wl5ylq7pcBjX8vhjHcO4XBq20D5eMoXjwqMo/+szKAqzJ+WV3BgAL50akLKrT9Rw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fsharp/-/dict-fsharp-1.0.5.tgz",
+      "integrity": "sha512-6SsdHOtUsTDZ50wjK4FcvIjPiwBSDU9M/+zmUWpFfT5k5d5Ei80n4HGisFtuFdtmoLgz2F/xNnVvhsA2MWJv+w==",
       "dev": true
     },
     "node_modules/@cspell/dict-fullstack": {
@@ -610,39 +619,39 @@
       "dev": true
     },
     "node_modules/@cspell/dict-gaming-terms": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-gaming-terms/-/dict-gaming-terms-1.0.8.tgz",
-      "integrity": "sha512-7OL0zTl93WFWhhtpXFrtm9uZXItC3ncAs8d0iQDMMFVNU1rBr6raBNxJskxE5wx2Ant12fgI66ZGVagXfN+yfA==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-gaming-terms/-/dict-gaming-terms-1.0.10.tgz",
+      "integrity": "sha512-LJBUSg2ErWi5+QQysFKFwRvq09zAswteIKdAM/g06NpSiPT+SoIeRNKnnASmvuQQSFS427EwgKKtJ3723n2SFQ==",
       "dev": true
     },
     "node_modules/@cspell/dict-git": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-git/-/dict-git-3.0.3.tgz",
-      "integrity": "sha512-LSxB+psZ0qoj83GkyjeEH/ZViyVsGEF/A6BAo8Nqc0w0HjD2qX/QR4sfA6JHUgQ3Yi/ccxdK7xNIo67L2ScW5A==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-git/-/dict-git-3.0.4.tgz",
+      "integrity": "sha512-C44M+m56rYn6QCsLbiKiedyPTMZxlDdEYAsPwwlL5bhMDDzXZ3Ic8OCQIhMbiunhCOJJT+er4URmOmM+sllnjg==",
       "dev": true
     },
     "node_modules/@cspell/dict-golang": {
-      "version": "6.0.16",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.16.tgz",
-      "integrity": "sha512-hZOBlgcguv2Hdc93n2zjdAQm1j3grsN9T9WhPnQ1wh2vUDoCLEujg+6gWhjcLb8ECOcwZTWgNyQLWeOxEsAj/w==",
+      "version": "6.0.18",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.18.tgz",
+      "integrity": "sha512-Mt+7NwfodDwUk7423DdaQa0YaA+4UoV3XSxQwZioqjpFBCuxfvvv4l80MxCTAAbK6duGj0uHbGTwpv8fyKYPKg==",
       "dev": true
     },
     "node_modules/@cspell/dict-google": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-google/-/dict-google-1.0.4.tgz",
-      "integrity": "sha512-JThUT9eiguCja1mHHLwYESgxkhk17Gv7P3b1S7ZJzXw86QyVHPrbpVoMpozHk0C9o+Ym764B7gZGKmw9uMGduQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-google/-/dict-google-1.0.5.tgz",
+      "integrity": "sha512-KNrzfUsoFat94slWzo36g601sIGz6KtE4kBMM0gpqwFLK/MXRyaW65IL4SwysY0PEhuRzg9spLLMnUXuVcY2hQ==",
       "dev": true
     },
     "node_modules/@cspell/dict-haskell": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-haskell/-/dict-haskell-4.0.4.tgz",
-      "integrity": "sha512-EwQsedEEnND/vY6tqRfg9y7tsnZdxNqOxLXSXTsFA6JRhUlr8Qs88iUUAfsUzWc4nNmmzQH2UbtT25ooG9x4nA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-haskell/-/dict-haskell-4.0.5.tgz",
+      "integrity": "sha512-s4BG/4tlj2pPM9Ha7IZYMhUujXDnI0Eq1+38UTTCpatYLbQqDwRFf2KNPLRqkroU+a44yTUAe0rkkKbwy4yRtQ==",
       "dev": true
     },
     "node_modules/@cspell/dict-html": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.10.tgz",
-      "integrity": "sha512-I9uRAcdtHbh0wEtYZlgF0TTcgH0xaw1B54G2CW+tx4vHUwlde/+JBOfIzird4+WcMv4smZOfw+qHf7puFUbI5g==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.11.tgz",
+      "integrity": "sha512-QR3b/PB972SRQ2xICR1Nw/M44IJ6rjypwzA4jn+GH8ydjAX9acFNfc+hLZVyNe0FqsE90Gw3evLCOIF0vy1vQw==",
       "dev": true
     },
     "node_modules/@cspell/dict-html-symbol-entities": {
@@ -652,21 +661,21 @@
       "dev": true
     },
     "node_modules/@cspell/dict-java": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-java/-/dict-java-5.0.10.tgz",
-      "integrity": "sha512-pVNcOnmoGiNL8GSVq4WbX/Vs2FGS0Nej+1aEeGuUY9CU14X8yAVCG+oih5ZoLt1jaR8YfR8byUF8wdp4qG4XIw==",
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-java/-/dict-java-5.0.11.tgz",
+      "integrity": "sha512-T4t/1JqeH33Raa/QK/eQe26FE17eUCtWu+JsYcTLkQTci2dk1DfcIKo8YVHvZXBnuM43ATns9Xs0s+AlqDeH7w==",
       "dev": true
     },
     "node_modules/@cspell/dict-julia": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-julia/-/dict-julia-1.0.4.tgz",
-      "integrity": "sha512-bFVgNX35MD3kZRbXbJVzdnN7OuEqmQXGpdOi9jzB40TSgBTlJWA4nxeAKV4CPCZxNRUGnLH0p05T/AD7Aom9/w==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-julia/-/dict-julia-1.0.5.tgz",
+      "integrity": "sha512-rMC9OC8POmGw9pN96ByZJaY0YGtzSh64AtuJu4uFcuooF0MGmtXwiAhazRC5kPK5XMS+pKMQql/ItTyKbYh1yg==",
       "dev": true
     },
     "node_modules/@cspell/dict-k8s": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-k8s/-/dict-k8s-1.0.9.tgz",
-      "integrity": "sha512-Q7GELSQIzo+BERl2ya/nBEnZeQC+zJP19SN1pI6gqDYraM51uYJacbbcWLYYO2Y+5joDjNt/sd/lJtLaQwoSlA==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-k8s/-/dict-k8s-1.0.10.tgz",
+      "integrity": "sha512-313haTrX9prep1yWO7N6Xw4D6tvUJ0Xsx+YhCP+5YrrcIKoEw5Rtlg8R4PPzLqe6zibw6aJ+Eqq+y76Vx5BZkw==",
       "dev": true
     },
     "node_modules/@cspell/dict-latex": {
@@ -676,84 +685,84 @@
       "dev": true
     },
     "node_modules/@cspell/dict-lorem-ipsum": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-lorem-ipsum/-/dict-lorem-ipsum-4.0.3.tgz",
-      "integrity": "sha512-WFpDi/PDYHXft6p0eCXuYnn7mzMEQLVeqpO+wHSUd+kz5ADusZ4cpslAA4wUZJstF1/1kMCQCZM6HLZic9bT8A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-lorem-ipsum/-/dict-lorem-ipsum-4.0.4.tgz",
+      "integrity": "sha512-+4f7vtY4dp2b9N5fn0za/UR0kwFq2zDtA62JCbWHbpjvO9wukkbl4rZg4YudHbBgkl73HRnXFgCiwNhdIA1JPw==",
       "dev": true
     },
     "node_modules/@cspell/dict-lua": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-lua/-/dict-lua-4.0.6.tgz",
-      "integrity": "sha512-Jwvh1jmAd9b+SP9e1GkS2ACbqKKRo9E1f9GdjF/ijmooZuHU0hPyqvnhZzUAxO1egbnNjxS/J2T6iUtjAUK2KQ==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-lua/-/dict-lua-4.0.7.tgz",
+      "integrity": "sha512-Wbr7YSQw+cLHhTYTKV6cAljgMgcY+EUAxVIZW3ljKswEe4OLxnVJ7lPqZF5JKjlXdgCjbPSimsHqyAbC5pQN/Q==",
       "dev": true
     },
     "node_modules/@cspell/dict-makefile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-makefile/-/dict-makefile-1.0.3.tgz",
-      "integrity": "sha512-R3U0DSpvTs6qdqfyBATnePj9Q/pypkje0Nj26mQJ8TOBQutCRAJbr2ZFAeDjgRx5EAJU/+8txiyVF97fbVRViw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-makefile/-/dict-makefile-1.0.4.tgz",
+      "integrity": "sha512-E4hG/c0ekPqUBvlkrVvzSoAA+SsDA9bLi4xSV3AXHTVru7Y2bVVGMPtpfF+fI3zTkww/jwinprcU1LSohI3ylw==",
       "dev": true
     },
     "node_modules/@cspell/dict-markdown": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-markdown/-/dict-markdown-2.0.7.tgz",
-      "integrity": "sha512-F9SGsSOokFn976DV4u/1eL4FtKQDSgJHSZ3+haPRU5ki6OEqojxKa8hhj4AUrtNFpmBaJx/WJ4YaEzWqG7hgqg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-markdown/-/dict-markdown-2.0.8.tgz",
+      "integrity": "sha512-GCzfae+PLw9MjdgOO0OB67zguNfhiLnaZX1glCNJ6G1ZWqfeC9eBOxrAR3BkFXoBY0cvDSjIP037QXFEfCgeTg==",
       "dev": true,
       "peerDependencies": {
-        "@cspell/dict-css": "^4.0.16",
-        "@cspell/dict-html": "^4.0.10",
+        "@cspell/dict-css": "^4.0.17",
+        "@cspell/dict-html": "^4.0.11",
         "@cspell/dict-html-symbol-entities": "^4.0.3",
-        "@cspell/dict-typescript": "^3.1.11"
+        "@cspell/dict-typescript": "^3.1.12"
       }
     },
     "node_modules/@cspell/dict-monkeyc": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-monkeyc/-/dict-monkeyc-1.0.9.tgz",
-      "integrity": "sha512-Jvf6g5xlB4+za3ThvenYKREXTEgzx5gMUSzrAxIiPleVG4hmRb/GBSoSjtkGaibN3XxGx5x809gSTYCA/IHCpA==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-monkeyc/-/dict-monkeyc-1.0.10.tgz",
+      "integrity": "sha512-7RTGyKsTIIVqzbvOtAu6Z/lwwxjGRtY5RkKPlXKHEoEAgIXwfDxb5EkVwzGQwQr8hF/D3HrdYbRT8MFBfsueZw==",
       "dev": true
     },
     "node_modules/@cspell/dict-node": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-5.0.5.tgz",
-      "integrity": "sha512-7NbCS2E8ZZRZwlLrh2sA0vAk9n1kcTUiRp/Nia8YvKaItGXLfxYqD2rMQ3HpB1kEutal6hQLVic3N2Yi1X7AaA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-5.0.6.tgz",
+      "integrity": "sha512-CEbhPCpxGvRNByGolSBTrXXW2rJA4bGqZuTx1KKO85mwR6aadeOmUE7xf/8jiCkXSy+qvr9aJeh+jlfXcsrziQ==",
       "dev": true
     },
     "node_modules/@cspell/dict-npm": {
-      "version": "5.1.13",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.13.tgz",
-      "integrity": "sha512-7S1Pwq16M4sqvv/op7iHErc6Diz+DXsBYRMS0dDj6HUS44VXMvgejXa3RMd5jwBmcHzkInFm3DW1eb2exBs0cg==",
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.21.tgz",
+      "integrity": "sha512-AHqgbnBPwdMUF6jV/vyf5lz1+9MpmQn8h2E/Px0jHYFri4VTZ5TNBa40NaTNC/L/U/ggbVQTSoBnqZ6rLFwGCg==",
       "dev": true
     },
     "node_modules/@cspell/dict-php": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.0.13.tgz",
-      "integrity": "sha512-P6sREMZkhElzz/HhXAjahnICYIqB/HSGp1EhZh+Y6IhvC15AzgtDP8B8VYCIsQof6rPF1SQrFwunxOv8H1e2eg==",
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.0.14.tgz",
+      "integrity": "sha512-7zur8pyncYZglxNmqsRycOZ6inpDoVd4yFfz1pQRe5xaRWMiK3Km4n0/X/1YMWhh3e3Sl/fQg5Axb2hlN68t1g==",
       "dev": true
     },
     "node_modules/@cspell/dict-powershell": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-5.0.13.tgz",
-      "integrity": "sha512-0qdj0XZIPmb77nRTynKidRJKTU0Fl+10jyLbAhFTuBWKMypVY06EaYFnwhsgsws/7nNX8MTEQuewbl9bWFAbsg==",
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-5.0.14.tgz",
+      "integrity": "sha512-ktjjvtkIUIYmj/SoGBYbr3/+CsRGNXGpvVANrY0wlm/IoGlGywhoTUDYN0IsGwI2b8Vktx3DZmQkfb3Wo38jBA==",
       "dev": true
     },
     "node_modules/@cspell/dict-public-licenses": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.11.tgz",
-      "integrity": "sha512-rR5KjRUSnVKdfs5G+gJ4oIvQvm8+NJ6cHWY2N+GE69/FSGWDOPHxulCzeGnQU/c6WWZMSimG9o49i9r//lUQyA==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.12.tgz",
+      "integrity": "sha512-obreJMVbz8ZrXyc60PcS/B2FwXaO3AWPO2x50zrI/n4UDuBr/UdPb6M1q++6c08n+151I35GEx52xRFiToSg4g==",
       "dev": true
     },
     "node_modules/@cspell/dict-python": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.12.tgz",
-      "integrity": "sha512-U25eOFu+RE0aEcF2AsxZmq3Lic7y9zspJ9SzjrC0mfJz+yr3YmSCw4E0blMD3mZoNcf7H/vMshuKIY5AY36U+Q==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.14.tgz",
+      "integrity": "sha512-NZ/rsTH5gqTlEwbSg0vn5b1TsyzrUvA6ykwCVCwsVDdlQAS82cyDsF9JqHp8S4d6PFykmkfSxtAXYyOUr0KCbg==",
       "dev": true,
       "dependencies": {
-        "@cspell/dict-data-science": "^2.0.5"
+        "@cspell/dict-data-science": "^2.0.6"
       }
     },
     "node_modules/@cspell/dict-r": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-r/-/dict-r-2.0.4.tgz",
-      "integrity": "sha512-cBpRsE/U0d9BRhiNRMLMH1PpWgw+N+1A2jumgt1if9nBGmQw4MUpg2u9I0xlFVhstTIdzXiLXMxP45cABuiUeQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-r/-/dict-r-2.0.5.tgz",
+      "integrity": "sha512-CpZvA/6Ps/vCaR5c+2tL1dGU7ZlIFMp+lUamamHGG1ZIc0+j+16Tb1+9oksEf7k8LCI/F5Io4uIJ+0NezaY8Rg==",
       "dev": true
     },
     "node_modules/@cspell/dict-ruby": {
@@ -763,65 +772,66 @@
       "dev": true
     },
     "node_modules/@cspell/dict-rust": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-4.0.10.tgz",
-      "integrity": "sha512-6o5C8566VGTTctgcwfF3Iy7314W0oMlFFSQOadQ0OEdJ9Z9ERX/PDimrzP3LGuOrvhtEFoK8pj+BLnunNwRNrw==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-4.0.11.tgz",
+      "integrity": "sha512-OGWDEEzm8HlkSmtD8fV3pEcO2XBpzG2XYjgMCJCRwb2gRKvR+XIm6Dlhs04N/K2kU+iH8bvrqNpM8fS/BFl0uw==",
       "dev": true
     },
     "node_modules/@cspell/dict-scala": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-scala/-/dict-scala-5.0.6.tgz",
-      "integrity": "sha512-tl0YWAfjUVb4LyyE4JIMVE8DlLzb1ecHRmIWc4eT6nkyDqQgHKzdHsnusxFEFMVLIQomgSg0Zz6hJ5S1E4W4ww==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-scala/-/dict-scala-5.0.7.tgz",
+      "integrity": "sha512-yatpSDW/GwulzO3t7hB5peoWwzo+Y3qTc0pO24Jf6f88jsEeKmDeKkfgPbYuCgbE4jisGR4vs4+jfQZDIYmXPA==",
       "dev": true
     },
     "node_modules/@cspell/dict-software-terms": {
-      "version": "4.1.17",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-4.1.17.tgz",
-      "integrity": "sha512-QORIk1R5DV8oOQ+oAlUWE7UomaJwUucqu2srrc2+PmkoI6R1fJwwg2uHCPBWlIb4PGDNEdXLv9BAD13H+0wytQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-4.2.2.tgz",
+      "integrity": "sha512-cgteXRzx2W/Ug7QSdFJrVxLES7krrZEjZ9J6sXRWOsVYFpgu2Gup8NKmjKOZ8NTnCjHQFrMnbmKdv56q9Kwixw==",
       "dev": true
     },
     "node_modules/@cspell/dict-sql": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-sql/-/dict-sql-2.1.8.tgz",
-      "integrity": "sha512-dJRE4JV1qmXTbbGm6WIcg1knmR6K5RXnQxF4XHs5HA3LAjc/zf77F95i5LC+guOGppVF6Hdl66S2UyxT+SAF3A==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-sql/-/dict-sql-2.1.9.tgz",
+      "integrity": "sha512-dyVtWGUs79SihmxzoXXOpA2mRipQhzZOy5mrRTZvMp3HE7Y5vM1ag/Di8+QCtjYD6l7MjVjp0CxkKp1U7PBpbw==",
       "dev": true
     },
     "node_modules/@cspell/dict-svelte": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-svelte/-/dict-svelte-1.0.5.tgz",
-      "integrity": "sha512-sseHlcXOqWE4Ner9sg8KsjxwSJ2yssoJNqFHR9liWVbDV+m7kBiUtn2EB690TihzVsEmDr/0Yxrbb5Bniz70mA==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-svelte/-/dict-svelte-1.0.6.tgz",
+      "integrity": "sha512-8LAJHSBdwHCoKCSy72PXXzz7ulGROD0rP1CQ0StOqXOOlTUeSFaJJlxNYjlONgd2c62XBQiN2wgLhtPN+1Zv7Q==",
       "dev": true
     },
     "node_modules/@cspell/dict-swift": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-swift/-/dict-swift-2.0.4.tgz",
-      "integrity": "sha512-CsFF0IFAbRtYNg0yZcdaYbADF5F3DsM8C4wHnZefQy8YcHP/qjAF/GdGfBFBLx+XSthYuBlo2b2XQVdz3cJZBw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-swift/-/dict-swift-2.0.5.tgz",
+      "integrity": "sha512-3lGzDCwUmnrfckv3Q4eVSW3sK3cHqqHlPprFJZD4nAqt23ot7fic5ALR7J4joHpvDz36nHX34TgcbZNNZOC/JA==",
       "dev": true
     },
     "node_modules/@cspell/dict-terraform": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-terraform/-/dict-terraform-1.0.6.tgz",
-      "integrity": "sha512-Sqm5vGbXuI9hCFcr4w6xWf4Y25J9SdleE/IqfM6RySPnk8lISEmVdax4k6+Kinv9qaxyvnIbUUN4WFLWcBPQAg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-terraform/-/dict-terraform-1.0.8.tgz",
+      "integrity": "sha512-YR2v2iDtuzEIwOWAlV9V8pdnrIQud6wHQOhuk3oqR3PS0rkAd6dkWrS0Ce2gbZY7AHHxQ2jvJ66pOjAdIDXbtA==",
       "dev": true
     },
     "node_modules/@cspell/dict-typescript": {
-      "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.1.11.tgz",
-      "integrity": "sha512-FwvK5sKbwrVpdw0e9+1lVTl8FPoHYvfHRuQRQz2Ql5XkC0gwPPkpoyD1zYImjIyZRoYXk3yp9j8ss4iz7A7zoQ==",
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.1.12.tgz",
+      "integrity": "sha512-gQxryTuRrRW3whM7gASetOTcPVsDGxfVn/MoSX507rcsFdZTnX18+M6D4iE0sUtranF1MWscGPIm6J2gfL3Zxw==",
       "dev": true
     },
     "node_modules/@cspell/dict-vue": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-vue/-/dict-vue-3.0.3.tgz",
-      "integrity": "sha512-akmYbrgAGumqk1xXALtDJcEcOMYBYMnkjpmGzH13Ozhq1mkPF4VgllFQlm1xYde+BUKNnzMgPEzxrL2qZllgYA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-vue/-/dict-vue-3.0.4.tgz",
+      "integrity": "sha512-0dPtI0lwHcAgSiQFx8CzvqjdoXROcH+1LyqgROCpBgppommWpVhbQ0eubnKotFEXgpUCONVkeZJ6Ql8NbTEu+w==",
       "dev": true
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.16.0.tgz",
-      "integrity": "sha512-FH+B5y71qfunagXiLSJhXP9h/Vwb1Z8Cc/hLmliGekw/Y8BuYknL86tMg9grXBYNmM0kifIv6ZesQl8Km/p/rA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.17.1.tgz",
+      "integrity": "sha512-XQtr2olYOtqbg49E+8SISd6I5DzfxmsKINDn0ZgaTFeLalnNdF3ewDU4gOEbApIzGffRa1mW9t19MsiVrznSDw==",
       "dev": true,
       "dependencies": {
+        "@cspell/url": "8.17.1",
         "import-meta-resolve": "^4.1.0"
       },
       "engines": {
@@ -829,27 +839,27 @@
       }
     },
     "node_modules/@cspell/filetypes": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-8.16.0.tgz",
-      "integrity": "sha512-u2Ub0uSwXFPJFvXhAO/0FZBj3sMr4CeYCiQwTUsdFRkRMFpbTc7Vf+a+aC2vIj6WcaWrYXrJy3NZF/yjqF6SGw==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-8.17.1.tgz",
+      "integrity": "sha512-AxYw6j7EPYtDFAFjwybjFpMc9waXQzurfBXmEVfQ5RQRlbylujLZWwR6GnMqofeNg4oGDUpEjcAZFrgdkvMQlA==",
       "dev": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/strong-weak-map": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.16.0.tgz",
-      "integrity": "sha512-R6N12wEIQpBk2uyni/FU1SFSIjP0uql7ynXVcF1ob8/JJeRoikssydi9Xq5J6ghMw+X50u35mFvg9BgWKz0d+g==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.17.1.tgz",
+      "integrity": "sha512-8cY3vLAKdt5gQEMM3Gr57BuQ8sun2NjYNh9qTdrctC1S9gNC7XzFghTYAfHSWR4VrOUcMFLO/izMdsc1KFvFOA==",
       "dev": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/url": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.16.0.tgz",
-      "integrity": "sha512-zW+6hAieD/FjysfjY4mVv7iHWWasBP3ldj6L+xy2p4Kuax1nug7uuJqMHlAVude/OywNwENG0rYaP/P9Pg4O+w==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.17.1.tgz",
+      "integrity": "sha512-LMvReIndW1ckvemElfDgTt282fb2C3C/ZXfsm0pJsTV5ZmtdelCHwzmgSBmY5fDr7D66XDp8EurotSE0K6BTvw==",
       "dev": true,
       "engines": {
         "node": ">=18.0"
@@ -1399,9 +1409,9 @@
       }
     },
     "node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "optional": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -1513,9 +1523,9 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-MBIOHVZqVqgfro1euRDWX7OO0fBVUUMrN6Pwm8LQsz8cWhEpihlvR70ENj3f40j58TNxZaWv2ndSkInykNBBJw=="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A=="
     },
     "node_modules/@types/memoizee": {
       "version": "0.4.11",
@@ -1816,12 +1826,12 @@
       }
     },
     "node_modules/agent-base/node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "optional": true,
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -1833,9 +1843,9 @@
       }
     },
     "node_modules/agent-base/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "optional": true
     },
     "node_modules/ajv": {
@@ -1869,6 +1879,15 @@
       "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
       "engines": {
         "node": ">=0.4.2"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -2141,9 +2160,9 @@
       }
     },
     "node_modules/balena-hup-action-utils": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/balena-hup-action-utils/-/balena-hup-action-utils-6.1.0.tgz",
-      "integrity": "sha512-hy9hlaL98j04m4plX7ks8MxChuGvcCMMK987q4abjGAqieG1AOI2zrChBwUpKifsIy80c/BY1odIw8ojDdCYgA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/balena-hup-action-utils/-/balena-hup-action-utils-6.2.2.tgz",
+      "integrity": "sha512-2Te4S5u8abq+YWAwHecwG3YdA0mtwgeguI7hI7hfOBLIofmjbYf4kRgOi8q85Qr8pjWLvDgDdTzYdM396y2eLA==",
       "dependencies": {
         "balena-semver": "^2.3.5",
         "tslib": "^2.6.2",
@@ -2154,9 +2173,9 @@
       }
     },
     "node_modules/balena-register-device": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/balena-register-device/-/balena-register-device-9.0.2.tgz",
-      "integrity": "sha512-+ViJroGVRMsdc9P7qw75y7QFDFClGlK1dQebm95bTQ183LL+rOE4BFhcp/I+34E8fkafuuRFNSVO28003Xi5MQ==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/balena-register-device/-/balena-register-device-9.0.4.tgz",
+      "integrity": "sha512-TykiABQ4k0UVBOvLNwr4xKQJvBVNumMvv8NF6kw+kxBlkuj0MgD+yI3HUncALiDvcb8aKg0SocCSn2lirZ56Cw==",
       "dependencies": {
         "@types/uuid": "^8.3.0",
         "tslib": "^2.2.0",
@@ -2168,20 +2187,20 @@
         "npm": ">=6.0.0"
       },
       "peerDependencies": {
-        "balena-request": "^13.3.1"
+        "balena-request": "^13.3.1 || ^14.0.0"
       }
     },
     "node_modules/balena-request": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/balena-request/-/balena-request-13.3.2.tgz",
-      "integrity": "sha512-rvpgAsDtzS2bKBvu4QPjHSRuDPHsd4pgY0eIDfu985XYYLv+wbkztHY0aSCMhRFzig+3OI0Yq5837dD8nzCfdw==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/balena-request/-/balena-request-14.0.1.tgz",
+      "integrity": "sha512-D6sQyeOZNoR736WVBD5F0AL/XsiGTioD9vaDpiqQJZvhShTDVzbNXkW7Sd+QCGrSP3gpdqorGN7hyEZsv5WZlA==",
       "dependencies": {
         "@balena/node-web-streams": "^0.2.3",
         "balena-errors": "^4.9.0",
         "fetch-ponyfill": "^7.1.0",
         "fetch-readablestream": "^0.2.0",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.0.0",
+        "form-data-encoder": "^4.0.2",
+        "formdata-node": "^6.0.3",
         "progress-stream": "^2.0.0",
         "qs": "^6.9.4",
         "tslib": "^2.0.0",
@@ -2195,9 +2214,9 @@
       }
     },
     "node_modules/balena-sdk": {
-      "version": "20.6.8",
-      "resolved": "https://registry.npmjs.org/balena-sdk/-/balena-sdk-20.6.8.tgz",
-      "integrity": "sha512-d2q6DJcybO0uj9VrEqnaUY6jd3FW+QmBe4J+FaAuh4zPZLwZLetb6p8WhL3XkQBlj2Ej/RRQgg5ZAL1hx9Qx+A==",
+      "version": "20.8.3",
+      "resolved": "https://registry.npmjs.org/balena-sdk/-/balena-sdk-20.8.3.tgz",
+      "integrity": "sha512-LSn2/a0TRhrXC3ZM2inIKZ64pZveRarlo4YFd78HTm9tAyrA/5YnnUG8hbEjpMGXvD5xhMmBbgzy5DReGiRJQQ==",
       "dependencies": {
         "@balena/es-version": "^1.0.0",
         "@types/json-schema": "^7.0.9",
@@ -2205,9 +2224,9 @@
         "abortcontroller-polyfill": "^1.7.1",
         "balena-auth": "^6.0.1",
         "balena-errors": "^4.9.0",
-        "balena-hup-action-utils": "~6.1.0",
-        "balena-register-device": "^9.0.2",
-        "balena-request": "^13.3.2",
+        "balena-hup-action-utils": "~6.2.0",
+        "balena-register-device": "^9.0.4",
+        "balena-request": "^14.0.0",
         "balena-semver": "^2.3.0",
         "balena-settings-client": "^5.0.0",
         "date-fns": "^3.0.5",
@@ -2217,7 +2236,7 @@
         "mime": "^3.0.0",
         "ndjson": "^2.0.0",
         "p-throttle": "^4.1.1",
-        "pinejs-client-core": "^6.15.0",
+        "pinejs-client-core": "^7.0.0",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -2239,9 +2258,9 @@
       }
     },
     "node_modules/balena-semver/node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2691,9 +2710,9 @@
       }
     },
     "node_modules/capnp-ts/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
@@ -3129,24 +3148,24 @@
       }
     },
     "node_modules/cspell": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.16.0.tgz",
-      "integrity": "sha512-U6Up/4nODE+Ca+zqwZXTgBioGuF2JQHLEUIuoRJkJzAZkIBYDqrMXM+zdSL9E39+xb9jAtr9kPAYJf1Eybgi9g==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.17.1.tgz",
+      "integrity": "sha512-D0lw8XTXrTycNzOn5DkfPJNUT00X53OgvFDm+0SzhBr1r+na8LEh3CnQ6zKYVU0fL0x8vU82vs4jmGjDho9mPg==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-json-reporter": "8.16.0",
-        "@cspell/cspell-pipe": "8.16.0",
-        "@cspell/cspell-types": "8.16.0",
-        "@cspell/dynamic-import": "8.16.0",
-        "@cspell/url": "8.16.0",
+        "@cspell/cspell-json-reporter": "8.17.1",
+        "@cspell/cspell-pipe": "8.17.1",
+        "@cspell/cspell-types": "8.17.1",
+        "@cspell/dynamic-import": "8.17.1",
+        "@cspell/url": "8.17.1",
         "chalk": "^5.3.0",
         "chalk-template": "^1.1.0",
         "commander": "^12.1.0",
-        "cspell-dictionary": "8.16.0",
-        "cspell-gitignore": "8.16.0",
-        "cspell-glob": "8.16.0",
-        "cspell-io": "8.16.0",
-        "cspell-lib": "8.16.0",
+        "cspell-dictionary": "8.17.1",
+        "cspell-gitignore": "8.17.1",
+        "cspell-glob": "8.17.1",
+        "cspell-io": "8.17.1",
+        "cspell-lib": "8.17.1",
         "fast-json-stable-stringify": "^2.1.0",
         "file-entry-cache": "^9.1.0",
         "get-stdin": "^9.0.0",
@@ -3165,28 +3184,28 @@
       }
     },
     "node_modules/cspell-config-lib": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.16.0.tgz",
-      "integrity": "sha512-PGT6ohLtIYXYLIm+R5hTcTrF0dzj8e7WAUJSJe5WlV/7lrwVdwgWaliLcXtSSPmfxgczr6sndX9TMJ2IEmPrmg==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.17.1.tgz",
+      "integrity": "sha512-x1S7QWprgUcwuwiJB1Ng0ZTBC4G50qP9qQyg/aroMkcdMsHfk26E8jUGRPNt4ftHFzS4YMhwtXuJQ9IgRUuNPA==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-types": "8.16.0",
+        "@cspell/cspell-types": "8.17.1",
         "comment-json": "^4.2.5",
-        "yaml": "^2.6.0"
+        "yaml": "^2.6.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-dictionary": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.16.0.tgz",
-      "integrity": "sha512-Y3sN6ttLBKbu0dOLcduY641n5QP1srUvZkW4bOTnG455DbIZfilrP1El/2Hl0RS6hC8LN9PM4bsIm/2xgdbApA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.17.1.tgz",
+      "integrity": "sha512-zSl9l3wii+x16yc2NVZl/+CMLeLBAiuEd5YoFkOYPcbTJnfPwdjMNcj71u7wBvNJ+qwbF+kGbutEt15yHW3NBw==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-pipe": "8.16.0",
-        "@cspell/cspell-types": "8.16.0",
-        "cspell-trie-lib": "8.16.0",
+        "@cspell/cspell-pipe": "8.17.1",
+        "@cspell/cspell-types": "8.17.1",
+        "cspell-trie-lib": "8.17.1",
         "fast-equals": "^5.0.1"
       },
       "engines": {
@@ -3194,14 +3213,14 @@
       }
     },
     "node_modules/cspell-gitignore": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.16.0.tgz",
-      "integrity": "sha512-ODKe0ooyzYSBJkwgIVZSRIvzoZfT4tEbFt4fFDT88wPyyfX7xp7MAQhXy5KD1ocXH0WvYbdv37qzn2UbckrahA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.17.1.tgz",
+      "integrity": "sha512-bk727Zf4FBCjm9Mwvyreyhgjwe+YhPQEW7PldkHiinKd+Irfez4s8GXLQb1EgV0UpvViqaqBqLmngjZdS30BTA==",
       "dev": true,
       "dependencies": {
-        "@cspell/url": "8.16.0",
-        "cspell-glob": "8.16.0",
-        "cspell-io": "8.16.0",
+        "@cspell/url": "8.17.1",
+        "cspell-glob": "8.17.1",
+        "cspell-io": "8.17.1",
         "find-up-simple": "^1.0.0"
       },
       "bin": {
@@ -3212,12 +3231,12 @@
       }
     },
     "node_modules/cspell-glob": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.16.0.tgz",
-      "integrity": "sha512-xJSXRHwfENCNFmjpVSEucXY8E3BrpSCA+TukmOYtLyaMKtn6EAwoCpEU7Oj2tZOjdivprPmQ74k4Dqb1RHjIVQ==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.17.1.tgz",
+      "integrity": "sha512-cUwM5auSt0RvLX7UkP2GEArJRWc85l51B1voArl+3ZIKeMZwcJpJgN3qvImtF8yRTZwYeYCs1sgsihb179q+mg==",
       "dev": true,
       "dependencies": {
-        "@cspell/url": "8.16.0",
+        "@cspell/url": "8.17.1",
         "micromatch": "^4.0.8"
       },
       "engines": {
@@ -3225,13 +3244,13 @@
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.16.0.tgz",
-      "integrity": "sha512-vvbJEkBqXocGH/H975RtkfMzVpNxNGMd0JCDd+NjbpeRyZceuChFw5Tie7kHteFY29SwZovub+Am3F4H1kmf9A==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.17.1.tgz",
+      "integrity": "sha512-H5tLcBuW7aUj9L0rR+FSbnWPEsWb8lWppHVidtqw9Ll1CUHWOZC9HTB2RdrhJZrsz/8DJbM2yNbok0Xt0VAfdw==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-pipe": "8.16.0",
-        "@cspell/cspell-types": "8.16.0"
+        "@cspell/cspell-pipe": "8.17.1",
+        "@cspell/cspell-types": "8.17.1"
       },
       "bin": {
         "cspell-grammar": "bin.mjs"
@@ -3241,40 +3260,40 @@
       }
     },
     "node_modules/cspell-io": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.16.0.tgz",
-      "integrity": "sha512-WIK5uhPMjGsTAzm2/fGRbIdr7zWsMVG1fn8wNJYUiYELuyvzvLelfI1VG6szaFCGYqd6Uvgb/fS0uNbwGqCLAQ==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.17.1.tgz",
+      "integrity": "sha512-liIOsblt7oVItifzRAbuxiYrwlgw1VOqKppMxVKtYoAn2VUuuEpjCj6jLWpoTqSszR/38o7ChsHY1LHakhJZmw==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-service-bus": "8.16.0",
-        "@cspell/url": "8.16.0"
+        "@cspell/cspell-service-bus": "8.17.1",
+        "@cspell/url": "8.17.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-lib": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.16.0.tgz",
-      "integrity": "sha512-fU8CfECyuhT12COIi4ViQu2bTkdqaa+05YSd2ZV8k8NA7lapPaMFnlooxdfcwwgZJfHeMhRVMzvQF1OhWmwGfA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.17.1.tgz",
+      "integrity": "sha512-66n83Q7bK5tnvkDH7869/pBY/65AKmZVfCOAlsbhJn3YMDbNHFCHR0d1oNMlqG+n65Aco89VGwYfXxImZY+/mA==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "8.16.0",
-        "@cspell/cspell-pipe": "8.16.0",
-        "@cspell/cspell-resolver": "8.16.0",
-        "@cspell/cspell-types": "8.16.0",
-        "@cspell/dynamic-import": "8.16.0",
-        "@cspell/filetypes": "8.16.0",
-        "@cspell/strong-weak-map": "8.16.0",
-        "@cspell/url": "8.16.0",
+        "@cspell/cspell-bundled-dicts": "8.17.1",
+        "@cspell/cspell-pipe": "8.17.1",
+        "@cspell/cspell-resolver": "8.17.1",
+        "@cspell/cspell-types": "8.17.1",
+        "@cspell/dynamic-import": "8.17.1",
+        "@cspell/filetypes": "8.17.1",
+        "@cspell/strong-weak-map": "8.17.1",
+        "@cspell/url": "8.17.1",
         "clear-module": "^4.1.2",
         "comment-json": "^4.2.5",
-        "cspell-config-lib": "8.16.0",
-        "cspell-dictionary": "8.16.0",
-        "cspell-glob": "8.16.0",
-        "cspell-grammar": "8.16.0",
-        "cspell-io": "8.16.0",
-        "cspell-trie-lib": "8.16.0",
+        "cspell-config-lib": "8.17.1",
+        "cspell-dictionary": "8.17.1",
+        "cspell-glob": "8.17.1",
+        "cspell-grammar": "8.17.1",
+        "cspell-io": "8.17.1",
+        "cspell-trie-lib": "8.17.1",
         "env-paths": "^3.0.0",
         "fast-equals": "^5.0.1",
         "gensequence": "^7.0.0",
@@ -3289,13 +3308,13 @@
       }
     },
     "node_modules/cspell-trie-lib": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.16.0.tgz",
-      "integrity": "sha512-Io1qqI0r4U9ewAWBLClFBBlxLeAoIi15PUGJi4Za1xrlgQJwRE8PMNIJNHKmPEIp78Iute3o/JyC2OfWlxl4Sw==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.17.1.tgz",
+      "integrity": "sha512-13WNa5s75VwOjlGzWprmfNbBFIfXyA7tYYrbV+LugKkznyNZJeJPojHouEudcLq3SYb2Q6tJ7qyWcuT5bR9qPA==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-pipe": "8.16.0",
-        "@cspell/cspell-types": "8.16.0",
+        "@cspell/cspell-pipe": "8.17.1",
+        "@cspell/cspell-types": "8.17.1",
         "gensequence": "^7.0.0"
       },
       "engines": {
@@ -4256,9 +4275,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -4279,7 +4298,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -4294,6 +4313,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express-http-to-https": {
@@ -4809,28 +4832,19 @@
       }
     },
     "node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
-    },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-4.0.2.tgz",
+      "integrity": "sha512-KQVhvhK8ZkWzxKxOr56CPulAhH3dobtuQ4+hNQ+HekH/Wp5gSOafqRAeTphQUJAIk0GBvHZgJ2ZGRWd5kphMuw==",
       "engines": {
-        "node": ">= 12.20"
+        "node": ">= 18"
       }
     },
-    "node_modules/formdata-node/node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+    "node_modules/formdata-node": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-6.0.3.tgz",
+      "integrity": "sha512-8e1++BCiTzUno9v5IZ2J6bv4RU+3UKDmqWUQD0MIMVCd9AdhWkO1gw57oo1mNEX1dMq2EGI+FbWz4B92pscSQg==",
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/forwarded": {
@@ -4944,27 +4958,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/gauge/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/gauge/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "optional": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/gensequence": {
@@ -5769,12 +5762,12 @@
       }
     },
     "node_modules/https-proxy-agent/node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "optional": true,
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -5786,9 +5779,9 @@
       }
     },
     "node_modules/https-proxy-agent/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "optional": true
     },
     "node_modules/iconv-lite": {
@@ -7127,9 +7120,9 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "3.20241106.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20241106.0.tgz",
-      "integrity": "sha512-PjOoJKjUUofCueQskfhXlGvvHxZj36UAJAp1DnquMK88MFF50zCULblh0KXMSNM+bXeQYA94Gj06a7kfmBGxPw==",
+      "version": "3.20241218.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20241218.0.tgz",
+      "integrity": "sha512-spYFDArH0wd+wJSTrzBrWrXJrbyJhRMJa35mat947y1jYhVV8I5V8vnD3LwjfpLr0SaEilojz1OIW7ekmnRe+w==",
       "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
@@ -7140,7 +7133,7 @@
         "glob-to-regexp": "^0.4.1",
         "stoppable": "^1.1.0",
         "undici": "^5.28.4",
-        "workerd": "1.20241106.1",
+        "workerd": "1.20241218.0",
         "ws": "^8.18.0",
         "youch": "^3.2.2",
         "zod": "^3.22.3"
@@ -7291,9 +7284,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "dev": true,
       "funding": [
         {
@@ -7370,24 +7363,6 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
       "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
       "optional": true
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "engines": {
-        "node": ">=10.5.0"
-      }
     },
     "node_modules/node-downloader-helper": {
       "version": "2.1.9",
@@ -7938,9 +7913,9 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
     },
     "node_modules/pathe": {
       "version": "1.1.2",
@@ -7981,11 +7956,11 @@
       }
     },
     "node_modules/pinejs-client-core": {
-      "version": "6.15.6",
-      "resolved": "https://registry.npmjs.org/pinejs-client-core/-/pinejs-client-core-6.15.6.tgz",
-      "integrity": "sha512-p3us4VveQ8AZcVOO4PTlslTubCUDL2BQY5+zU+My5+5nUNkLc7fBMLzpbU9wKgYtSsFX05V4dkSy4z3KNIT7ig==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pinejs-client-core/-/pinejs-client-core-7.2.0.tgz",
+      "integrity": "sha512-47ZWj2HbhKKLUbvnutohzh75972esGM+CO+a331/ldIgNhLZ5DYfIBrHlR4C9RBiEXC2Us9qD0twyi4qnZJ2xg==",
       "dependencies": {
-        "@balena/abstract-sql-to-typescript": "^3.2.3",
+        "@balena/abstract-sql-to-typescript": "^4.0.0",
         "@balena/es-version": "^1.0.3"
       },
       "engines": {
@@ -8557,15 +8532,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/resolve.exports": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
-      "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/reusify": {
@@ -9197,16 +9163,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
+    "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -9861,9 +9818,9 @@
     },
     "node_modules/unenv": {
       "name": "unenv-nightly",
-      "version": "2.0.0-20241111-080453-894aa31",
-      "resolved": "https://registry.npmjs.org/unenv-nightly/-/unenv-nightly-2.0.0-20241111-080453-894aa31.tgz",
-      "integrity": "sha512-0W39QQOQ9VE8kVVUpGwEG+pZcsCXk5wqNG6rDPE6Gr+fiA69LR0qERM61hW5KCOkC1/ArCFrfCGjwHyyv/bI0Q==",
+      "version": "2.0.0-20241204-140205-a5d5190",
+      "resolved": "https://registry.npmjs.org/unenv-nightly/-/unenv-nightly-2.0.0-20241204-140205-a5d5190.tgz",
+      "integrity": "sha512-jpmAytLeiiW01pl5bhVn9wYJ4vtiLdhGe10oXlJBuQEX8mxjxO8BlEXGHU4vr4yEikjFP1wsomTHt/CLU8kUwg==",
       "dev": true,
       "dependencies": {
         "defu": "^6.1.4",
@@ -9929,12 +9886,15 @@
       }
     },
     "node_modules/url": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.3.tgz",
-      "integrity": "sha512-6hxOLGfZASQK/cijlZnZJTq8OXAkt/3YGfQX45vvMYXpZoo8NdWZcY73K108Jf759lS1Bv/8wXnHDTSz17dSRw==",
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
       "dependencies": {
         "punycode": "^1.4.1",
-        "qs": "^6.11.2"
+        "qs": "^6.12.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/url-loader": {
@@ -10334,9 +10294,9 @@
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
     },
     "node_modules/workerd": {
-      "version": "1.20241106.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20241106.1.tgz",
-      "integrity": "sha512-1GdKl0kDw8rrirr/ThcK66Kbl4/jd4h8uHx5g7YHBrnenY5SX1UPuop2cnCzYUxlg55kPjzIqqYslz1muRFgFw==",
+      "version": "1.20241218.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20241218.0.tgz",
+      "integrity": "sha512-7Z3D4vOVChMz9mWDffE299oQxUWm/pbkeAWx1btVamPcAK/2IuoNBhwflWo3jyuKuxvYuFAdIucgYxc8ICqXiA==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -10346,21 +10306,20 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20241106.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20241106.1",
-        "@cloudflare/workerd-linux-64": "1.20241106.1",
-        "@cloudflare/workerd-linux-arm64": "1.20241106.1",
-        "@cloudflare/workerd-windows-64": "1.20241106.1"
+        "@cloudflare/workerd-darwin-64": "1.20241218.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20241218.0",
+        "@cloudflare/workerd-linux-64": "1.20241218.0",
+        "@cloudflare/workerd-linux-arm64": "1.20241218.0",
+        "@cloudflare/workerd-windows-64": "1.20241218.0"
       }
     },
     "node_modules/wrangler": {
-      "version": "3.88.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.88.0.tgz",
-      "integrity": "sha512-1yM5cgerjKkIBL9GOzIWhl8MsyEGNTsN4emJCiLLHJFz52TSNjJJlMbd1x0hX351mfy2MsGgUqKcx8iRL51PcQ==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.99.0.tgz",
+      "integrity": "sha512-k0x4rT3G/QCbxcoZY7CHRVlAIS8WMmKdga6lf4d2c3gXFqssh44vwlTDuARA9QANBxKJTcA7JPTJRfUDhd9QBA==",
       "dev": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.3.4",
-        "@cloudflare/workers-shared": "0.7.1",
         "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
         "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
         "blake3-wasm": "^2.1.5",
@@ -10368,15 +10327,14 @@
         "date-fns": "^4.1.0",
         "esbuild": "0.17.19",
         "itty-time": "^1.0.6",
-        "miniflare": "3.20241106.0",
+        "miniflare": "3.20241218.0",
         "nanoid": "^3.3.3",
         "path-to-regexp": "^6.3.0",
         "resolve": "^1.22.8",
-        "resolve.exports": "^2.0.2",
         "selfsigned": "^2.0.1",
         "source-map": "^0.6.1",
-        "unenv": "npm:unenv-nightly@2.0.0-20241111-080453-894aa31",
-        "workerd": "1.20241106.1",
+        "unenv": "npm:unenv-nightly@2.0.0-20241204-140205-a5d5190",
+        "workerd": "1.20241218.0",
         "xxhash-wasm": "^1.0.1"
       },
       "bin": {
@@ -10390,7 +10348,7 @@
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20241106.0"
+        "@cloudflare/workers-types": "^4.20241218.0"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -10516,9 +10474,9 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
-      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
       "dev": true,
       "bin": {
         "yaml": "bin.mjs"
@@ -10568,9 +10526,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
+      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
   "homepage": "https://github.com/balena-io/docs",
   "dependencies": {
     "@balena/doxx": "^1.0.3",
-    "balena-sdk": "^20.6.8",
+    "balena-sdk": "^20.8.3",
     "bootstrap": "^3.4.1",
     "bootstrap-select": "^1.13.18",
     "coffeescript": "^2.7.0",
-    "express": "^4.21.1",
+    "express": "^4.21.2",
     "express-http-to-https": "1.1.4",
     "headroom.js": "0.12.0",
     "highlight.js": "10.7.3",
@@ -44,7 +44,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "cspell": "^8.16.0",
+    "cspell": "^8.17.1",
     "css-loader": "5.2.7",
     "file-loader": "6.2.0",
     "line-by-line": "^0.1.6",
@@ -56,7 +56,7 @@
     "watch": "^1.0.2",
     "webpack": "5.96.1",
     "webpack-cli": "^5.1.4",
-    "wrangler": "^3.88.0"
+    "wrangler": "^3.99.0"
   },
   "versionist": {
     "publishedAt": "2024-12-27T19:10:14.859Z"


### PR DESCRIPTION
Contains an additional change to resolve failing CI checks about `env` not being in context of `args`
I used this way of passing the env variable to get it into context. 

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
