### PR TITLE
Move update-locking docs directly into docs

### DIFF
--- a/external-docs.json
+++ b/external-docs.json
@@ -29,10 +29,6 @@
       "ref": "v17.8.2",
       "files": [
         {
-          "source": "docs/update-locking.md",
-          "target": "pages/external-docs/update-locking.md"
-        },
-        {
           "source": "docs/API.md",
           "target": "pages/external-docs/supervisor-api.md"
         },

--- a/pages/SUMMARY.md
+++ b/pages/SUMMARY.md
@@ -95,7 +95,7 @@
   * [Deploy to your Fleet](learn/deploy/deployment.md)
   * [Release strategy](learn/deploy/release-strategy/README.md)
     * [Release policy](learn/deploy/release-strategy/release-policy.md)
-    * [Update locks](external-docs/update-locking.md)
+    * [Update locks](learn/deploy/release-strategy/update-locking.md)
     * [Controlling the update strategy](learn/deploy/release-strategy/update-strategies.md)
   * [Delta updates](learn/deploy/delta.md)
   * [Offline Updates](learn/deploy/offline-updates.md)

--- a/pages/learn/deploy/release-strategy/update-locking.md
+++ b/pages/learn/deploy/release-strategy/update-locking.md
@@ -66,17 +66,17 @@ Using the [`lockfile` library](https://www.npmjs.com/package/lockfile), the lock
 import lockFile from 'lockfile';
 
 lockFile.lock('/tmp/balena/updates.lock', function(err) {
-	// A non-null err probably means the Supervisor is about to kill us
-	if (err != null) { throw new Error('Could not acquire lock: ', err); }
+    // A non-null err probably means the Supervisor is about to kill us
+    if (err != null) { throw new Error('Could not acquire lock: ', err); }
 
-	// Here we have the lock, so we can do critical stuff:
-	doTheHarlemShake();
+    // Here we have the lock, so we can do critical stuff:
+    doTheHarlemShake();
 
-	// Now we release the lock, and we can be killed again
-	return lockFile.unlock('/tmp/balena/updates.lock', function(err) {
-		// If err is not null here, something went really wrong
-		if (err != null) { throw err; }
-	});
+    // Now we release the lock, and we can be killed again
+    return lockFile.unlock('/tmp/balena/updates.lock', function(err) {
+        // If err is not null here, something went really wrong
+        if (err != null) { throw err; }
+    });
 });
 ```
 
@@ -95,8 +95,8 @@ Check the link for more examples and other Python libraries that provide locking
 
 The update lock can be overridden in case you need to force an update, for instance, if your app has hung in a critical section.
 
-The recommended way to do this is to use the 'Override the update lock ...' toggle in the [Fleet or Device Configuration](https://docs.balena.io/learn/manage/configuration/#managing-device-configuration-variables) page. Go to the configuration page of the device or fleet, locate the 'Override the update lock ...' item from the list, click the activate button, and set the toggle to enabled. After disabling the toggle, update locks may be set again and will be respected.
+The recommended way to do this is to use the 'Override the update lock ...' toggle in the [Fleet or Device Configuration](../../manage/configuration/#managing-device-configuration-variables) page. Go to the configuration page of the device or fleet, locate the 'Override the update lock ...' item from the list, click the activate button, and set the toggle to enabled. After disabling the toggle, update locks may be set again and will be respected.
 
-Also, you can programatically override locks one time by querying the `/v1/update` endpoint of the [Supervisor HTTP API](https://docs.balena.io/reference/supervisor/supervisor-api), with `{ "force": true }` as body. Note that this will not set the lock override config var.
+Also, you can programatically override locks one time by querying the `/v1/update` endpoint of the [Supervisor HTTP API](../../../reference/supervisor/supervisor-api), with `{ "force": true }` as body. Note that this will not set the lock override config var.
 
 Please note that setting the override is a one-time action. Locks set previously are deleted upon setting the config var, and will need to be recreated.


### PR DESCRIPTION
Change-type: patch
Connects-to: https://github.com/balena-os/balena-supervisor/pull/2521
Fibery: https://balena.fibery.io/Work/Project/Move-non-reference-external-docs-directly-into-the-docs-2487
Fibery: https://balena.fibery.io/Work/Improvement/Review-all-automations-with-a-focus-on-reducing-their-number-3933

---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
