### PR TITLE
Replace `Get all devices` with `Get all devices by organization`

### DIFF
--- a/config/dictionaries/resource.json
+++ b/config/dictionaries/resource.json
@@ -349,20 +349,20 @@
     ],
     "examples": [
       {
-        "id": "get-devices",
-        "summary": "Get all devices",
-        "description": "",
-        "method": "GET",
-        "endpoint": "/v7/device",
-        "filters": ""
-      },
-      {
         "id": "devices-by-fleet",
         "summary": "Get all devices by fleet",
         "description": "",
         "method": "GET",
         "endpoint": "/v7/device",
         "filters": "?\\$filter=belongs_to__application%20eq%20'<FLEET ID>'"
+      },
+      {
+        "id": "devices-by-org",
+        "summary": "Get all devices by organization",
+        "description": "",
+        "method": "GET",
+        "endpoint": "/v7/device",
+        "filters": "?\\$filter=belongs_to__application/any(a:a/organization%20eq%20'<ORG ID>')"
       },
       {
         "id": "device-by-id",

--- a/pages/reference/api/resources/device.md
+++ b/pages/reference/api/resources/device.md
@@ -59,18 +59,18 @@
 ---
 ## Examples 
 
-### Get all devices
-
-```bash
-GET "https://api.balena-cloud.com/v7/device" \
--H "Content-Type: application/json" \
--H "Authorization: Bearer <AUTH_TOKEN>" 
-```
-
 ### Get all devices by fleet
 
 ```bash
 GET "https://api.balena-cloud.com/v7/device?\$filter=belongs_to__application%20eq%20'<FLEET ID>'" \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer <AUTH_TOKEN>" 
+```
+
+### Get all devices by organization
+
+```bash
+GET "https://api.balena-cloud.com/v7/device?\$filter=belongs_to__application/any(a:a/organization%20eq%20'<ORG ID>')" \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer <AUTH_TOKEN>" 
 ```


### PR DESCRIPTION
Getting all devices the user has access to via any path is both costly and liable to cause problems later if the user becomes part of more organizations or otherwise gains access to devices that they do not expect to be included

Change-type: patch


---

> *Please make sure to read the [CONTRIBUTING](https://github.com/balena-io/docs/blob/master/CONTRIBUTING.md) document before opening the PR for relevant information on contributing to the documentation. Thanks!*
