### PR TITLE
reference/wifi-dongles.md: Remove list of supported modems

### DIFF
--- a/pages/reference/hardware/wifi-dongles.md
+++ b/pages/reference/hardware/wifi-dongles.md
@@ -1,24 +1,13 @@
 ---
-title: Supported WiFi adapters
-excerpt: WiFi adapters known to work with {{ $names.company.lower }} devices
+title: WiFi adapters and Modems
+excerpt: Notes on WiFi adapter and modem compatibility with balenaOS
 ---
 
-# Supported Wifi Adapters
+# Wifi Adapters and Modems
 
-{{> "meta-balena/supported-wifi-adapters" }}
+Balena's software validation is only doing a [sanity check](https://github.com/balena-os/meta-balena/tree/1fb02321afaaea4e43e296ae556e628a1dfed530/tests/suites/os/tests/modem) on features that are commonly required by balenaOS. To run these tests, we use a sample modem with the driver provided by the manufacturer and the NetworkManager/ModemManager support. 
 
-Balena's software validation is only doing a sanity check on features that are commonly required by balenaOS. To run these tests, we use the driver provided by the manufacturer and the NetworkManager/ModemManager support. 
-
-Balena cannot guarantee that a modem or chipset is reliable and ready for production from our end. End users should run the necessary tests to validate their use case end-to-end and work with the vendor to resolve issues.
-
-## Supported modems 
-
-{{> "meta-balena/supported-modems" }}
-
-
-## WiFi USB Dongle
-
-{{> "meta-balena/supported-wifi-usb-dongle" }}
+Balena cannot guarantee that a specific modem or chipset is reliable and ready for production from our end. End users should run the necessary tests to validate their use case end-to-end and work with the vendor to resolve issues.
 
 
 ### Configuration

--- a/tools/fetch-external.sh
+++ b/tools/fetch-external.sh
@@ -35,11 +35,11 @@ curl --fail --show-error -o shared/masterclass/debugging/supervisor.md -L https:
 cd shared/meta-balena/ && {
   curl --fail --show-error -o meta-balena.md -L https://raw.githubusercontent.com/balena-os/meta-balena/master/README.md
   # Extract modem text
-  ../../tools/extract-markdown.sh "Modems" <meta-balena.md >supported-modems.md
+  # ../../tools/extract-markdown.sh "Modems" <meta-balena.md >supported-modems.md
   # Extract Wifi adapters
-  ../../tools/extract-markdown.sh "WiFi Adapters" <meta-balena.md >supported-wifi-adapters.md
+  # ../../tools/extract-markdown.sh "WiFi Adapters" <meta-balena.md >supported-wifi-adapters.md
   # Extract Recommended WiFi USB dongle
-  ../../tools/extract-markdown.sh "Recommended WiFi USB dongle" <meta-balena.md >supported-wifi-usb-dongle.md
+  # ../../tools/extract-markdown.sh "Recommended WiFi USB dongle" <meta-balena.md >supported-wifi-usb-dongle.md
   # Extract config.json
   ../../tools/extract-markdown.sh "config.json" <meta-balena.md >config-json.md
   rm meta-balena.md


### PR DESCRIPTION
The list of supported wifi dongles and modems is out of date and sets an uneralistic expectation for hardware compatibility - its better to remove this until we actually have a proper modem story

Change-type: patch

Supersedes https://github.com/balena-io/docs/pull/2193 if we go with this

---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
