### PR TITLE
Add extra-firmware page to sidebar navigation

### DIFF
--- a/config/navigation.txt
+++ b/config/navigation.txt
@@ -41,6 +41,7 @@ Learn
     [/learn/develop/multicontainer]
     Develop with Apps[/learn/develop/apps]
     [/learn/develop/blocks]
+    [/learn/develop/extra-firmware]
     [/learn/develop/runtime]
     [/learn/develop/hardware]
       [/learn/develop/hardware/gpio]


### PR DESCRIPTION
## Summary

- The extra-firmware docs page (merged in #3257) was missing a `config/navigation.txt` entry, making it inaccessible from the sidebar and search results
- Adds `[/learn/develop/extra-firmware]` to the DEVELOP section, between `blocks` and `runtime`

## Test plan

- [x] Verify "Extra firmware" appears in the DEVELOP section of the left sidebar
- [x] Confirm clicking the link navigates to `/learn/develop/extra-firmware/`
- [ ] Confirm the page appears in search results for "extra firmware"