### PR TITLE
Fix cookie consent banner customize tab options being ignored when clicking on 'Save selection'

### DIFF
--- a/templates/_track.html
+++ b/templates/_track.html
@@ -88,11 +88,13 @@ if (window.CookieConsent) {
     },
   })
 
-  cc.on('accept', () => {
-    addAnalyticsClient();
-    gtag('consent', 'update', {
-      'analytics_storage': 'granted'
-    });
+  cc.on('accept', (cc) => {
+    if (cc.acceptedCategories?.includes('analytics')) {
+      addAnalyticsClient();
+      gtag('consent', 'update', {
+        'analytics_storage': 'granted',
+      });
+    }
   });
 }
 


### PR DESCRIPTION
Incident: https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/Cookie-consent-tracking-enabled-after-rejection-in-the-'customize'-tab-of-the-cookie-consent-banner-110

Change-type: patch


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
