### PR TITLE
Update our analytics setup

### DIFF
--- a/templates/_track.html
+++ b/templates/_track.html
@@ -16,7 +16,7 @@ function addAnalyticsClient() {
   el.crossOrigin = 'anonymous';
   el.async = true;
   el.src =
-    'https://cdn.jsdelivr.net/npm/analytics-client@latest/dist/bundle.js';
+    'https://cdn.jsdelivr.net/npm/analytics-client@3.1.1/dist/bundle.js';
 
   el.onload = function (_) {
     var urlParamsHandler = new analyticsClient.AnalyticsUrlParams();
@@ -26,7 +26,7 @@ function addAnalyticsClient() {
     }
 
     var client = analyticsClient.createClient({
-      projectName: 'balena-main',
+      projectName: '1963512249dcd02836369507fb6dd034',
       componentName: 'docs',
       endpoint: 'data.{{ $names.cloud_domain }}',
       deviceId: urlParamsHandler.getPassedDeviceId(),
@@ -83,6 +83,8 @@ if (window.CookieConsent) {
     },
     cookie: {
       secure: false,
+      domain: 'balena.io',
+      name: 'cookie_consent',
     },
   })
 


### PR DESCRIPTION
* Switch the project name to the public Amplitude API key for future compatibility with Amplitude Experiment SDK
* Add a name to the consent cookie (instead of `undefined`) and a domain so it's available for the whole balena.io property (top and sub-domains)
* Fix the version of `analytics-client` to v3.1.1 to prevent regressions