### PR TITLE
Move customer board support docs directly to docs

### DIFF
--- a/external-docs.json
+++ b/external-docs.json
@@ -45,10 +45,6 @@
           "target": "pages/external-docs/rollbacks.md"
         },
         {
-          "source": "contributing-device-support.md",
-          "target": "pages/external-docs/customer-board-support.md"
-        },
-        {
           "source": "docs/debugging-balenaos.md",
           "target": "pages/.gitbook/includes/journal-logs.md",
           "transform": {

--- a/pages/SUMMARY.md
+++ b/pages/SUMMARY.md
@@ -222,7 +222,7 @@
   * [Configuring balenaOS](reference/os/configuration.md)
   * [Time management](reference/os/time.md)
   * [Advanced boot settings](reference/os/advanced.md)
-  * [Customer Board Support](external-docs/customer-board-support.md)
+  * [Customer Board Support](reference/os/customer-board-support.md)
   * [Secure Boot and Full Disk Encryption](reference/os/secure-boot-and-full-disk-encryption/README.md)
     * [Overview](reference/os/secure-boot-and-full-disk-encryption/overview.md)
     * [Setup guides](reference/os/secure-boot-and-full-disk-encryption/setup-guides/README.md)

--- a/pages/faq/questions.md
+++ b/pages/faq/questions.md
@@ -111,7 +111,7 @@ Please contact sales@balena.io with any questions regarding continued device sup
 
 ### **I have a device that is not on the supported devices list. Can it run on balena?**
 
-There are a few options for devices that do not have an official device type on balena. If your device has an x86 architecture, you can try either the [Intel NUC](../learn/getting-started/intel-nuc.md) image (which is built to support generic x86 devices with a minimum set of drivers), or the generic genericx86-64 image (that includes all the standard X86 drivers). For other devices, you can [build your own](https://github.com/balena-os/meta-balena/blob/master/contributing-device-support.md) version of balenaOS using our [open source repos](https://github.com/balena-os). To discuss custom board support, please contact sales@balena.io.
+There are a few options for devices that do not have an official device type on balena. If your device has an x86 architecture, you can try either the [Intel NUC](../learn/getting-started/intel-nuc.md) image (which is built to support generic x86 devices with a minimum set of drivers), or the generic genericx86-64 image (that includes all the standard X86 drivers). For other devices, you can [build your own](../reference/os/customer-board-support.md) version of balenaOS using our [open source repos](https://github.com/balena-os). To discuss custom board support, please contact sales@balena.io.
 
 ### **What to keep in mind when choosing power supply units?**
 

--- a/pages/reference/os/customer-board-support.md
+++ b/pages/reference/os/customer-board-support.md
@@ -2,8 +2,9 @@
 
 We can support your hardware in two ways:
 
-1. **Check for existing support** – See if your board is already listed on our [supported devices list](https://docs.balena.io/reference/hardware/devices/).  
+1. **Check for existing support** – See if your board is already listed on our [supported devices list](../hardware/devices/).  
 2. **Request custom support** – If you need an alternative to our existing options, explore our [Custom Device Support (CDS) service](https://www.balena.io/pricing#:~:text=Custom%20Device%20Support). This paid service includes a custom balenaOS build for your hardware and ongoing maintenance for a monthly fee.
 
-__Note:__ We do not currently support customers who wish to bring up balenaOS on new hardware themselves.
-
+{% hint style="info" %}
+We do not currently support customers who wish to bring up balenaOS on new hardware themselves.
+{% endhint %}


### PR DESCRIPTION
Change-type: patch

Connects-to: https://github.com/balena-os/meta-balena/pull/3872
Fibery: https://balena.fibery.io/Work/Project/Move-non-reference-external-docs-directly-into-the-docs-2487
Fibery: https://balena.fibery.io/Work/Improvement/Review-all-automations-with-a-focus-on-reducing-their-number-3933

---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
