### PR TITLE
Clarify NTP host firewalling and remove obsolete information

### DIFF
--- a/pages/reference/OS/network.md
+++ b/pages/reference/OS/network.md
@@ -484,13 +484,6 @@ Location: https://api.balena-cloud.com/
 Vary: Accept
 ```
 
-NTP / UDP packets (port 123) are exchanged with:
-
-* `0.resinio.pool.ntp.org`
-* `1.resinio.pool.ntp.org`
-* `2.resinio.pool.ntp.org`
-* `3.resinio.pool.ntp.org`
-
 [Google's Public DNS](https://developers.google.com/speed/public-dns) server at 8.8.8.8 is used by
 default and in addition to DNS servers obtained via DHCP from your local network or service provider (balenaOS may issue queries to multiple DNS servers simultaneously, for the quickest response to be used). If additional DNS servers are configured via DHCP or other means, it is OK for the local network to block requests to `8.8.8.8`.
 To avoid any requests being made to `8.8.8.8` by balenaOS, modify the

--- a/pages/reference/OS/time.md
+++ b/pages/reference/OS/time.md
@@ -62,15 +62,7 @@ Starting from {{ $names.os.lower }} 2.0.7, the devices connect to the following 
 
 To be clear, `ntp.org` uses a large pool of servers that change frequently. So UDP port `123` must be open outgoing to all hosts.
 
-Prior to {{ $names.os.lower }} 2.0.7 the NTP service connects to the following time servers by default and these need to be accessible to the device:
-
-* pool.ntp.org
-* time1.google.com
-* time2.google.com
-* time3.google.com
-* time4.google.com
-
-Starting from {{ $names.os.lower }} 2.1.0, you can configure your own NTP servers in the [`config.json` file][config-json] location in the [boot partition][boot-partition]. For example:
+You can configure your own NTP servers in the [`config.json` file][config-json] location in the [boot partition][boot-partition]. For example:
 
 ```json
 "ntpServers": "0.resinio.pool.ntp.org 1.resinio.pool.ntp.org"

--- a/pages/reference/OS/time.md
+++ b/pages/reference/OS/time.md
@@ -60,6 +60,8 @@ Starting from {{ $names.os.lower }} 2.0.7, the devices connect to the following 
 * 2.resinio.pool.ntp.org
 * 3.resinio.pool.ntp.org
 
+To be clear, `ntp.org` uses a large pool of servers that change frequently. So UDP port `123` must be open outgoing to all hosts.
+
 Prior to {{ $names.os.lower }} 2.0.7 the NTP service connects to the following time servers by default and these need to be accessible to the device:
 
 * pool.ntp.org


### PR DESCRIPTION
A couple of commits around NTP:

Clarify outbound port requirements when using the default ntp.org servers. We have seen some tickets recently with customers only opening port 123/UDP only for those servers.

Also removed some information related to NTP for balenaOS v2.1 and under.

I'd appreciate @alexgg approval on content, and @vipulgupta2048 on presentation.
