### PR TITLE
Replace contracts submodule trigger with regex-based version tracking

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,6 +18,7 @@
       "description": "Sync external documentation when source repos are updated",
       "matchManagers": ["custom.regex"],
       "matchFileNames": ["external-docs.json"],
+      "excludePackageNames": ["balena-io/contracts"],
       "postUpgradeTasks": {
         "commands": ["npm run sync-external -- --repo {{{depName}}}"],
         "fileFilters": [
@@ -31,16 +32,18 @@
     },
     {
       "description": "Generate device-specific content when contracts are updated",
-      "matchManagers": ["git-submodules"],
-      "matchFileNames": ["contracts"],
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["balena-io/contracts"],
       "postUpgradeTasks": {
         "commands": ["npm run generate-device-specific-content"],
         "fileFilters": [
-          "pages/getting-started/",
-          "pages/faq/troubleshooting/",
+          "pages/learn/getting-started/**",
+          "pages/faq/troubleshooting/**",
           "pages/reference/hardware/devices.md",
+          "pages/reference/supervisor/config-list/**",
           "pages/SUMMARY.md",
-          "pages/reference/supervisor/config-list/"
+          "pages/.gitbook/assets/dt-*",
+          "pages/.gitbook/includes/esr-supported-devices.md"
         ],
         "executionMode": "update"
       }

--- a/external-docs.json
+++ b/external-docs.json
@@ -195,7 +195,6 @@
       "dictionary": "config/dictionaries/pythonsdk.json"
     }
   ],
-
   "dynamic": [
     {
       "id": "balena-labs-projects",
@@ -210,6 +209,13 @@
       "org": "balena-io-examples",
       "target": "pages/.gitbook/includes/balena-example-projects.md",
       "perPage": 100
+    }
+  ],
+  "tracked": [
+    {
+      "id": "contracts",
+      "repo": "balena-io/contracts",
+      "ref": "v2.0.137"
     }
   ]
 }


### PR DESCRIPTION
Add a `tracked` section to external-docs.json for repos that need Renovate version tracking without file syncing. Track balena-io/contracts there so Renovate detects new tags and triggers device-specific content generation via a dedicated packageRule. Also fixes incorrect fileFilter paths in the renovate config.
