### PR TITLE
DocSearch: Add analytics tags

### DIFF
--- a/templates/_algolia.html
+++ b/templates/_algolia.html
@@ -8,6 +8,7 @@
     getMissingResultsUrl: ({ query }) => {
       return `https://github.com/balena-io/docs/issues/new?title=${query}`;
     },
+    analyticsTags: ['docs', 'default'],
   });
   docsearch({
     container: '.search-404-wrapper',
@@ -17,6 +18,7 @@
     getMissingResultsUrl: ({ query }) => {
       return `https://github.com/balena-io/docs/issues/new?title=${query}`;
     },
+    analyticsTags: ['docs', '404'],
   });
   docsearch({
     container: '.search-mobile-wrapper',
@@ -26,5 +28,6 @@
     getMissingResultsUrl: ({ query }) => {
       return `https://github.com/balena-io/docs/issues/new?title=${query}`;
     },
+    analyticsTags: ['docs', 'mobile'],
   });
 </script>


### PR DESCRIPTION
Change-type: patch
Hunch: https://balena.fibery.io/Inputs/Hunch/DocSearch-is-not-being-used-in-the-dashboard-because-it-is-so-hidden-1480

---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
