### PR TITLE
Update outdated internal docs

### DIFF
--- a/pages/.gitbook/includes/labels-version-note.md
+++ b/pages/.gitbook/includes/labels-version-note.md
@@ -1,7 +1,0 @@
----
-title: labels-version-note
----
-
-{% hint style="warning" %}
-If you have devices in your app that have a supervisor version lower than 7.22.0, then you should use the `io.resin.features.` form of the labels to ensure that all devices obey the label. Earlier supervisor versions will not understand the `io.balena.features` label.
-{% endhint %}

--- a/pages/faq/questions.md
+++ b/pages/faq/questions.md
@@ -6,7 +6,7 @@ title: FAQs
 
 ### **Can I use multiple containers?**
 
-Multiple container fleets are supported, beginning with balenaOS v2.12.0. To run multiple containers, you will need to have a [microservices fleet](../learn/accounts/fleet-types.md) and include a `docker-compose.yml` file at the root of your project. You can reference the [multicontainer documentation](../learn/develop/multicontainer.md) for more details on the supported configurations.
+Multiple container fleets are supported in fleets by default. To run multiple containers, you will need to include a `docker-compose.yml` file at the root of your project. You can reference the [multicontainer documentation](../learn/develop/multicontainer.md) for more details on the supported configurations.
 
 If you are running a Docker-in-Docker setup, which builds a single container on the balena servers but has a `docker-compose.yml` file at the root of the project, you'll want to rename the file to something like `dind-compose.yml`. Then when you run Docker Compose in your container, you can use the `-f` flag with the new file name: `docker-compose -f dind-compose.yml up`.
 
@@ -46,26 +46,13 @@ For fleets running [multiple containers](../learn/develop/multicontainer.md), yo
 
 Yes! It's actually pretty easy. Have a look at the [network setup](../reference/os/network.md#setting-a-static-ip) section of our documentation. In general, most network configurations can be achieved by changing the NetworkManager configuration file.
 
-### **Why can't I SSH into or run code in older versions of the host OS?**
-
-While you’ve always been able to SSH into your container, we had previously restricted SSH access to the host OS. We had a number of reasons for doing this:
-
-* Code in the host OS currently isn't kept inside a container, so we are unable to track or update it at all.
-* If code run in the host OS inadvertently kills our supervisor or overwrites critical data (such as data used to identify it), the device could become inaccessible and no longer updateable.
-* Configuration of network device drivers, mount points, security provisions, and many other details have been carefully chosen to serve the balena ecosystem and your containers. Rogue code running in the host OS might interfere with this, leading to issues or degradation of performance which we would likely not be able to help you with.
-* When troubleshooting issues we base our assumptions on the host OS behaving as we expect it to. If you have made changes here, there's a good chance we won't be able to reproduce the issues locally and therefore won't be able to help you.
-
-However, we've heard from users that they would still like to be able to SSH into the host OS on their devices, so we decided to add that capability starting with balenaOS version 2.7.5. This gives you access to logs and tools for services that operate outside the scope of your container, such as NetworkManager, Docker, cloudlink, and the supervisor. For more details, please check out [this documentation](../learn/develop/runtime.md).
-
 ### **Which data is persisted on devices across updates/power cycles?**
 
