### PR TITLE
Update link-checker workflow

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -3,17 +3,26 @@ name: link checker
 on:
   # Run workflow to be triggered manually
   workflow_dispatch:
+    inputs:
+      deployment_url:
+        type: string
+        description: 'Deployment URL'
+        required: false
+        default: 'https://docs.balena.io'
   # Check links once a week on Monday
   schedule:
-    - cron: "00 00 * * 1"
+    - cron: '00 00 * * 1'
   # Allow workflow to be called by other workflows
   workflow_call:
     inputs:
       deployment_url:
         type: string
-        description: "Deployment URL"
+        description: 'Deployment URL'
         required: false
-        default: "https://docs.balena.io"
+        default: 'https://docs.balena.io'
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -26,23 +35,13 @@ jobs:
   Checking-Links:
     runs-on: ubuntu-latest
     steps:
-      # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      # fetch external files && Building the docs
-      - name: Build the docs
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 24
-
-      - run: npm run deploy-docs
-
       - name: Restore lychee cache
         id: restore-cache
-        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .lycheecache
@@ -50,14 +49,14 @@ jobs:
           restore-keys: cache-lychee-
 
       # Run link checker on the generated HTML
-      - name: Link Checker
+      - name: Run Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@2b973e86fc7b1f6b36a93795fe2c9c6ae1118621 # v1.10.0
         with:
           args: >
-            --base ${{ inputs.deployment_url }}
+            --base ${{ inputs.deployment_url || 'https://docs.balena.io' }}
             --config ./lychee.toml
-            build/**/*
+            pages/**/*
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Issue From File

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -3,23 +3,11 @@ name: link checker
 on:
   # Run workflow to be triggered manually
   workflow_dispatch:
-    inputs:
-      deployment_url:
-        type: string
-        description: 'Deployment URL'
-        required: false
-        default: 'https://docs.balena.io'
   # Check links once a week on Monday
   schedule:
     - cron: '00 00 * * 1'
   # Allow workflow to be called by other workflows
   workflow_call:
-    inputs:
-      deployment_url:
-        type: string
-        description: 'Deployment URL'
-        required: false
-        default: 'https://docs.balena.io'
   pull_request:
     branches:
       - main
@@ -54,7 +42,6 @@ jobs:
         uses: lycheeverse/lychee-action@2b973e86fc7b1f6b36a93795fe2c9c6ae1118621 # v1.10.0
         with:
           args: >
-            --base ${{ inputs.deployment_url || 'https://docs.balena.io' }}
             --config ./lychee.toml
             pages/**/*
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/lychee.toml
+++ b/lychee.toml
@@ -119,10 +119,12 @@ exclude = [
     "https://github.com/balena-io/docs/issues/new?*",
     "https://api/",
     "https://raw.githubusercontent.com/balena-os/meta-balena/$%7Bos_version_tag%7D/meta-balena-common/recipes-containers/balena-supervisor/balena-supervisor.inc",
+    ".gitbook/assets/",
+    "^[^http]"
     ]
 
 # Exclude these filesystem paths from getting checked.
-exclude_path = ["./build/img/", "./build/css/", "./build/favicon.png", "./build/dist/", "./node_modules"]
+exclude_path = []
 
 # Already mentioned in the GitHub action to include paths to check links
 include = []


### PR DESCRIPTION
- Removed 'deploy-docs' step
- Add missing input from workflow dispatch trigger
- Removed 'setup-node' step
- Fixed base path to ./pages
- Removed conditions from cache-save step
- Update lychee exclude paths
- Add pull request target