-The only data we [guarantee to be persisted](../learn/develop/runtime.md#persistent-storage) across reboot, shutdown and device update/container restart is the contents of the `/data` folder, or any [named volumes](../learn/develop/multicontainer.md#named-volumes) on devices running balenaOS v2.12.0 and above. However, when a device is restarted or power cycled the container is not recreated, meaning all the data that was present in the container's filesystem before, remains. It's very important not to rely on this behavior, as containers are recreated on release updates, when environment variables are changed in the UI or API, or when a fleet restart is requested.
+The only data we [guarantee to be persisted](../learn/develop/runtime.md#persistent-storage) across reboot, shutdown and device update/container restart is the contents of the `/data` folder and any [named volumes](../learn/develop/multicontainer.md#named-volumes). However, when a device is restarted or power cycled the container is not recreated, meaning all the data that was present in the container's filesystem before, remains. It's very important not to rely on this behavior, as containers are recreated on release updates, when environment variables are changed in the UI or API, or when a fleet restart is requested.
 
 ### **Why does /data disappear when I move a device between fleets?**
 
-Persistent data is specific to a fleet. If you move devices between fleets running different code, then keeping persistent data from the old fleet could potentially cause issues.
-
-On devices running balenaOS versions before 2.12.0, if you move the device back to the old fleet you'll find `/data` remains intact. Newer balenaOS versions automatically purge named volumes when a device is moved to a new fleet.
+Persistent data is specific to a fleet. If you move devices between fleets running different code, then keeping persistent data from the old fleet could potentially cause issues. balenaOS automatically purge named volumes when a device is moved to a new fleet.
 
 ### **It appears that there is a centralized master running (in cloud) and agents running on devices. Is that accurate?**
 
@@ -111,7 +98,7 @@ Please contact sales@balena.io with any questions regarding continued device sup
 
 ### **I have a device that is not on the supported devices list. Can it run on balena?**
 
-There are a few options for devices that do not have an official device type on balena. If your device has an x86 architecture, you can try either the [Intel NUC](../learn/getting-started/intel-nuc.md) image (which is built to support generic x86 devices with a minimum set of drivers), or the generic genericx86-64 image (that includes all the standard X86 drivers). For other devices, you can [build your own](https://github.com/balena-os/meta-balena/blob/master/contributing-device-support.md) version of balenaOS using our [open source repos](https://github.com/balena-os). To discuss custom board support, please contact sales@balena.io.
+There are a few options for devices that do not have an official device type on balena. If your device has an x86 architecture, you can try either the [Intel NUC](../learn/getting-started/intel-nuc.md) image (which is built to support generic x86 devices with a minimum set of drivers), or the generic genericx86-64 image (that includes all the standard X86 drivers). To discuss custom board support, please contact sales@balena.io.
 
 ### **What to keep in mind when choosing power supply units?**
 

--- a/pages/faq/troubleshooting/raspberry-pi.md
+++ b/pages/faq/troubleshooting/raspberry-pi.md
@@ -54,7 +54,7 @@ If the Raspberry Pi is unable to connect to the balena servers, the `ACT` LED wi
 
 This is either because it is not connected to the network or because the network ports which balena relies on are blocked in some way.
 
-- The first things to check in this case is that your device is correctly connected to ethernet or that you correctly entered the wifi credentials. To check wifi credentials, power your device down, remove the SD card, and mount the SD card on your personal computer. If your device is running balenaOS version 2.0 or greater, wifi credentials are listed in `system-connections/resin-wifi`, found in the `resin-boot` partition of the SD card. Otherwise, check the `config.json` file (in the `resin-boot` partition for versions 1.2 and greater, or `resin-conf` for earlier versions).
+- The first things to check in this case is that your device is correctly connected to ethernet or that you correctly entered the wifi credentials. To check wifi credentials, power your device down, remove the SD card, and mount the SD card on your personal computer. Wifi credentials are listed in `system-connections/resin-wifi`, found in the `resin-boot` partition of the SD card.
 - Secondly check that your network is not restricting or blocking the ports specified in the [balena network requirements](../../reference/os/network.md#network-requirements).
 - If you still aren't able to get your device online, reach out to us in the [forums](https://forums.balena.io).
 

--- a/pages/faq/troubleshooting/raspberry-pi2.md
+++ b/pages/faq/troubleshooting/raspberry-pi2.md
@@ -54,7 +54,7 @@ If the Raspberry Pi is unable to connect to the balena servers, the `ACT` LED wi
 
 This is either because it is not connected to the network or because the network ports which balena relies on are blocked in some way.
 
-- The first things to check in this case is that your device is correctly connected to ethernet or that you correctly entered the wifi credentials. To check wifi credentials, power your device down, remove the SD card, and mount the SD card on your personal computer. If your device is running balenaOS version 2.0 or greater, wifi credentials are listed in `system-connections/resin-wifi`, found in the `resin-boot` partition of the SD card. Otherwise, check the `config.json` file (in the `resin-boot` partition for versions 1.2 and greater, or `resin-conf` for earlier versions).
+- The first things to check in this case is that your device is correctly connected to ethernet or that you correctly entered the wifi credentials. To check wifi credentials, power your device down, remove the SD card, and mount the SD card on your personal computer. Wifi credentials are listed in `system-connections/resin-wifi`, found in the `resin-boot` partition of the SD card.
 - Secondly check that your network is not restricting or blocking the ports specified in the [balena network requirements](../../reference/os/network.md#network-requirements).
 - If you still aren't able to get your device online, reach out to us in the [forums](https://forums.balena.io).
 

--- a/pages/faq/troubleshooting/raspberrypi0-2w-64.md
+++ b/pages/faq/troubleshooting/raspberrypi0-2w-64.md
@@ -54,7 +54,7 @@ If the Raspberry Pi is unable to connect to the balena servers, the `ACT` LED wi
 
 This is either because it is not connected to the network or because the network ports which balena relies on are blocked in some way.
 
-- The first things to check in this case is that your device is correctly connected to ethernet or that you correctly entered the wifi credentials. To check wifi credentials, power your device down, remove the SD card, and mount the SD card on your personal computer. If your device is running balenaOS version 2.0 or greater, wifi credentials are listed in `system-connections/resin-wifi`, found in the `resin-boot` partition of the SD card. Otherwise, check the `config.json` file (in the `resin-boot` partition for versions 1.2 and greater, or `resin-conf` for earlier versions).
+- The first things to check in this case is that your device is correctly connected to ethernet or that you correctly entered the wifi credentials. To check wifi credentials, power your device down, remove the SD card, and mount the SD card on your personal computer. Wifi credentials are listed in `system-connections/resin-wifi`, found in the `resin-boot` partition of the SD card.
 - Secondly check that your network is not restricting or blocking the ports specified in the [balena network requirements](../../reference/os/network.md#network-requirements).
 - If you still aren't able to get your device online, reach out to us in the [forums](https://forums.balena.io).
 

--- a/pages/faq/troubleshooting/raspberrypi3-64.md
+++ b/pages/faq/troubleshooting/raspberrypi3-64.md
@@ -59,7 +59,7 @@ If the Raspberry Pi is unable to connect to the balena servers, the `ACT` LED wi
 
 This is either because it is not connected to the network or because the network ports which balena relies on are blocked in some way.
 
-- The first things to check in this case is that your device is correctly connected to ethernet or that you correctly entered the wifi credentials. To check wifi credentials, power your device down, remove the SD card, and mount the SD card on your personal computer. If your device is running balenaOS version 2.0 or greater, wifi credentials are listed in `system-connections/resin-wifi`, found in the `resin-boot` partition of the SD card. Otherwise, check the `config.json` file (in the `resin-boot` partition for versions 1.2 and greater, or `resin-conf` for earlier versions).
+- The first things to check in this case is that your device is correctly connected to ethernet or that you correctly entered the wifi credentials. To check wifi credentials, power your device down, remove the SD card, and mount the SD card on your personal computer. Wifi credentials are listed in `system-connections/resin-wifi`, found in the `resin-boot` partition of the SD card.
 - Secondly check that your network is not restricting or blocking the ports specified in the [balena network requirements](../../reference/os/network.md#network-requirements).
 - If you still aren't able to get your device online, reach out to us in the [forums](https://forums.balena.io).
 

--- a/pages/faq/troubleshooting/raspberrypi3.md
+++ b/pages/faq/troubleshooting/raspberrypi3.md
@@ -59,7 +59,7 @@ If the Raspberry Pi is unable to connect to the balena servers, the `ACT` LED wi
 
 This is either because it is not connected to the network or because the network ports which balena relies on are blocked in some way.
 
-- The first things to check in this case is that your device is correctly connected to ethernet or that you correctly entered the wifi credentials. To check wifi credentials, power your device down, remove the SD card, and mount the SD card on your personal computer. If your device is running balenaOS version 2.0 or greater, wifi credentials are listed in `system-connections/resin-wifi`, found in the `resin-boot` partition of the SD card. Otherwise, check the `config.json` file (in the `resin-boot` partition for versions 1.2 and greater, or `resin-conf` for earlier versions).
+- The first things to check in this case is that your device is correctly connected to ethernet or that you correctly entered the wifi credentials. To check wifi credentials, power your device down, remove the SD card, and mount the SD card on your personal computer. Wifi credentials are listed in `system-connections/resin-wifi`, found in the `resin-boot` partition of the SD card.
 - Secondly check that your network is not restricting or blocking the ports specified in the [balena network requirements](../../reference/os/network.md#network-requirements).
 - If you still aren't able to get your device online, reach out to us in the [forums](https://forums.balena.io).
 

--- a/pages/faq/troubleshooting/raspberrypi4-64.md
+++ b/pages/faq/troubleshooting/raspberrypi4-64.md
@@ -54,7 +54,7 @@ If the Raspberry Pi is unable to connect to the balena servers, the `ACT` LED wi
 
 This is either because it is not connected to the network or because the network ports which balena relies on are blocked in some way.
 
-- The first things to check in this case is that your device is correctly connected to ethernet or that you correctly entered the wifi credentials. To check wifi credentials, power your device down, remove the SD card, and mount the SD card on your personal computer. If your device is running balenaOS version 2.0 or greater, wifi credentials are listed in `system-connections/resin-wifi`, found in the `resin-boot` partition of the SD card. Otherwise, check the `config.json` file (in the `resin-boot` partition for versions 1.2 and greater, or `resin-conf` for earlier versions).
+- The first things to check in this case is that your device is correctly connected to ethernet or that you correctly entered the wifi credentials. To check wifi credentials, power your device down, remove the SD card, and mount the SD card on your personal computer. Wifi credentials are listed in `system-connections/resin-wifi`, found in the `resin-boot` partition of the SD card.
 - Secondly check that your network is not restricting or blocking the ports specified in the [balena network requirements](../../reference/os/network.md#network-requirements).
 - If you still aren't able to get your device online, reach out to us in the [forums](https://forums.balena.io).
 

--- a/pages/learn/deploy/release-strategy/update-strategies.md
+++ b/pages/learn/deploy/release-strategy/update-strategies.md
@@ -5,7 +5,7 @@ excerpt: Choosing an update strategy for your balena devices
 
 # Controlling the update strategy
 
-With the balena device supervisor version 1.3, we added the ability to choose the update strategy on devices, that is, the order and way in which the steps to perform an update are executed. You can check whether your Supervisor has the appropriate version in the "Supervisor version" entry in the device dashboard page. These update strategies allow users to choose between four modes that are suited for different applications, depending on available resources and the possible need to have a container running at all times.
+The balena device supervisor allows you to choose the update strategy on devices. An update strategy is the order and way in which the steps to perform an update are executed. These update strategies allow users to choose between four modes that are suited for different applications, depending on available resources and the possible need to have a container running at all times.
 
 Update strategies can be applied by setting a [docker-compose label](../../../reference/supervisor/docker-compose.md#labels). The two labels that are involved are:
 
@@ -55,10 +55,6 @@ This strategy is meant for resource-constrained scenarios or when the images be 
 
 {% hint style="warning" %}
 This strategy is only recommended for extreme low storage scenarios, where the available storage cannot even fit the target [image deltas](../delta.md). For most cases, using the default strategy or the `kill-then-download` strategy (if memory usage is a concern), and ensuring [deltas are enabled](../delta.md) is the recommended approach.
-{% endhint %}
-
-{% hint style="warning" %}
-**Requires Supervisor >= v2.5.1**
 {% endhint %}
 
 ## hand-over

--- a/pages/learn/develop/dockerfile.md
+++ b/pages/learn/develop/dockerfile.md
@@ -7,7 +7,7 @@ excerpt: Use Dockerfiles to package your balena services and their dependencies
 
 Balena uses [Docker](https://www.docker.com/) containers to manage deployment and updates. You can use one or more containers to package your services with whichever environments and tools they need to run.
 
-To ensure a service has everything it needs, you'll want to create a list of instructions for building a [container image](https://docs.docker.com/engine/understanding-docker/#/inside-docker). Whether the build process is done [on your device](local-mode.md), [on your workstation](../../external-docs/balena-cli/latest.md#build), or on the [balena builders](../deploy/deployment.md), the end result is a read-only image that ends up on your device. This image is used by the container engine (balena or Docker, depending on the balenaOS version) to kick off a running container.
+To ensure a service has everything it needs, you'll want to create a list of instructions for building a [container image](https://docs.docker.com/engine/understanding-docker/#/inside-docker). Whether the build process is done [on your device](local-mode.md), [on your workstation](../../external-docs/balena-cli/latest.md#build), or on the [balena builders](../deploy/deployment.md), the end result is a read-only image that ends up on your device. This image is used by the container engine to kick off a running container.
 
 {% hint style="info" %}
 For additional information on working with Dockerfiles with balena see the [services masterclass](../../external-docs/masterclasses/services-masterclass.md).
@@ -36,8 +36,6 @@ Containers ran as single container **have no security restrictions**, this shoul
 {% endhint %}
 
 To deploy a single-container release to balena, simply place a `Dockerfile` at the root of your repository. A `docker-compose.yml` file will be automatically generated, ensuring your container has host networking, is privileged, and has `lib/modules`, `/lib/firmware`, and `/run/dbus` bind mounted into the container. The default `docker-compose.yml` will look something like this:
-
-{% include "../../.gitbook/includes/labels-version-note.md" %}
 
 ```yaml
 version: '2.1'

--- a/pages/learn/develop/hardware/i2c-and-spi.md
+++ b/pages/learn/develop/hardware/i2c-and-spi.md
@@ -85,7 +85,7 @@ To demonstrate this functionality, you can push this project ([https://github.co
 
 #### Raspberry Pi camera module
 
-Depending on the version of your balenaOS, the system contains different version of the Raspberry Pi firmware, and you need to apply slightly different settings. In both cases you can either modify `config.txt` on the `resin-boot` partition of your SD card, or add the settings remotely by using `BALENA_HOST_CONFIG_variablename` settings in your [fleet or device configuration](../../manage/configuration.md).
+Depending on the version of your balenaOS, the system contains a different version of the Raspberry Pi firmware and you need to apply slightly different settings. In both cases you can either modify `config.txt` on the `resin-boot` partition of your SD card, or add the settings remotely by using `BALENA_HOST_CONFIG_variablename` settings in your [fleet or device configuration](../../manage/configuration.md).
 
 **BalenaOS 1.16.0 and newer**
 

--- a/pages/learn/develop/local-mode.md
+++ b/pages/learn/develop/local-mode.md
@@ -11,7 +11,6 @@ Local mode is the development mode for balena. It allows you to build and sync c
 
 To use local mode on a device:
 
-* The device must be running balenaOS v2.29.0 or higher.
 * The device must be running a [development](../../reference/os/overview.md) variant of the OS.
 * You must have the [balena CLI](../../external-docs/balena-cli/latest.md) installed on your development machine.
 * Local mode must be enabled through the balenaCloud dashboard. You can enable it from the device _Settings_ tab.

--- a/pages/learn/develop/multicontainer.md
+++ b/pages/learn/develop/multicontainer.md
@@ -76,7 +76,7 @@ Setting `network_mode` to `host` allows the container to share the same network 
 
 ### Named volumes
 
-With multicontainer fleets, balena supports the use of named volumes, a feature that expands on the [persistent storage](runtime.md#persistent-storage) functionality used by older versions of balenaOS. Named volumes can be given arbitrary names and can be linked to a directory in one or more containers. As long as every release of the fleet includes a `docker-compose.yml` and the volume name does not change, the data in the volume will persist across updates.
+Balena supports the use of named volumes, a feature that expands on the [persistent storage](runtime.md#persistent-storage) functionality used by older versions of balenaOS. Named volumes can be given arbitrary names and can be linked to a directory in one or more containers. As long as every release of the fleet includes a `docker-compose.yml` and the volume name does not change, the data in the volume will persist across updates.
 
 Use the `volumes` field of the service to link a directory in your container to your named volume. The named volume should also be specified at the top level of the `docker-compose.yml`:
 

--- a/pages/learn/develop/runtime.md
+++ b/pages/learn/develop/runtime.md
@@ -61,13 +61,7 @@ It's recommended to only give that level of access to containers that have a sin
 {% endhint %}
 
 ```
-# for balena supervisor versions 1.7.0 and newer (both balenaOS 1.x and 2.x) use this version:
 DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
-```
-
-```
-# for balena supervisor before 1.7.0 use this version:
-DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host_run/dbus/system_bus_socket
 ```
 
 Below you can find a couple of examples. All of them requires either prepending the command with the above `DBUS_SYSTEM_BUS_ADDRESS=...` or setting the variable for all commands by running `export DBUS_SYSTEM_BUS_ADDRESS=...` with the correct environment variable value from above.
@@ -187,7 +181,7 @@ Since the `/etc/modules` you see in your container belongs to the container's fi
 ## Supervisor
 
 {% hint style="warning" %}
-In multicontainer fleets, the `io.balena.features.supervisor-api` label must be applied for each service that requires access to the Supervisor API. If you have devices with a supervisor version lower than 7.22.0, you should use `io.resin.features` labeling as that will ensure backward compatibility
+In multicontainer fleets, the `io.balena.features.supervisor-api` label must be applied for each service that requires access to the Supervisor API.
 {% endhint %}
 
 ### Reboot from Inside the Container
@@ -298,17 +292,7 @@ In the balena host OS [dnsmasq](https://www.thekelleys.org.uk/dnsmasq/doc.html) 
 
 If you have data or configurations that you would like to persist through application and host OS updates, you have the option to keep them in persistent storage. Persistent storage is a good place to write system logs and other application data that should remain untouched even as your code changes.
 
-**Before balenaOS v2.12.0**
-
-On devices running OS versions before 2.12.0, the `/data` folder in the container is automatically linked to a directory on the host OS and guaranteed to persist across updates. The contents of the `/data` folder can be accessed via the host OS at `/mnt/data/resin-data/<APP ID>`.
-
-The `/data` folder is not synced between devices in your fleet. In addition, the folder is unique to a specific fleet, so if you transfer your device to a new fleet the `/data` folder from the previous fleet will not be accessible in the container. It will, however, still be available via the host OS and if the device is moved back to the original fleet.
-
-Note that the `/data` folder is **not** mounted when your project is building on our build servers, so you can't access it from your `Dockerfile`. The `/data` volume only exists when the container is running on the deployed devices.
-
-**balenaOS v2.12.0 and above**
-
-Beginning with balenaOS v2.12.0, persistent storage is handled through [named volumes](multicontainer.md#named-volumes). The behavior is much the same as persistent storage on older host OS versions. In fact, for single-container fleets, the default `docker-compose.yml` sets up a `resin-data` named volume that links to a `/data` directory in the container. The only difference between this and earlier versions is that accessing this data via the host OS is done at `/var/lib/docker/volumes/<APP ID>_resin-data/_data`, rather than the `/mnt/data/resin-data/<APP ID>` location used with earlier host OS versions.
+Persistent storage is handled through [named volumes](multicontainer.md#named-volumes). The behavior is much the same as persistent storage on older host OS versions. In fact, for single-container fleets, the default `docker-compose.yml` sets up a `resin-data` named volume that links to a `/data` directory in the container. The only difference between this and earlier versions is that accessing this data via the host OS is done at `/var/lib/docker/volumes/<APP ID>_resin-data/_data`, rather than the `/mnt/data/resin-data/<APP ID>` location used with earlier host OS versions.
 
 Named volumes can be given arbitrary names and can be linked to a directory in one or more containers. As long as every release includes a `docker-compose.yml` and the volume name does not change, the data in the volume will persist between updates.
 
@@ -317,9 +301,7 @@ When using named volumes, note that:
 * If a device is moved to a new fleet, the old `/data` folder will be automatically purged.
 * During the build process, data added to a container directory that is configured to link to a named volume will be copied to the volume the first time it's created on the device.
 
-**Using a Supervisor with a version >= v10.0.0**
-
-Since balena-supervisor v10.0.0, volumes are no longer automatically removed from disk when references to them are removed from a fleet's `docker-compose` file. This means that it's no longer possible for data to be lost due to the accidental rename of a volume.
+Volumes are not automatically removed from disk when references to them are removed from a fleet's `docker-compose` file. This means that it's not possible for data to be lost due to the accidental rename of a volume.
 
 If you change volume names regularly, your device will now continue to retain all previous volumes including their contents. To avoid this the supervisor API now provides an [endpoint to cleanup unreferenced volumes](../../external-docs/supervisor-api.md#cleanup-volumes-with-no-references). Additionally, it is possible to perform this action from the dashboard via the `Purge Data` action, found on the `Actions` tab for a device.
 
@@ -329,7 +311,7 @@ Volumes will continue to be removed automatically when moving a device between f
 
 **Transfer large files**
 
-If you have large files you would like your containers to have access to, you can transfer them from your computer directly to your device's SD card. First insert the SD card in your computer and find the `resin-data` partition. Then look for the folder associated with your application, which will either be at `/resin-data/<APP ID>` or `/docker/volumes/<APP ID>_<VOLUME NAME>/_<CONTAINER DIRECTORY>`, depending on your host OS version. Note that these directories will only exist after your application has been started at least once.
+If you have large files you would like your containers to have access to, you can transfer them from your computer directly to your device's SD card. First insert the SD card in your computer and find the `resin-data` partition. Then look for the folder associated with your application, which will either be at `/resin-data/<APP ID>`. Note that these directories will only exist after your application has been started at least once.
 
 ### Temporary directories
 

--- a/pages/learn/getting-started/asus-tinker-edge-t.md
+++ b/pages/learn/getting-started/asus-tinker-edge-t.md
@@ -79,19 +79,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/beaglebone-ai64.md
+++ b/pages/learn/getting-started/beaglebone-ai64.md
@@ -79,19 +79,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/beaglebone-black.md
+++ b/pages/learn/getting-started/beaglebone-black.md
@@ -79,19 +79,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/cl-som-imx8.md
+++ b/pages/learn/getting-started/cl-som-imx8.md
@@ -79,19 +79,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/coral-dev.md
+++ b/pages/learn/getting-started/coral-dev.md
@@ -78,19 +78,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/eg5120-imx8mp.md
+++ b/pages/learn/getting-started/eg5120-imx8mp.md
@@ -79,19 +79,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/forecr-dsb-ornx-orin-nano-8gb.md
+++ b/pages/learn/getting-started/forecr-dsb-ornx-orin-nano-8gb.md
@@ -77,19 +77,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/generic-aarch64.md
+++ b/pages/learn/getting-started/generic-aarch64.md
@@ -75,19 +75,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/generic-amd64.md
+++ b/pages/learn/getting-started/generic-amd64.md
@@ -76,19 +76,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/genericx86-64-ext.md
+++ b/pages/learn/getting-started/genericx86-64-ext.md
@@ -76,19 +76,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/imx8m-var-dart.md
+++ b/pages/learn/getting-started/imx8m-var-dart.md
@@ -79,19 +79,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/imx8mm-lpddr4-evk.md
+++ b/pages/learn/getting-started/imx8mm-lpddr4-evk.md
@@ -79,19 +79,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/imx8mm-var-dart.md
+++ b/pages/learn/getting-started/imx8mm-var-dart.md
@@ -79,19 +79,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/imx8mm-var-som.md
+++ b/pages/learn/getting-started/imx8mm-var-som.md
@@ -79,19 +79,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/intel-nuc.md
+++ b/pages/learn/getting-started/intel-nuc.md
@@ -77,19 +77,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/iot-gate-imx8.md
+++ b/pages/learn/getting-started/iot-gate-imx8.md
@@ -76,19 +76,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/iot-gate-imx8plus-d1d8.md
+++ b/pages/learn/getting-started/iot-gate-imx8plus-d1d8.md
@@ -67,19 +67,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/iot-gate-imx8plus.md
+++ b/pages/learn/getting-started/iot-gate-imx8plus.md
@@ -67,19 +67,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/iotdin-imx8p-d1d8.md
+++ b/pages/learn/getting-started/iotdin-imx8p-d1d8.md
@@ -67,19 +67,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/iotdin-imx8p.md
+++ b/pages/learn/getting-started/iotdin-imx8p.md
@@ -67,19 +67,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/isg-503.md
+++ b/pages/learn/getting-started/isg-503.md
@@ -79,19 +79,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/jetson-agx-orin-devkit-64gb.md
+++ b/pages/learn/getting-started/jetson-agx-orin-devkit-64gb.md
@@ -77,19 +77,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/jetson-agx-orin-devkit.md
+++ b/pages/learn/getting-started/jetson-agx-orin-devkit.md
@@ -64,19 +64,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/jetson-nano-2gb-devkit.md
+++ b/pages/learn/getting-started/jetson-nano-2gb-devkit.md
@@ -64,19 +64,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/jetson-nano-emmc.md
+++ b/pages/learn/getting-started/jetson-nano-emmc.md
@@ -64,19 +64,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/jetson-nano.md
+++ b/pages/learn/getting-started/jetson-nano.md
@@ -63,19 +63,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/jetson-orin-nano-devkit-nvme.md
+++ b/pages/learn/getting-started/jetson-orin-nano-devkit-nvme.md
@@ -77,19 +77,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/jetson-orin-nano-seeed-j3010.md
+++ b/pages/learn/getting-started/jetson-orin-nano-seeed-j3010.md
@@ -77,19 +77,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/jetson-orin-nx-seeed-j4012.md
+++ b/pages/learn/getting-started/jetson-orin-nx-seeed-j4012.md
@@ -77,19 +77,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/jetson-orin-nx-xavier-nx-devkit.md
+++ b/pages/learn/getting-started/jetson-orin-nx-xavier-nx-devkit.md
@@ -77,19 +77,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/jetson-tx2-nx-devkit.md
+++ b/pages/learn/getting-started/jetson-tx2-nx-devkit.md
@@ -64,19 +64,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/jetson-tx2.md
+++ b/pages/learn/getting-started/jetson-tx2.md
@@ -78,19 +78,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/jetson-xavier-nx-devkit-emmc.md
+++ b/pages/learn/getting-started/jetson-xavier-nx-devkit-emmc.md
@@ -64,19 +64,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/jetson-xavier-nx-devkit.md
+++ b/pages/learn/getting-started/jetson-xavier-nx-devkit.md
@@ -62,19 +62,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/jetson-xavier.md
+++ b/pages/learn/getting-started/jetson-xavier.md
@@ -64,19 +64,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/jn30b-nano.md
+++ b/pages/learn/getting-started/jn30b-nano.md
@@ -64,19 +64,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/kontron-mx8mm.md
+++ b/pages/learn/getting-started/kontron-mx8mm.md
@@ -79,19 +79,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/nanopi-r2s.md
+++ b/pages/learn/getting-started/nanopi-r2s.md
@@ -75,19 +75,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/nitrogen8mm.md
+++ b/pages/learn/getting-started/nitrogen8mm.md
@@ -79,19 +79,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/owa5x.md
+++ b/pages/learn/getting-started/owa5x.md
@@ -79,19 +79,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/phyboard-lyra-am62xx-2.md
+++ b/pages/learn/getting-started/phyboard-lyra-am62xx-2.md
@@ -79,19 +79,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/raspberry-pi.md
+++ b/pages/learn/getting-started/raspberry-pi.md
@@ -77,19 +77,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/raspberry-pi2.md
+++ b/pages/learn/getting-started/raspberry-pi2.md
@@ -75,19 +75,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/raspberrypi0-2w-64.md
+++ b/pages/learn/getting-started/raspberrypi0-2w-64.md
@@ -75,19 +75,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/raspberrypi3-64.md
+++ b/pages/learn/getting-started/raspberrypi3-64.md
@@ -75,19 +75,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/raspberrypi3.md
+++ b/pages/learn/getting-started/raspberrypi3.md
@@ -75,19 +75,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/raspberrypi4-64.md
+++ b/pages/learn/getting-started/raspberrypi4-64.md
@@ -77,19 +77,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/raspberrypi4-unipi-neuron.md
+++ b/pages/learn/getting-started/raspberrypi4-unipi-neuron.md
@@ -75,19 +75,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/raspberrypi5.md
+++ b/pages/learn/getting-started/raspberrypi5.md
@@ -75,19 +75,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/raspberrypicm4-ioboard.md
+++ b/pages/learn/getting-started/raspberrypicm4-ioboard.md
@@ -71,19 +71,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/revpi-connect-4.md
+++ b/pages/learn/getting-started/revpi-connect-4.md
@@ -71,19 +71,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/revpi-connect-s.md
+++ b/pages/learn/getting-started/revpi-connect-s.md
@@ -71,19 +71,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/rockpi-4b-rk3399.md
+++ b/pages/learn/getting-started/rockpi-4b-rk3399.md
@@ -79,19 +79,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/ucm-imx93.md
+++ b/pages/learn/getting-started/ucm-imx93.md
@@ -79,19 +79,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/up-board.md
+++ b/pages/learn/getting-started/up-board.md
@@ -77,19 +77,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/getting-started/var-som-mx6.md
+++ b/pages/learn/getting-started/var-som-mx6.md
@@ -78,19 +78,19 @@ Now that you have an `operational` device in your fleet, it's time to deploy som
 
 {% tabs %}
 {% tab title="OSX" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-macOS-x64-installer.pkg).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-macOS-x64-installer.pkg).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open the Terminal app ([Terminal User guide](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac)).
 {% endtab %}
 
 {% tab title="Windows" %}
-1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-windows-x64-installer.exe).
+1. [Download the CLI installer](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-windows-x64-installer.exe).
 2. Double click the downloaded file to run the installer and follow the installer's instructions.
 3. To run balena CLI commands, open a command prompt: Click on the Windows Start Menu, type PowerShell, and then click on Windows PowerShell.
 {% endtab %}
 
 {% tab title="Linux" %}
-1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v24.1.3/balena-cli-v24.1.3-linux-x64-standalone.tar.gz).
+1. [Download the standalone CLI](https://github.com/balena-io/balena-cli/releases/download/v25.0.0/balena-cli-v25.0.0-linux-x64-standalone.tar.gz).
 2. Extract the contents of the tar.gz file to any folder you choose, for example `/home/james`. The extracted contents will include a `balena/bin` folder.
 3. Add that folder (e.g. `/home/james/balena/bin`) to the PATH environment variable. Check this [StackOverflow](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) post for instructions. Close and re-open the terminal window so that the changes to PATH can take effect.
 {% endtab %}

--- a/pages/learn/manage/actions.md
+++ b/pages/learn/manage/actions.md
@@ -38,7 +38,7 @@ Restart device container is not equivalent to a reboot of the device!
 
 ### Purge Data
 
-This action clears [persistent storage](../develop/runtime.md#persistent-storage) on any applicable devices. For devices running balenaOS versions before 2.12.0, this means clearing the `/data` folder in the container (and the associated volume at `/mnt/data/resin-data`). On newer balenaOS versions, this action deletes all named volumes and recreates them as empty.
+This action clears [persistent storage](../develop/runtime.md#persistent-storage) on any applicable devices. This action deletes all named volumes and recreates them as empty.
 
 It should be noted that currently these action notifications are not queued up, so if a device is offline when the action is triggered, it will never be notified of it.
 
@@ -97,7 +97,7 @@ Note that you are only able to move devices between fleets with device types tha
 Obviously you may only select one fleet to transfer your device to. Once you select the appropriate radio button, your device will immediately appear in the selected fleet's device list. Note that it will take a while for the device to start the update process as it does not receive a push notification of a new code update from the API, so it has to wait for the update poll, which happens every couple of minutes.
 
 {% hint style="warning" %}
-For devices running balenaOS version 2.12.0 and above, data in [persistent storage](../develop/runtime.md#persistent-storage) (named volumes) is automatically purged when a device is moved to a new fleet. On older host OS versions, the `/data` folder in the new fleet will not contain any of the old fleet data, but it can still be accessed via the host OS and if the device is switched back to the original fleet. Unless you plan to revert back to the original fleet, be sure to [purge](actions.md#purge-data) the `/data` folder.
+Data in [persistent storage](../develop/runtime.md#persistent-storage) (named volumes) is automatically purged when a device is moved to a new fleet.
 {% endhint %}
 
 ### BalenaOS Update
@@ -188,4 +188,6 @@ This option can be used to mark your release as valid or invalid. Entities can o
 
 This option permanently deletes your release. This may be the setting you want to use if you want to clean up releases beyond simply [invalidating releases](actions.md#validation-status).
 
-**Info:** If you have a device [preloaded](../../external-docs/masterclasses/advanced-cli.md#id-5.-preloading-and-preregistering) with an OS version lower than 2.113.14 and a release, and you delete the release before provisioning the device, then when the device provisions it will be in a VPN-only state. To fix this, you must update the supervisor on the device to version 14.9.4 or higher.
+{% hint style="info" %}
+If you have a device [preloaded](../../external-docs/masterclasses/advanced-cli.md#id-5.-preloading-and-preregistering) with an OS version lower than 2.113.14 and a release, and you delete the release before provisioning the device, then when the device provisions it will be in a VPN-only state. To fix this, you must update the supervisor on the device to version 14.9.4 or higher.
+{% endhint %}

--- a/pages/learn/manage/configuration.md
+++ b/pages/learn/manage/configuration.md
@@ -4,7 +4,7 @@ title: Configuration
 
 # Configuration
 
-Variables on the configuration page allow you to provide runtime configuration to the host OS and supervisor. These variables all begin with `BALENA_` or `RESIN_`. Beginning with supervisor v7.0.0, a number of them appear automatically in your dashboard when your device is provisioned.
+Variables on the configuration page allow you to provide runtime configuration to the host OS and supervisor. These variables all begin with `BALENA_` or `RESIN_`. A number of them appear automatically in your dashboard when your device is provisioned.
 
 Configuration can be managed at both the fleet and device level.
 

--- a/pages/learn/manage/ssh-access.md
+++ b/pages/learn/manage/ssh-access.md
@@ -7,10 +7,6 @@ excerpt: Communicate with the host OS and service containers via SSH with balena
 
 To help you debug, develop, and work with your fleets, we've provided a browser-based terminal and a command line tool for easy SSH access to your devices. With these tools, you have console access to any of your running containers, as well as to the host OS, letting you test out small snippets of code and check system logs on your device. You can also access your device via a standalone SSH client.
 
-{% hint style="warning" %}
-Host OS SSH access is available for devices running balenaOS version 2.7.5 and above.
-{% endhint %}
-
 SSH access is built on [Cloudlink](../welcome/security.md#cloudlink) and it not designed for high availability. It is not intended for use in the critical path of your application - you should not depend on it for continuous use as part of your own application.
 
 ### Using the dashboard web terminal
@@ -56,8 +52,6 @@ $ balena device ssh 192.168.1.23
 $ balena device ssh <device-uuid>.local
 ```
 
-When used with a [production variant of balenaOS](../../reference/os/overview.md#development-vs.-production-mode), this feature requires balena CLI v13.3.0 or later, and balenaOS v2.44.0 or later. Otherwise, an SSH key must be added to the device's `config.json` file, [sshKeys section](../../reference/os/configuration.md#sshkeys). These restrictions do not apply to [development variants of balenaOS](../../reference/os/overview.md#development-vs.-production-mode), which allow unauthenticated `root` access (and for this reason, should never be directly exposed to the public internet).
-
 ### Using a standalone SSH client
 
 The SSH server of a balenaOS device (host OS) listens on TCP port `22222`, and access is also possible with a standalone ssh client:
@@ -66,7 +60,7 @@ The SSH server of a balenaOS device (host OS) listens on TCP port `22222`, and a
 $ ssh -p 22222 <username>@<device_ip_address>
 ```
 
-When the username is `root`, [production variants of balenaOS](../../reference/os/overview.md#development-vs.-production-mode) perform authentication against public SSH keys previously added to the device's `config.json` file, [sshKeys section](../../reference/os/configuration.md#sshkeys). When the username matches a valid balenaCloud user account, authentication is also performed against that user's public SSH keys [stored in balenaCloud](ssh-access.md#add-an-ssh-key-to-balenacloud) (this feature requires balenaOS v2.44.0 or later). The username can be found in the profile or preferences section of the web dashboard, or with the balena whoami\` CLI command.
+When the username is `root`, [production variants of balenaOS](../../reference/os/overview.md#development-vs.-production-mode) perform authentication against public SSH keys previously added to the device's `config.json` file, [sshKeys section](../../reference/os/configuration.md#sshkeys). When the username matches a valid balenaCloud user account, authentication is also performed against that user's public SSH keys [stored in balenaCloud](ssh-access.md#add-an-ssh-key-to-balenacloud). The username can be found in the profile or preferences section of the web dashboard, or with the balena whoami\` CLI command.
 
 Development variants of balenaOS allow unauthenticated access and should never be directly exposed to the public internet.
 
@@ -174,7 +168,7 @@ $ dmesg | tail -n 100
 
 #### Monitor balenaEngine
 
-beginning with version 2.9.0, balenaOS includes the lightweight container engine [**balenaEngine**](https://www.balena.io/engine) to manage **Docker** containers. If you think the supervisor or application container may be having problems, you’ll want to use `balena` for debugging.
+BalenaOS includes the lightweight container engine [**balenaEngine**](https://www.balena.io/engine) to manage **Docker** containers. If you think the supervisor or application container may be having problems, you’ll want to use `balena` for debugging.
 
 From the host OS this command will show the status of all containers:
 
@@ -187,10 +181,6 @@ You can also check the **journalctl** logs for messages related to the balenaEng
 ```shell
 $ journalctl --follow -n 100 -u balena
 ```
-
-{% hint style="warning" %}
-For devices with balenaOS versions earlier than 2.9.0, you can replace `balena` in these commands with `docker`.
-{% endhint %}
 
 #### Inspect network settings
 

--- a/pages/reference/os/advanced.md
+++ b/pages/reference/os/advanced.md
@@ -82,7 +82,7 @@ For further information on UART device tree overlays, see the [Raspberry Pi docu
 
 The Raspberry Pi allows loading [custom device tree overlays](https://github.com/raspberrypi/linux/blob/rpi-4.19.y/arch/arm/boot/dts/overlays/README) using the `dtoverlay` setting in `config.txt`. It also allows setting parameters for the default overlay with the `dtparam` setting. For these settings, the syntax is different from other keys because several entries can be added, and the bootloader will use all of them.
 
-To allow setting several values, devices running balenaOS version >= 2.12.0 (supervisor >= 7.0.0), will parse the values of `BALENA_HOST_CONFIG_dtoverlay` and `BALENA_HOST_CONFIG_dtparam` in a special way where the value of the configuration variable will be treated as the contents of a JSON array (without the enclosing braces `[]`), so a comma-separated list of quote-enclosed values (straight quotes, not curly) will be split into several lines.
+To allow setting several values, devices will parse the values of `BALENA_HOST_CONFIG_dtoverlay` and `BALENA_HOST_CONFIG_dtparam` in a special way where the value of the configuration variable will be treated as the contents of a JSON array (without the enclosing braces `[]`), so a comma-separated list of quote-enclosed values (straight quotes, not curly) will be split into several lines.
 
 For example, the default value of `BALENA_HOST_CONFIG_dtparam = "i2c_arm=on","spi=on","audio=on"` will translate into the following entries in config.txt:
 

--- a/pages/reference/os/overview.md
+++ b/pages/reference/os/overview.md
@@ -12,7 +12,7 @@ The core insight behind balenaOS is that Linux containers offer, for the first t
 
 BalenaOS is an operating system built for easy portability to multiple device types (via the [Yocto framework](https://www.yoctoproject.org/) and optimized for Linux containers, and Docker in particular. There are many decisions, large and small, we have made to enable that vision, which are present throughout our architecture.
 
-The first version of balenaOS was developed as part of the balena platform, and has run on thousands of embedded devices on balena, deployed in many different contexts for several years. balenaOS v2 represents the combination of the learnings we extracted over those years, as well as our determination to make balenaOS a first-class open source project, able to run as an independent operating system, for any context where embedded devices and containers intersect.
+The first version of balenaOS was developed as part of the balena platform, and has run on thousands of embedded devices on balena, deployed in many different contexts for several years. balenaOS v2 and later versions represent the combination of the learnings we extracted over those years, as well as our determination to make balenaOS a first-class open source project, able to run as an independent operating system, for any context where embedded devices and containers intersect.
 
 We look forward to working with the community to grow and mature balenaOS into an operating system with even broader device support, a broader operating envelope, and as always, taking advantage of the most modern developments in security and reliability.
 
@@ -41,7 +41,7 @@ Production mode disables passwordless root access, and an SSH key must be [added
 
 In balenaOS, logs are written to an 8 MB journald RAM buffer in order to avoid wear on the flash storage used by most of the supported boards.
 
-To persist logs on the device, enable persistent logging via the [configuration](../../learn/manage/configuration.md#fleet-configuration-management) tab in the balenaCloud dashboard, or prior to device provisioning setting the `"persistentLogging": true` [key](configuration.md#persistentlogging) in `config.json`. The logs can be accessed via the host OS at `/var/log/journal`. For versions of balenaOS < 2.45.0, persistent logs are limited to 8 MB and stored in the state partition of the device. BalenaOS versions >= 2.45.0 store a maximum of 32 MB of persistent logs in the data partition of the device.
+To persist logs on the device, enable persistent logging via the [configuration](../../learn/manage/configuration.md#fleet-configuration-management) tab in the balenaCloud dashboard, or prior to device provisioning setting the `"persistentLogging": true` [key](configuration.md#persistentlogging) in `config.json`. The logs can be accessed via the host OS at `/var/log/journal`. BalenaOS stores a maximum of 32 MB of persistent logs in the data partition of the device.
 
 ### Hostname
 
@@ -97,10 +97,6 @@ In order to improve the [development experience](../../learn/develop/local-mode.
 
 ### chrony
 
-{% hint style="info" %}
-BalenaOS versions less than v2.13.0 used systemd-timesyncd for time management.
-{% endhint %}
-
 [chrony](https://en.wikipedia.org/wiki/Chrony) is used by balenaOS to keep the system time synchronized.
 
 ### OpenVPN
@@ -108,10 +104,6 @@ BalenaOS versions less than v2.13.0 used systemd-timesyncd for time management.
 [OpenVPN](https://community.openvpn.net/openvpn) is used as the VPN service by balenaOS, which connects to cloudlink, allowing a device to be connected to remotely and enabling remote SSH access.
 
 ### OpenSSH
-
-{% hint style="info" %}
-BalenaOS versions < v2.38.0 use [dropbear](https://matt.ucc.asn.au/dropbear/dropbear.html) as the SSH server and client
-{% endhint %}
 
 [OpenSSH](https://www.openssh.com/) is used in balenaOS as the SSH server and client allowing remote login using the SSH protocol.
 
@@ -142,10 +134,6 @@ A diagram of our read-only rootfs can be seen below:
 ## BalenaOS Yocto Composition
 
 BalenaOS is composed of multiple [Yocto](https://www.yoctoproject.org/) layers. The Yocto Project build system uses these layers to compile balenaOS for the various [supported devices](../hardware/devices.md). Below is an example from the [Raspberry Pi family](https://github.com/balena-os/balena-raspberrypi/blob/master/layers/meta-balena-raspberrypi/conf/samples/bblayers.conf.sample).
-
-{% hint style="info" %}
-Instructions for building your own version of balenaOS are available [here](https://www.balena.io/os/docs/custom-build/#Bake-your-own-Image).
-{% endhint %}
 
 | Layer Name                                 | Repository                                                                                                                                                                               | Description                                                               |
 | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |

--- a/pages/reference/os/time.md
+++ b/pages/reference/os/time.md
@@ -5,11 +5,7 @@ excerpt: How time is synchronized and managed for balena devices
 
 # Time management
 
-{% hint style="warning" %}
-Starting from balenaOS 2.13.1 the `chrony` service is used for time management. Prior versions of balenaOS use `systemd-timesyncd`.
-{% endhint %}
-
-Devices running balenaOS make use of the `chrony` (or `systemd-timesyncd`) service to keep the system time synchronized. That service is running in the host OS, independent of the application containers.
+Devices running balenaOS make use of the `chrony` service to keep the system time synchronized. That service is running in the host OS, independent of the application containers.
 
 It is important that the date and time are set correctly, as an inaccurate date can manifest itself as several different issues on the device, such as SSL/TLS certificates appearing invalid. If you want to query the current time on the device, you can do so by using the `date` utility or the datetime related functions of the standard library of your language.
 
@@ -41,16 +37,6 @@ The estimated drift of the system clock is saved to a driftfile located at `/var
 * `chronyc sources` - A list of all the current NTP sources being used by the NTP daemon, which will also indicate if they are reachable.
 * `chronyc tracking` - Information about the system clock itself, including skew.
 * `chronyc ntpdata` - Detailed information on all the current NTP sources.
-
-## systemd-timesyncd
-
-{% hint style="info" %}
-This section is only applicable to balenaOS versions < 2.13.1.
-{% endhint %}
-
-When the balena device boots up, and before any container is run, the system will query the hardware clock to get the current time, while it will also read the timestamp value, stored in the last modification time of a special file, `/var/lib/systemd/clock`. If the hardware clock is behind the value stored with `/var/lib/systemd/clock`, the system will forcefully set the clock to the stored value. This is done to ensure that time from the point of view of the applications is monotonically increasing. After that, the device will start its Network Time Protocol (NTP) client, which will be attempting to sync the clock with NTP servers periodically. If a successful synchronization occurs, the last modification time of `/var/lib/systemd/clock` is updated to that timestamp.
-
-When you first provision a device, as a fallback, `/var/lib/systemd/clock` is set to the timestamp of the host OS build (or more precisely, the timestamp of the systemd build within the host OS). For more info, you can check the [`systemd-timesyncd` documentation](https://www.freedesktop.org/software/systemd/man/systemd-timesyncd.service.html) and the [timesyncd source code](https://github.com/systemd/systemd/blob/master/src/timesync/timesyncd.c).
 
 ## Networking Requirements
 

--- a/pages/reference/os/updates/self-service.md
+++ b/pages/reference/os/updates/self-service.md
@@ -7,10 +7,10 @@ excerpt: How to update balenaOS versions from your dashboard
 
 ## Which devices and versions are supported?
 
-Since we periodically release updates and improvements to balenaOS (the host OS running on all balena devices), we encourage you to keep your devices up to date. We offer self-service host OS updates between 2.x versions and from 1.x to 2.x versions. All 2.x devices will default to delta-based updates if available, thus reducing the size of the update sent over the network.
+Since we periodically release updates and improvements to balenaOS (the host OS running on all balena devices), we encourage you to keep your devices up to date. Self-service host OS updates are available for all devices over v2.51. Devices will default to delta-based updates if available, thus reducing the size of the update sent over the network.
 
 {% hint style="warning" %}
-BalenaOS 1.x to 2.x updates limit the amount of data you can have in your application's `/data` folder to about 170MB (compressed). If you have more data, the update will fail and your device won't be modified.
+BalenaOS 2.x updates limit the amount of data you can have in your application's `/data` folder to about 170MB (compressed). If you have more data, the update will fail and your device won't be modified.
 {% endhint %}
 
 Self-service updates are available for both `production` and `development` balenaOS variants.

--- a/pages/reference/supervisor/configuration-list/asus-tinker-edge-t.md
+++ b/pages/reference/supervisor/configuration-list/asus-tinker-edge-t.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/beaglebone-ai64.md
+++ b/pages/reference/supervisor/configuration-list/beaglebone-ai64.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/beaglebone-black.md
+++ b/pages/reference/supervisor/configuration-list/beaglebone-black.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/cl-som-imx8.md
+++ b/pages/reference/supervisor/configuration-list/cl-som-imx8.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/coral-dev.md
+++ b/pages/reference/supervisor/configuration-list/coral-dev.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/eg5120-imx8mp.md
+++ b/pages/reference/supervisor/configuration-list/eg5120-imx8mp.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/forecr-dsb-ornx-orin-nano-8gb.md
+++ b/pages/reference/supervisor/configuration-list/forecr-dsb-ornx-orin-nano-8gb.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/generic-aarch64.md
+++ b/pages/reference/supervisor/configuration-list/generic-aarch64.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/generic-amd64.md
+++ b/pages/reference/supervisor/configuration-list/generic-amd64.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/genericx86-64-ext.md
+++ b/pages/reference/supervisor/configuration-list/genericx86-64-ext.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/imx8m-var-dart.md
+++ b/pages/reference/supervisor/configuration-list/imx8m-var-dart.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/imx8mm-lpddr4-evk.md
+++ b/pages/reference/supervisor/configuration-list/imx8mm-lpddr4-evk.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/imx8mm-var-dart.md
+++ b/pages/reference/supervisor/configuration-list/imx8mm-var-dart.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/imx8mm-var-som.md
+++ b/pages/reference/supervisor/configuration-list/imx8mm-var-som.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/intel-nuc.md
+++ b/pages/reference/supervisor/configuration-list/intel-nuc.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/iot-gate-imx8.md
+++ b/pages/reference/supervisor/configuration-list/iot-gate-imx8.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/iot-gate-imx8plus-d1d8.md
+++ b/pages/reference/supervisor/configuration-list/iot-gate-imx8plus-d1d8.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/iot-gate-imx8plus.md
+++ b/pages/reference/supervisor/configuration-list/iot-gate-imx8plus.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/iotdin-imx8p-d1d8.md
+++ b/pages/reference/supervisor/configuration-list/iotdin-imx8p-d1d8.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/iotdin-imx8p.md
+++ b/pages/reference/supervisor/configuration-list/iotdin-imx8p.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/isg-503.md
+++ b/pages/reference/supervisor/configuration-list/isg-503.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/jetson-agx-orin-devkit-64gb.md
+++ b/pages/reference/supervisor/configuration-list/jetson-agx-orin-devkit-64gb.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/jetson-agx-orin-devkit.md
+++ b/pages/reference/supervisor/configuration-list/jetson-agx-orin-devkit.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/jetson-nano-2gb-devkit.md
+++ b/pages/reference/supervisor/configuration-list/jetson-nano-2gb-devkit.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/jetson-nano-emmc.md
+++ b/pages/reference/supervisor/configuration-list/jetson-nano-emmc.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/jetson-nano.md
+++ b/pages/reference/supervisor/configuration-list/jetson-nano.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/jetson-orin-nano-devkit-nvme.md
+++ b/pages/reference/supervisor/configuration-list/jetson-orin-nano-devkit-nvme.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/jetson-orin-nano-seeed-j3010.md
+++ b/pages/reference/supervisor/configuration-list/jetson-orin-nano-seeed-j3010.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/jetson-orin-nx-seeed-j4012.md
+++ b/pages/reference/supervisor/configuration-list/jetson-orin-nx-seeed-j4012.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/jetson-orin-nx-xavier-nx-devkit.md
+++ b/pages/reference/supervisor/configuration-list/jetson-orin-nx-xavier-nx-devkit.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/jetson-tx2-nx-devkit.md
+++ b/pages/reference/supervisor/configuration-list/jetson-tx2-nx-devkit.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/jetson-tx2.md
+++ b/pages/reference/supervisor/configuration-list/jetson-tx2.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/jetson-xavier-nx-devkit-emmc.md
+++ b/pages/reference/supervisor/configuration-list/jetson-xavier-nx-devkit-emmc.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/jetson-xavier-nx-devkit.md
+++ b/pages/reference/supervisor/configuration-list/jetson-xavier-nx-devkit.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/jetson-xavier.md
+++ b/pages/reference/supervisor/configuration-list/jetson-xavier.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/jn30b-nano.md
+++ b/pages/reference/supervisor/configuration-list/jn30b-nano.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/kontron-mx8mm.md
+++ b/pages/reference/supervisor/configuration-list/kontron-mx8mm.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/nanopi-r2s.md
+++ b/pages/reference/supervisor/configuration-list/nanopi-r2s.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/nitrogen8mm.md
+++ b/pages/reference/supervisor/configuration-list/nitrogen8mm.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/owa5x.md
+++ b/pages/reference/supervisor/configuration-list/owa5x.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/phyboard-lyra-am62xx-2.md
+++ b/pages/reference/supervisor/configuration-list/phyboard-lyra-am62xx-2.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/raspberry-pi.md
+++ b/pages/reference/supervisor/configuration-list/raspberry-pi.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/raspberry-pi2.md
+++ b/pages/reference/supervisor/configuration-list/raspberry-pi2.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/raspberrypi0-2w-64.md
+++ b/pages/reference/supervisor/configuration-list/raspberrypi0-2w-64.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/raspberrypi3-64.md
+++ b/pages/reference/supervisor/configuration-list/raspberrypi3-64.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/raspberrypi3.md
+++ b/pages/reference/supervisor/configuration-list/raspberrypi3.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/raspberrypi4-64.md
+++ b/pages/reference/supervisor/configuration-list/raspberrypi4-64.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/raspberrypi4-unipi-neuron.md
+++ b/pages/reference/supervisor/configuration-list/raspberrypi4-unipi-neuron.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/raspberrypi5.md
+++ b/pages/reference/supervisor/configuration-list/raspberrypi5.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/raspberrypicm4-ioboard.md
+++ b/pages/reference/supervisor/configuration-list/raspberrypicm4-ioboard.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/revpi-connect-4.md
+++ b/pages/reference/supervisor/configuration-list/revpi-connect-4.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/revpi-connect-s.md
+++ b/pages/reference/supervisor/configuration-list/revpi-connect-s.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/rockpi-4b-rk3399.md
+++ b/pages/reference/supervisor/configuration-list/rockpi-4b-rk3399.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/ucm-imx93.md
+++ b/pages/reference/supervisor/configuration-list/ucm-imx93.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/up-board.md
+++ b/pages/reference/supervisor/configuration-list/up-board.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/configuration-list/var-som-mx6.md
+++ b/pages/reference/supervisor/configuration-list/var-som-mx6.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/pages/reference/supervisor/docker-compose.md
+++ b/pages/reference/supervisor/docker-compose.md
@@ -110,9 +110,13 @@ It's recommended to only give that level of access to containers that have a sin
 i.e. balena-socket, dbus, sysfs, procfs, kernel-modules, firmware, extra-firmware, and supervisor-api can be used to completely take over a device.
 {% endhint %}
 
-{% include "../../.gitbook/includes/labels-version-note.md" %}
+Labels are considered _dangerous_ if they break container isolation and can lead to a full device take-over if a container is compromised.
 
-| Label                             | Default            | Dangerous (*)        | Description                                                                                                                                                                                                                                                                | Supervisor | balenaOS\  |
+{% hint style="info" %}
+You can find which supervisor ships with which balenaOS versions in the [balenaOS Changelog](https://github.com/balena-os/meta-balena/blob/master/CHANGELOG.md).
+{% endhint %}
+
+| Label                             | Default            | Dangerous            | Description                                                                                                                                                                                                                                                                | Supervisor | balenaOS   |
 | --------------------------------- | ------------------ | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ---------- |
 | io.balena.features.balena-socket  | false              | dangerous            | Bind mounts the balena container engine socket into the container and sets the environment variable `DOCKER_HOST` with the socket location for use by docker clients.                                                                                                      | v7.23.0    | v2.21.0    |
 | io.balena.features.dbus           | false              | dangerous            | Bind mounts the host OS dbus into the container using `/run/dbus:/host/run/dbus`.                                                                                                                                                                                          | v7.23.0    | v2.21.0    |
@@ -126,10 +130,6 @@ i.e. balena-socket, dbus, sysfs, procfs, kernel-modules, firmware, extra-firmwar
 | io.balena.features.balena-api     | false              | dangerous            | When enabled, it will make sure that `BALENA_API_KEY` is added to the container environment variables.                                                                                                                                                                     | v7.23.0    | v2.21.0    |
 | io.balena.update.strategy         | download-then-kill |                      | Set the fleet update strategy.                                                                                                                                                                                                                                             | v7.23.0    | v2.21.0    |
 | io.balena.update.handover-timeout | 60000              |                      | Time, in milliseconds, before an old container is automatically killed. Only used with the `hand-over` update strategy.                                                                                                                                                    | v7.23.0    | v2.21.0    |
-
-Labels are considered _dangerous_ if they breaks container isolation and can lead to a full device take-over on container is compromised.
-
-\* balenaOS versions that ship with a compatible device supervisor version as per [balenaOS Changelog](https://github.com/balena-os/meta-balena/blob/master/CHANGELOG.md).
 
 
 These labels are applied to a specific service with the `labels:` setting:

--- a/pages/reference/supervisor/supervisor-upgrades.md
+++ b/pages/reference/supervisor/supervisor-upgrades.md
@@ -23,10 +23,6 @@ From the dialog box that opens, select the Supervisor version you would like to 
 
 Additionally, these updates can be scheduled for an offline device as well. The update will be performed once the device comes back online and successfully connects to the balenaCloud backend.
 
-{% hint style="warning" %}
-Only devices running balenaOS v2.12.0 or greater are able to upgrade the Supervisor independently.
-{% endhint %}
-
 ## Upgrade paths
 
 Downgrades of the Supervisor are not supported.

--- a/templates/config-list.md
+++ b/templates/config-list.md
@@ -1,5 +1,5 @@
-The list contains configuration and their respective variables that can be used with balena devices. Some of which will
-automatically appear for devices with supervisor v7.0.0 and greater. While they may not automatically populate in the
+The list contains configuration and their respective variables that can be used with balena devices. Some of these will
+automatically appear for devices. While they may not automatically populate in the
 Configuration dashboard, most of these variables can still be used with older supervisor versions, so be sure to check
 the *Supported by* context for each configuration.
 

--- a/templates/troubleshooting/raspberry-pi.md
+++ b/templates/troubleshooting/raspberry-pi.md
@@ -23,7 +23,7 @@ If the Raspberry Pi is unable to connect to the balena servers, the `ACT` LED wi
 
 This is either because it is not connected to the network or because the network ports which balena relies on are blocked in some way.
 
-- The first things to check in this case is that your device is correctly connected to ethernet or that you correctly entered the wifi credentials. To check wifi credentials, power your device down, remove the SD card, and mount the SD card on your personal computer. If your device is running balenaOS version 2.0 or greater, wifi credentials are listed in `system-connections/resin-wifi`, found in the `resin-boot` partition of the SD card. Otherwise, check the `config.json` file (in the `resin-boot` partition for versions 1.2 and greater, or `resin-conf` for earlier versions).
+- The first things to check in this case is that your device is correctly connected to ethernet or that you correctly entered the wifi credentials. To check wifi credentials, power your device down, remove the SD card, and mount the SD card on your personal computer. Wifi credentials are listed in `system-connections/resin-wifi`, found in the `resin-boot` partition of the SD card.
 - Secondly check that your network is not restricting or blocking the ports specified in the [balena network requirements](../../reference/os/network.md#network-requirements).
 - If you still aren't able to get your device online, reach out to us in the [forums](https://forums.balena.io).
 

--- a/templates/troubleshooting/raspberry-pi2.md
+++ b/templates/troubleshooting/raspberry-pi2.md
@@ -23,7 +23,7 @@ If the Raspberry Pi is unable to connect to the balena servers, the `ACT` LED wi
 
 This is either because it is not connected to the network or because the network ports which balena relies on are blocked in some way.
 
-- The first things to check in this case is that your device is correctly connected to ethernet or that you correctly entered the wifi credentials. To check wifi credentials, power your device down, remove the SD card, and mount the SD card on your personal computer. If your device is running balenaOS version 2.0 or greater, wifi credentials are listed in `system-connections/resin-wifi`, found in the `resin-boot` partition of the SD card. Otherwise, check the `config.json` file (in the `resin-boot` partition for versions 1.2 and greater, or `resin-conf` for earlier versions).
+- The first things to check in this case is that your device is correctly connected to ethernet or that you correctly entered the wifi credentials. To check wifi credentials, power your device down, remove the SD card, and mount the SD card on your personal computer. Wifi credentials are listed in `system-connections/resin-wifi`, found in the `resin-boot` partition of the SD card.
 - Secondly check that your network is not restricting or blocking the ports specified in the [balena network requirements](../../reference/os/network.md#network-requirements).
 - If you still aren't able to get your device online, reach out to us in the [forums](https://forums.balena.io).
 

--- a/templates/troubleshooting/raspberrypi0-2w-64.md
+++ b/templates/troubleshooting/raspberrypi0-2w-64.md
@@ -23,7 +23,7 @@ If the Raspberry Pi is unable to connect to the balena servers, the `ACT` LED wi
 
 This is either because it is not connected to the network or because the network ports which balena relies on are blocked in some way.
 
-- The first things to check in this case is that your device is correctly connected to ethernet or that you correctly entered the wifi credentials. To check wifi credentials, power your device down, remove the SD card, and mount the SD card on your personal computer. If your device is running balenaOS version 2.0 or greater, wifi credentials are listed in `system-connections/resin-wifi`, found in the `resin-boot` partition of the SD card. Otherwise, check the `config.json` file (in the `resin-boot` partition for versions 1.2 and greater, or `resin-conf` for earlier versions).
+- The first things to check in this case is that your device is correctly connected to ethernet or that you correctly entered the wifi credentials. To check wifi credentials, power your device down, remove the SD card, and mount the SD card on your personal computer. Wifi credentials are listed in `system-connections/resin-wifi`, found in the `resin-boot` partition of the SD card.
 - Secondly check that your network is not restricting or blocking the ports specified in the [balena network requirements](../../reference/os/network.md#network-requirements).
 - If you still aren't able to get your device online, reach out to us in the [forums](https://forums.balena.io).
 

--- a/templates/troubleshooting/raspberrypi3-64.md
+++ b/templates/troubleshooting/raspberrypi3-64.md
@@ -28,7 +28,7 @@ If the Raspberry Pi is unable to connect to the balena servers, the `ACT` LED wi
 
 This is either because it is not connected to the network or because the network ports which balena relies on are blocked in some way.
 
-- The first things to check in this case is that your device is correctly connected to ethernet or that you correctly entered the wifi credentials. To check wifi credentials, power your device down, remove the SD card, and mount the SD card on your personal computer. If your device is running balenaOS version 2.0 or greater, wifi credentials are listed in `system-connections/resin-wifi`, found in the `resin-boot` partition of the SD card. Otherwise, check the `config.json` file (in the `resin-boot` partition for versions 1.2 and greater, or `resin-conf` for earlier versions).
+- The first things to check in this case is that your device is correctly connected to ethernet or that you correctly entered the wifi credentials. To check wifi credentials, power your device down, remove the SD card, and mount the SD card on your personal computer. Wifi credentials are listed in `system-connections/resin-wifi`, found in the `resin-boot` partition of the SD card.
 - Secondly check that your network is not restricting or blocking the ports specified in the [balena network requirements](../../reference/os/network.md#network-requirements).
 - If you still aren't able to get your device online, reach out to us in the [forums](https://forums.balena.io).
 

--- a/templates/troubleshooting/raspberrypi3.md
+++ b/templates/troubleshooting/raspberrypi3.md
@@ -28,7 +28,7 @@ If the Raspberry Pi is unable to connect to the balena servers, the `ACT` LED wi
 
 This is either because it is not connected to the network or because the network ports which balena relies on are blocked in some way.
 
-- The first things to check in this case is that your device is correctly connected to ethernet or that you correctly entered the wifi credentials. To check wifi credentials, power your device down, remove the SD card, and mount the SD card on your personal computer. If your device is running balenaOS version 2.0 or greater, wifi credentials are listed in `system-connections/resin-wifi`, found in the `resin-boot` partition of the SD card. Otherwise, check the `config.json` file (in the `resin-boot` partition for versions 1.2 and greater, or `resin-conf` for earlier versions).
+- The first things to check in this case is that your device is correctly connected to ethernet or that you correctly entered the wifi credentials. To check wifi credentials, power your device down, remove the SD card, and mount the SD card on your personal computer. Wifi credentials are listed in `system-connections/resin-wifi`, found in the `resin-boot` partition of the SD card.
 - Secondly check that your network is not restricting or blocking the ports specified in the [balena network requirements](../../reference/os/network.md#network-requirements).
 - If you still aren't able to get your device online, reach out to us in the [forums](https://forums.balena.io).
 

--- a/templates/troubleshooting/raspberrypi4-64.md
+++ b/templates/troubleshooting/raspberrypi4-64.md
@@ -23,7 +23,7 @@ If the Raspberry Pi is unable to connect to the balena servers, the `ACT` LED wi
 
 This is either because it is not connected to the network or because the network ports which balena relies on are blocked in some way.
 
-- The first things to check in this case is that your device is correctly connected to ethernet or that you correctly entered the wifi credentials. To check wifi credentials, power your device down, remove the SD card, and mount the SD card on your personal computer. If your device is running balenaOS version 2.0 or greater, wifi credentials are listed in `system-connections/resin-wifi`, found in the `resin-boot` partition of the SD card. Otherwise, check the `config.json` file (in the `resin-boot` partition for versions 1.2 and greater, or `resin-conf` for earlier versions).
+- The first things to check in this case is that your device is correctly connected to ethernet or that you correctly entered the wifi credentials. To check wifi credentials, power your device down, remove the SD card, and mount the SD card on your personal computer. Wifi credentials are listed in `system-connections/resin-wifi`, found in the `resin-boot` partition of the SD card.
 - Secondly check that your network is not restricting or blocking the ports specified in the [balena network requirements](../../reference/os/network.md#network-requirements).
 - If you still aren't able to get your device online, reach out to us in the [forums](https://forums.balena.io).
 


### PR DESCRIPTION
Change-type: patch
Fibery: https://balena.fibery.io/Work/Project/Docs-Remove-references-to-EOL-OS-and-supervisor-versions-2519

---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
